### PR TITLE
Proper config & logging via bunyan

### DIFF
--- a/debian/restbase.default
+++ b/debian/restbase.default
@@ -1,13 +1,13 @@
 # Defaults for restbase initscript
 
 # File where the restbase daemon will write stderr and stdout to
-RESTBASE_LOG_FILE=/var/log/restbase/restbase.log
+LOG_FILE=/var/log/restbase/main.log
 
-RESTBASE_SETTINGS_FILE=/etc/restbase/settings.js
+SETTINGS_FILE=/etc/restbase/restbase.yaml
 
-PORT="8142"
+PORT="7231"
 
 # Default is to listen on all interfaces
 #INTERFACE="0.0.0.0"
 
-DAEMON_ARGS="-c $RESTBASE_SETTINGS_FILE"
+DAEMON_ARGS="-c $SETTINGS_FILE"

--- a/debian/restbase.init
+++ b/debian/restbase.init
@@ -18,7 +18,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="RESTBase HTTP service"
 NAME=restbase
-SCRIPT_PATH=/usr/lib/restbase/src/api/server.js
+SCRIPT_PATH=/usr/lib/restbase/server.js
 DAEMON="/usr/bin/nodejs $SCRIPT_PATH"
 DAEMON_ARGS=""
 PIDFILE=/var/run/$NAME.pid
@@ -60,12 +60,12 @@ do_start()
 	start-stop-daemon --start --quiet --pidfile $PIDFILE -bm \
 		-c restbase:restbase --test \
 		--exec /bin/sh -- \
-		-c "$DAEMON $DAEMON_ARGS >> /var/log/restbase/restbase.log 2>&1" \
+		-c "$DAEMON $DAEMON_ARGS >> $LOG_FILE 2>&1" \
 		|| return 1
 	start-stop-daemon --start --quiet --pidfile $PIDFILE -bm \
 		-c restbase:restbase \
 		--exec /bin/sh -- \
-		-c "$DAEMON $DAEMON_ARGS >> /var/log/restbase/restbase.log 2>&1" \
+		-c "$DAEMON $DAEMON_ARGS >> $LOG_FILE 2>&1" \
 		|| return 2
 	echo "Started RESTBase server on port $PORT"
 

