### PR TITLE
Add a Promise#fails function to check for an expected failure

### DIFF
--- a/test/simple.js
+++ b/test/simple.js
@@ -32,11 +32,14 @@ Promise.prototype.fails = function(onRejected) {
         return onRejected(e);
     }
     function check(x) {
-        if (!failed) throw new Error('expected error was not thrown');
-        return this;
+        if (!failed) {
+            throw new Error('expected error was not thrown');
+        } else {
+            return this;
+        }
     }
     return this.catch(trackFailure).then(check);
-}
+};
 
 describe('Simple API tests', function () {
     this.timeout(20000);


### PR DESCRIPTION
Fixes #26 

This implementation feels a little awkward to me, because of the way `.catch()` and `.then()` interact.  I found I needed to wrap the expected rejection function with one that tracks whether it ran, and if so, we know the expected failure occurred.  If there's a cleaner way to do this, I'd be interested to learn about it.
