### PR TITLE
Revert "Pass the (required) apiRes.rev directly"

### DIFF
--- a/lib/filters/bucket/pagecontent.js
+++ b/lib/filters/bucket/pagecontent.js
@@ -206,7 +206,7 @@ var contentTypes = {
     'data-parsoid': 'application/json; profile=mediawiki.org/specs/data-parsoid/1.0'
 };
 
-PCBucket.prototype.checkResponse = function (restbase, req, tid, apiRev, res) {
+PCBucket.prototype.checkResponse = function (restbase, req, tid, apiRes, res) {
     var self = this;
     var rp = req.params;
     if (rp.format === 'html' || rp.format === 'data-parsoid'
@@ -236,23 +236,34 @@ PCBucket.prototype.checkResponse = function (restbase, req, tid, apiRev, res) {
                             headers: rbUtil.extend({}, parsoidResp.headers,
                                     {'content-type': contentTypes['data-parsoid'] }),
                             body: parsoidResp.body['data-parsoid']
-                        }),
-                        restbase.put({ // Save / update the revision entry
-                            uri: '/v1/' + rp.domain + '/' + rp.bucket + '.rev'
-                                + '/' + rp.key,
-                            body: {
-                                table: rp.bucket + '.rev',
-                                attributes: {
-                                    page: rp.key,
-                                    rev: parseInt(rp.revision),
-                                    tid: tid,
-                                    user_id: apiRev.userid,
-                                    user_text: apiRev.user,
-                                    comment: apiRev.comment
-                                }
-                            }
                         })
-                    ]);
+                    ])
+                    .catch(function(e) {
+                        restbase.log('error/pagecontent/html/put', e);
+                    })
+                    // Save / update the revision entry
+                    .then(function(res) {
+                        if (apiRes) {
+                            var rev = apiRes.body.items[0].revisions[0];
+                            return restbase.put({
+                                uri: '/v1/' + rp.domain + '/' + rp.bucket + '.rev'
+                                    + '/' + rp.key,
+                                body: {
+                                    table: rp.bucket + '.rev',
+                                    attributes: {
+                                        page: rp.key,
+                                        rev: parseInt(rp.revision),
+                                        tid: tid,
+                                        user_id: rev.userid,
+                                        user_text: rev.user,
+                                        comment: rev.comment
+                                    }
+                                }
+                            });
+                        }
+                    });
+                } else {
+                    console.log(parsoidResp);
                 }
                 // And return the response to the client
                 var resp = {
@@ -310,13 +321,13 @@ PCBucket.prototype.getFormatRevision = function(restbase, req) {
                 })
                 .then(function(apiRes) {
                     if (apiRes.status === 200) {
-                        var apiRev = apiRes.body.items[0].revisions[0];
-                        var tid = rbUtil.tidFromDate(new Date(apiRev.timestamp));
+                        var rev = apiRes.body.items[0].revisions[0];
+                        var tid = rbUtil.tidFromDate(new Date(rev.timestamp));
                         req.uri = '/v1/' + rp.domain + '/' + rp.bucket + '.' + rp.format + '/' +
                             rp.key + '/' + tid;
                         return restbase.get(req)
                         // TODO: pass api result to checkResponse
-                        .then(self.checkResponse.bind(self, restbase, req, tid, apiRev));
+                        .then(self.checkResponse.bind(self, restbase, req, tid, apiRes));
                     } else {
                         // XXX: Return a proper error instead
                         return apiRes;


### PR DESCRIPTION
We can't insert into a table while it's being created. We really need better
tests for this stuff.

This reverts commit 2ab810bd6e51e95328e9fc1916029100aed9db5f.
