### PR TITLE
Allow configuration of the Parsoid host

### DIFF
--- a/lib/filters/global/parsoid.js
+++ b/lib/filters/global/parsoid.js
@@ -10,6 +10,9 @@ function pagebundle(parsoidHost, restbase, domain, key, rev) {
 }
 
 module.exports = function (conf) {
+    if (!conf.parsoidHost) {
+        conf.parsoidHost = 'http://parsoid-lb.eqiad.wikimedia.org';
+    }
     return {
         paths: {
             '/v1/{domain}/_svc/parsoid/{key}/{rev}': {

--- a/lib/server.js
+++ b/lib/server.js
@@ -161,9 +161,6 @@ function setupConfigDefaults(conf) {
             defaultConsistency: 'one' // use localQuorum in production
         };
     }
-    if (!conf.parsoidHost) {
-        conf.parsoidHost = 'http://parsoid-lb.eqiad.wikimedia.org';
-    }
     return conf;
 }
 
@@ -176,7 +173,6 @@ function main(conf) {
         conf: conf
     };
 
-
     // Load handlers & set up routers
     var storageRouter;
     return require('./storage')(opts)
@@ -184,11 +180,11 @@ function main(conf) {
         storageRouter = new RouteSwitch.fromHandlers([store]);
         var handlerDirs = [__dirname + '/filters/global'];
         var loader = function (handlerPath) {
-          var handler = require(handlerPath);
-          if (handler && ({}).toString.call(handler) === '[object Function]') {
-            handler = handler(conf);
-          }
-          return handler;
+            var handler = require(handlerPath);
+            if (typeof handler === 'function') {
+                handler = handler(conf);
+            }
+            return handler;
         };
         return RouteSwitch.fromDirectories(handlerDirs, opts.log, loader);
     })


### PR DESCRIPTION
Fixes #48 

Currently, there's not a convenient way to test this, since the mechanism for loading a configuration file lives in _./server.js_, which isn't used during testing.

Before we merge this, let's consider how to unify configuration loading so it's used both by `node server` and by mocha.

Also: this depends on an [unreleased routeswitch feature](https://github.com/wikimedia/routeswitch/pull/6).  Let's not merge this until it is [released](https://github.com/wikimedia/routeswitch/issues/8).
