### PR TITLE
git-ignore config.yaml to allow per-developer configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.yaml


### PR DESCRIPTION
This way we can keep our own _config.yaml_ for development, e.g. to specify the port we want.
