### PR TITLE
Add 'gelf' logger type

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,6 +9,7 @@ var url = require('url');
 var Busboy = require('busboy');
 var uuid = require('node-uuid');
 var bunyan = require('bunyan');
+var gelf_stream = require('gelf-stream');
 var dgram = require( 'dgram' );
 
 // TODO: use bunyan or the Parsoid logger backend!
@@ -175,7 +176,25 @@ Logger.prototype.log = function (level) {
 };
 
 util.makeLogger = function(conf) {
-    var newLogger = new Logger(conf);
+    if (!Array.isArray(conf.streams)) {
+        conf.streams = [];
+    }
+    var streams = [];
+    conf.streams.forEach(function(stream) {
+        if (stream.type === 'gelf') {
+            // Convert the 'gelf' logger type to a real logger
+            streams.push({
+                type: 'raw',
+                stream: gelf_stream.forBunyan(stream.host,
+                    stream.port, stream.options)
+            });
+        } else {
+            streams.push(stream);
+        }
+    });
+    var newConf = util.extend({}, conf);
+    newConf.streams = streams;
+    var newLogger = new Logger(newConf);
     function bindAndChild (logger) {
         var log = logger.log.bind(logger);
         log.child = function(args) {

--- a/package.json
+++ b/package.json
@@ -33,13 +33,14 @@
     "bunyan": "^1.1.3",
     "busboy": "~0.2.8",
     "extend": "^1.3.0",
+    "gelf-stream": "^0.2.4",
     "js-yaml": "^3.2.2",
     "node-uuid": "^1.4.1",
     "preq": ">=0.2.0",
     "request": "^2.44.0",
     "restbase-cassandra": "^0.2.0",
     "routeswitch": "0.5.x",
-    "yargs": ">=1.3.0" 
+    "yargs": ">=1.3.0"
   },
   "devDependencies": {
     "mocha": "^1.x.x"


### PR DESCRIPTION
Specifying a 'gelf' stream type with host and port parameters in the config
will transparently set up a gelf stream behind the scenes. This is what we'll
use exclusively in production, so that we don't have to deal with local log
rotation.
