### PR TITLE
Update for secondary index format changes

### DIFF
--- a/lib/filters/bucket/kv.js
+++ b/lib/filters/bucket/kv.js
@@ -42,12 +42,11 @@ KVBucket.prototype.makeSchema = function (opts) {
                 // 'deleted', 'nomove' etc?
                 tags: 'set<string>',
             },
-            index: {
-                hash: 'key',
-                range: 'tid',
-                order: 'desc',
-                static: 'latestTid'
-            }
+            index: [
+                { attribute: 'key', type: 'hash' },
+                { attribute: 'latestTid', type: 'static' },
+                { attribute: 'tid', type: 'range', order: 'desc' }
+            ]
         };
     } else {
         throw new Error('Bucket type ' + opts.type + ' not yet implemented');

--- a/lib/filters/bucket/pagecontent.js
+++ b/lib/filters/bucket/pagecontent.js
@@ -54,21 +54,20 @@ function getRevSchema () {
             comment: 'string',
             is_minor: 'boolean'
         },
-        index: {
-            hash: ['page'],
-            range: ['tid'],
-            order: ['desc'],
-            static: ['latest_tid']
-        },
+        index: [
+            { attribute: 'page', type: 'hash' },
+            { attribute: 'latest_tid', type: 'static' },
+            { attribute: 'tid', type: 'range', order: 'desc' }
+        ],
         secondaryIndexes: {
             // /pages.rev//page/Foo/12345
             // @specific time: /pages.history//rev/12345?ts=20140312T20:22:33.3Z
-            rev: {
-                hash: ['page'],
-                range: ['rev', 'tid'],
-                order: ['desc','desc'],
-                proj: ['deleted']
-            }
+            rev: [
+                { attribute: 'page', type: 'hash' },
+                { attribute: 'rev', type: 'range', order: 'desc' },
+                { attribute: 'tid', type: 'range', order: 'desc' },
+                { attribute: 'deleted', type: 'proj' }
+            ]
         }
     };
 }
@@ -158,8 +157,9 @@ PCBucket.prototype.getLatestFormat = function(restbase, req) {
         }
     })
     .then(function(apiRes) {
-        if (apiRes.status === 200) {
-            var rev = apiRes.body.items[0].revisions[0];
+        var items = apiRes.body && apiRes.body.items;
+        if (apiRes.status === 200 && items && items.length) {
+            var rev = items[0].revisions[0];
             return {
                 status: 302,
                 headers: {
@@ -227,7 +227,7 @@ function checkResponse(restbase, req, tid, apiRes, res) {
                     // Save / update the revision entry
                     .then(function(res) {
                         if (apiRes) {
-                            var rev = apiRes.body[0].revisions[0];
+                            var rev = apiRes.body.items[0].revisions[0];
                             return restbase.put({
                                 uri: '/v1/' + rp.domain + '/' + rp.bucket + '.rev'
                                     + '/' + rp.key,

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -171,9 +171,9 @@ var domainRegistrySchema = {
         acls: 'json', // default acls for entire domain
         quota: 'varint'
     },
-    index: {
-        hash: 'domain'
-    }
+    index: [
+        { attribute: 'domain', type: 'hash' }
+    ]
 };
 
 var tableRegistrySchema = {
@@ -185,10 +185,10 @@ var tableRegistrySchema = {
         store: 'string',    // 'default' or uuid
         acls: 'json'
     },
-    index: {
-        hash: 'domain',
-        range: 'table'
-    }
+    index: [
+        { attribute: 'domain', type: 'hash' },
+        { attribute: 'table', type: 'range', order: 'asc' }
+    ]
 };
 
 Storage.prototype.loadRegistry = function() {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node-uuid": "^1.4.1",
     "preq": ">=0.2.0",
     "request": "^2.44.0",
-    "restbase-cassandra": "^0.1.1",
+    "restbase-cassandra": "git+https://github.com/gwicke/restbase-cassandra#index_cleanup",
     "routeswitch": "0.5.x",
     "yargs": ">=1.3.0" 
   },


### PR DESCRIPTION
This updates restbase to reflect the index format changes in
https://github.com/gwicke/restbase-cassandra/pull/15

Only merge once that's merged.

Also includes a small fix in the pagecontent handler.
