### PR TITLE
Extract external Parsoid calling into a service wrapper

### DIFF
--- a/lib/filters/bucket/pagecontent.js
+++ b/lib/filters/bucket/pagecontent.js
@@ -199,7 +199,7 @@ function checkResponse(restbase, req, tid, apiRes, res) {
         if (res.status === 404 && /^[0-9]+$/.test(rp.revision)) {
             // Try to generate HTML on the fly by calling Parsoid
             return restbase.get({
-                uri: '/v1/' + rp.domain + '/services/parsoid/' + rp.key + '/' + rp.revision
+                uri: '/v1/' + rp.domain + '/_svc/parsoid/' + rp.key + '/' + rp.revision
             }).then(function(parsoidResp) {
                 // handle the response from Parsoid
                 //console.log(parsoidResp.status, parsoidResp.headers);

--- a/lib/filters/global/parsoid.js
+++ b/lib/filters/global/parsoid.js
@@ -6,7 +6,7 @@
 
 module.exports = {
     paths: {
-        '/v1/{domain}/services/parsoid/{key}/{rev}': {
+        '/v1/{domain}/_svc/parsoid/{key}/{rev}': {
             get: {
                 request_handler: function(restbase, req) {
                     var rp = req.params;


### PR DESCRIPTION
Looking for feedback on this refactor.  This lets the pagecontent handler treat Parsoid as a regular handler, without knowing directly how to access it externally.  External Parsoid access happens through a "service handler", which in the future we could configure without changing the pagecontent handler.