--- a/lib/filters/bucket/kv.js
+++ b/lib/filters/bucket/kv.js
@@ -138,7 +138,6 @@ KVBucket.prototype.listBucket = function(restbase, req, options) {
 // Format a revision response. Shared between different ways to retrieve a
 // revision (latest & with explicit revision).
 KVBucket.prototype.returnRevision = function(req, dbResult) {
-    //console.log(req, dbResult);
     if (dbResult.body && dbResult.body.items && dbResult.body.items.length) {
         var row = dbResult.body.items[0];
         var headers = {

--- a/lib/server.js
+++ b/lib/server.js
@@ -24,13 +24,19 @@ var app = {
     proxy: null
 };
 
-var opts = {
-    // Log method
-    log: util.log
-};
-
 // Handle a single request
-function handleRequest (req, resp) {
+function handleRequest (opts, req, resp) {
+    var newReq;
+
+    opts = {
+        log: opts.log.child({
+            req: {
+                method: req.method,
+                uri: req.uri
+            }
+        }),
+        conf: opts.conf
+    };
 
     // Start off by parsing any POST data with BusBoy
     return util.parsePOST(req)
@@ -48,7 +54,7 @@ function handleRequest (req, resp) {
                 console.error(e);
             }
         }
-        var newReq = {
+        newReq = {
             uri: urlData.pathname,
             query: urlData.query,
             method: req.method.toLowerCase(),
@@ -62,15 +68,21 @@ function handleRequest (req, resp) {
     .then(function(response) {
         //console.log('resp', response);
         if (response && response.status) {
+            if (response.status >= 500) {
+                opts.log('error/request', {req: newReq});
+            } else {
+                opts.log('info/request', {req: newReq});
+            }
             if (!response.headers) {
                 response.headers = {};
             }
 
+            var body;
             if (response.status >= 400) {
                 if (!response.body) {
                     response.body = {};
                 }
-                var body = response.body;
+                body = response.body;
                 if (response.status === 404) {
                     if (!body.type) { body.type = 'not_found'; }
                     if (!body.title) { body.title = 'Not found.'; }
@@ -90,7 +102,7 @@ function handleRequest (req, resp) {
                 }
             }
             if (response.body) {
-                var body = response.body;
+                body = response.body;
                 // Convert to a buffer
                 if (!Buffer.isBuffer(body)) {
                     if (typeof body === 'object') {
@@ -111,6 +123,7 @@ function handleRequest (req, resp) {
                 resp.end();
             }
         } else {
+            opts.log('error/request', {req: newReq}, "No content returned");
             response.headers['content-type'] = 'application/problem+json';
             resp.writeHead(response && response.status || 500, '', response && response.headers);
             resp.end(JSON.stringify({
@@ -123,18 +136,48 @@ function handleRequest (req, resp) {
 
     })
     .catch (function(e) {
-        opts.log('error/request', e, e.stack);
+        opts.log('error/request', e);
         // XXX: proper error reporting
         resp.writeHead(500, "Internal error");
         resp.end(e.stack);
     });
 }
 
+function setupConfigDefaults(conf) {
+    if (!conf) { conf = {}; }
+    if (!conf.logging) { conf.logging = {}; }
+    if (!conf.logging.name) { conf.logging.name = 'main'; }
+    if (!conf.sysdomain) { conf.sysdomain = "restbase.local"; }
+    if (!conf.storage) {
+        conf.storage = {
+            "default": {
+                // module name
+                "type": "restbase-cassandra",
+                "hosts": ["localhost"],
+                "id": "<uuid>",
+                "keyspace": "system",
+                "username": "test",
+                "password": "test",
+                "poolSize": 70,
+            }
+        };
+    }
+    return conf;
+}
+
 // Main app setup
-function main() {
+function main(conf) {
+    conf = setupConfigDefaults(conf);
+    // Set up the global options object with a logger
+    var opts = {
+        log: util.makeLogger(conf.logging),
+        conf: conf
+    };
+
+
     // Load handlers & set up routers
     var storageRouter;
-    return require('./storage')({log: util.log})
+    return require('./storage')(opts)
     .then(function(store) {
         storageRouter = new RouteSwitch.fromHandlers([store]);
         var handlerDirs = [__dirname + '/filters/global'];
@@ -142,15 +185,16 @@ function main() {
     })
     .then(function(proxyRouter) {
         app.restbase = new Restbase([proxyRouter, storageRouter], opts);
-        var server = http.createServer(handleRequest);
+        var server = http.createServer(handleRequest.bind(null, opts));
         // Use a large listen queue
         // Also, echo 1024 | sudo tee /proc/sys/net/core/somaxconn
         // (from 128 default)
-        server.listen(8888, null, 6000);
-        util.log('notice', 'listening on port 8888');
+        var port = conf.port || 7231;
+        server.listen(port, null, 6000);
+        opts.log('info', 'listening on port ' + port);
     })
     .catch(function(e) {
-        util.log('error', e);
+        opts.log('error', e);
     });
 }
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -9,7 +9,7 @@ var util = require('util');
 var RouteSwitch = require('routeswitch');
 
 function Storage (options) {
-    this.config = options.config;
+    this.conf = options.conf;
     this.log = options.log;
     this.setup = this.setup.bind(this);
     this.bucketHandlers = {};
@@ -102,9 +102,9 @@ function makeHandler(handlerSchema) {
 Storage.prototype.setup = function setup () {
     var self = this;
     // Set up storage backends
-    var storageNames = Object.keys(this.config.storage);
+    var storageNames = Object.keys(this.conf.storage);
     var storagePromises = storageNames.map(function(key) {
-            var storageConf = self.config.storage[key];
+            var storageConf = self.conf.storage[key];
             try {
                 // Storage backends are packaged separately.
                 // Example: restbase-cassandra
@@ -113,7 +113,10 @@ Storage.prototype.setup = function setup () {
                 // XXX: make this interface more flexible / extensible
                 // Perhaps an instance?
                 var backend = require(moduleName);
-                return backend(storageConf);
+                return backend({
+                    conf: storageConf,
+                    log: self.log
+                });
             } catch (e) {
                 self.log('error/setup/backend/' + key, e, e.stack);
                 // skip the backend
@@ -195,7 +198,7 @@ Storage.prototype.loadRegistry = function() {
     };
     // XXX: Retrieve the global config using the default revisioned blob
     // bucket & backend
-    var sysDomain = this.config.sysdomain;
+    var sysDomain = this.conf.sysdomain;
 
     // check if the domains table exists
     return store({
@@ -359,7 +362,7 @@ Storage.prototype.putDomain = function (restbase, req) {
             quota: 0
         };
 
-        var sysdomain = this.config.sysdomain;
+        var sysdomain = this.conf.sysdomain;
         var domain = req.params.domain.toLowerCase();
         var query = {
             uri: '/v1/' + sysdomain + '/domains/' + domain,
@@ -438,7 +441,7 @@ Storage.prototype.putBucket = function (restbase, req) {
             }
             // Insert the table into the registry
             var query = {
-                uri: '/v1/' + self.config.sysdomain + '/tables/' + rp.bucket,
+                uri: '/v1/' + self.conf.sysdomain + '/tables/' + rp.bucket,
                 method: 'put',
                 body: {
                     table: 'tables',
@@ -568,23 +571,6 @@ Storage.prototype.listBucket = function (restbase, req) {
  * object
  */
 function makeStorage (options) {
-    // XXX: move to global config
-    options.config = {
-        sysdomain: "restbase.local",
-        storage: {
-            "default": {
-                // module name
-                "type": "restbase-cassandra",
-                "hosts": ["localhost"],
-                "id": "<uuid>",
-                "keyspace": "system",
-                "username": "test",
-                "password": "test",
-                "poolSize": 70,
-            }
-        }
-    };
-
     var storage = new Storage(options);
     return storage.setup();
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,25 +8,8 @@ var util = {};
 var url = require('url');
 var Busboy = require('busboy');
 var uuid = require('node-uuid');
+var bunyan = require('bunyan');
 
-
-// TODO: use bunyan or the Parsoid logger backend!
-util.log = function (level, e) {
-    var msg = '[' + level + ']';
-    if (e) {
-        msg += ': ';
-        if (e.stack) {
-            msg += e.stack;
-        } else {
-            msg += e;
-        }
-    }
-    if (/^error/.test(level)) {
-        console.error(msg);
-    } else {
-        console.log(msg);
-    }
-};
 
 
 // Optimized URL parsing
@@ -119,5 +102,33 @@ util.tidFromDate = function tidFromDate(date) {
 
 util.extend = require('extend');
 
+
+// Simple bunyan logger wrapper
+function Logger (conf, logger) {
+    this.logger = logger || bunyan.createLogger(conf);
+}
+
+Logger.prototype.log = function (level) {
+    var logger = this.logger;
+    var simpleLevel = level.replace(/([^\/]+)(\/.*)?$/, '$1');
+    var params = Array.prototype.slice.call(arguments, 1);
+    if (logger[simpleLevel]) {
+        logger[simpleLevel].apply(logger, params);
+    } else {
+        logger.info.apply(logger, params);
+    }
+};
+
+util.makeLogger = function(conf) {
+    var newLogger = new Logger(conf);
+    function bindAndChild (logger) {
+        var log = logger.log.bind(logger);
+        log.child = function(args) {
+            return bindAndChild(new Logger(null, logger.logger.child(args)));
+        };
+        return log;
+    }
+    return bindAndChild(newLogger);
+};
 
 module.exports = util;

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
   "homepage": "https://github.com/gwicke/restbase",
   "dependencies": {
     "bluebird": "~2.2.2",
+    "bunyan": "^1.1.3",
     "busboy": "~0.2.8",
     "extend": "^1.3.0",
+    "js-yaml": "^3.2.2",
     "node-uuid": "^1.4.1",
     "preq": ">=0.2.0",
     "request": "^2.44.0",

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@
 
 var cluster = require('cluster'),
     path = require('path'),
+    yaml = require('js-yaml'),
     // process arguments
     opts = require( "yargs" )
         .usage( "Usage: $0 [-h|-v] [--param[=val]]" )
@@ -19,7 +20,7 @@ var cluster = require('cluster'),
             // systems. A single long-running request would otherwise hold up
             // all concurrent short requests.
             n: require( "os" ).cpus().length,
-            c: __dirname + '/localsettings.js',
+            c: __dirname + '/config.yaml',
 
             v: false,
             h: false
@@ -36,6 +37,15 @@ var cluster = require('cluster'),
 // lower overhead. Also bump up somaxconn with this command:
 // sudo sysctl -w net.core.somaxconn=4096
 cluster.schedulingPolicy = cluster.SCHED_NONE;
+
+var conf = {};
+if (argv.c) {
+    try {
+        conf = yaml.safeLoad(fs.readFileSync(argv.c));
+    } catch (e) {
+        console.error('Error while reading config file: ' + e);
+    }
+}
 
 if (cluster.isMaster && argv.n > 0) {
     var fs = require( "fs" ),
@@ -100,5 +110,5 @@ if (cluster.isMaster && argv.n > 0) {
     });
 
     var worker = require('./lib/server.js');
-    worker();
+    worker(conf);
 }

--- a/test/simple.js
+++ b/test/simple.js
@@ -11,7 +11,8 @@
 var restbase = require('../lib/server.js');
 var preq = require('preq');
 var assert = require('assert');
-var baseURL = 'http://localhost:8888/v1/en.wikipedia.org';
+var hostPort = 'http://localhost:7231';
+var baseURL = hostPort + '/v1/en.wikipedia.org';
 var bucketURL = baseURL + '/test101';
 
 function deepEqual (result, expected) {
@@ -27,12 +28,17 @@ function deepEqual (result, expected) {
 describe('Simple API tests', function () {
     before(function() {
         this.timeout(20000);
-        return restbase();
+        return restbase({
+            logging: {
+                name: 'restbase-tests',
+                level: 'warn'
+            }
+        });
     });
     describe('Domain & bucket creation', function() {
         it('should create a domain', function() {
             return preq.put({
-                uri: 'http://localhost:8888/v1/en.wikipedia.org',
+                uri: hostPort + '/v1/en.wikipedia.org',
                 headers: { 'content-type': 'application/json' },
                 body: {}
             })
@@ -140,7 +146,7 @@ describe('Simple API tests', function () {
     describe('404 handling', function() {
         it('should return a proper 404 when trying to retrieve a non-existing domain', function() {
             return preq.get({
-                uri: 'http://localhost:8888/v1/foobar.com'
+                uri: hostPort + '/v1/foobar.com'
             })
             .catch(function(e) {
                 deepEqual(e.status, 404);
@@ -149,7 +155,7 @@ describe('Simple API tests', function () {
         });
         it('should return a proper 404 when trying to list a non-existing domain', function() {
             return preq.get({
-                uri: 'http://localhost:8888/v1/foobar.com/'
+                uri: hostPort + '/v1/foobar.com/'
             })
             .catch(function(e) {
                 deepEqual(e.status, 404);


### PR DESCRIPTION
- Move the configuration to a yaml config file
- Support logging via bunyan
- Change the default port to 7231 (inspired by
  https://tools.ietf.org/html/rfc7231)
