### PR TITLE
Move action/query behind _svc/

### DIFF
--- a/lib/filters/bucket/pagecontent.js
+++ b/lib/filters/bucket/pagecontent.js
@@ -147,7 +147,7 @@ PCBucket.prototype.getLatestFormat = function(restbase, req) {
     var rp = req.params;
     var origURI = req.uri;
     return restbase.post({
-        uri: '/v1/' + rp.domain + '/action/query',
+        uri: '/v1/' + rp.domain + '/_svc/action/query',
         body: {
             format: 'json',
             action: 'query',
@@ -290,7 +290,7 @@ PCBucket.prototype.getFormatRevision = function(restbase, req) {
             } else {
                 // Try to resolve MW oldids to tids
                 return restbase.post({
-                    uri: '/v1/' + rp.domain + '/action/query',
+                    uri: '/v1/' + rp.domain + '/_svc/action/query',
                     body: {
                         format: 'json',
                         action: 'query',
@@ -400,7 +400,7 @@ PCBucket.prototype.getRedLinks = function(restbase, req) {
     var rp = req.params;
     function getLinkChunks(missing, gplcontinue) {
         return restbase.get({
-            uri: '/v1/' + rp.domain + '/action/query',
+            uri: '/v1/' + rp.domain + '/_svc/action/query',
             query: {
                 prop: 'info',
                 titles: decodeURIComponent(rp.key),

--- a/lib/filters/global/actions.js
+++ b/lib/filters/global/actions.js
@@ -6,7 +6,7 @@
 
 module.exports = {
     paths: {
-        '/v1/{domain}/action/query': {
+        '/v1/{domain}/_svc/action/query': {
             all: {
                 request_handler: function(restbase, req) {
                     var rp = req.params;


### PR DESCRIPTION
This follows the same pattern established for the Parsoid handler.

A good follow-up to this might be to extract the multiple references to `... + '/_svc/action/query'` in _pagecontent.js_, and put them into a single reusuable place.
