### PR TITLE
Integrate jshint into the mocha tests

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+node_modules
+test

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "yargs": ">=1.3.0"
   },
   "devDependencies": {
-    "mocha": "^1.x.x"
+    "mocha": "^1.x.x",
+    "mocha-jshint": "0.0.9"
   }
 }

--- a/test/jshint.spec.js
+++ b/test/jshint.spec.js
@@ -1,0 +1,1 @@
+require('mocha-jshint')();


### PR DESCRIPTION
The following directories contain lots of jshint problems, so they're ignored for now:
- node_modules
- test

Fixes #27
