### PR TITLE
Improve statsd logging further

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -82,7 +82,6 @@ RESTBase.prototype._request = function (req) {
                 var statName = (match.path || match.sortKey) + "." + req.method.toUpperCase();
                 // start timer
                 self.statsd.startTimer(statName);
-                self.statsd.count(statName + '.count');
                 // Found a matching proxy handler. Prepare to call it.
                 // Still using __proto__, as it's quite a bit faster than
                 // Object.create.
@@ -96,14 +95,12 @@ RESTBase.prototype._request = function (req) {
                 childReq.params = match.params;
                 return handler.request_handler(childRESTBase, childReq)
                 .then(function(item){
-                    if (item.status >= 500) {
-                        self.statsd.count(statName + '.error');
-                    }
-                    self.statsd.stopTimer(statName);
+                    var statusClass = Math.floor(item.status / 100) + 'xx';
+                    self.statsd.stopTimer(statName, [statusClass, 'ALL']);
                     return item;
                 })
                 .catch(function(err){
-                    self.statsd.stopTimer(statName);
+                    self.statsd.stopTimer(statName, ['5xx', 'ALL']);
                     throw err;
                 });
             }

--- a/lib/util.js
+++ b/lib/util.js
@@ -34,22 +34,34 @@ util.StatsD = function ( statsdHost, statsdPort ) {
                    .replace(/\//g, '_');
     }
 
-    this.startTimer = function ( name ) {
+    this.startTimer = function (name) {
         timers[name] = new Date();
     };
 
-    this.stopTimer = function ( name ) {
+    this.stopTimer = function (name, suffix) {
         var startTime = timers[name];
         if (!startTime) {
             throw new Error('Tried to stop a timer that does not exist: ' + name);
         }
         var delta = new Date() - startTime;
-        statsd.timing(makeName(name) + '.time', delta);
+
+        name = makeName(name);
+        if (Array.isArray(suffix)) {
+            // Send several timings at once
+            var stats = suffix.map(function(s) {
+                return name + (s ? '.' + s : '');
+            });
+            statsd.sendAll(stats, delta, 'ms');
+        } else {
+            suffix = suffix ? '.' + suffix : '';
+            statsd.timing(makeName(name) + suffix, delta);
+        }
         return delta;
     };
 
-    this.count = function ( name ) {
-        statsd.increment(makeName(name) + '.count');
+    this.count = function (name, suffix) {
+        suffix = suffix ? '.' + suffix : '';
+        statsd.increment(makeName(name) + suffix);
     };
 };
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "extend": "~1.3.0",
     "gelf-stream": "~0.2.4",
     "js-yaml": "~3.2.2",
-    "node-txstatsd": "~0.1.1",
+    "node-txstatsd": "~0.1.3",
     "node-uuid": "git+https://github.com/gwicke/node-uuid#master",
     "preq": "~0.2.2",
     "request": "^2.44.0",


### PR DESCRIPTION
- Record timings for each class of status codes separately. Graphite will also
  present a count & rate for each timing, so we can plot those & use them for
  thresholds.
- Use node-txstatsd's new ability to send multiple timings in one packet.
