### PR TITLE
Fix revision table creation

### DIFF
--- a/lib/filters/bucket/pagecontent.js
+++ b/lib/filters/bucket/pagecontent.js
@@ -109,13 +109,18 @@ PCBucket.prototype.createBucket = function(restbase, req) {
     var table = rp.bucket + '.rev';
     var revSchema = getRevSchema();
     revSchema.table = table;
+    revSchema.type = 'table';
     requests.push(restbase.put({
         uri: '/v1/' + rp.domain + '/' + table,
         body: revSchema
     }));
     return Promise.all(requests)
+    .catch(function(e) {
+        restbase.log('error/pagecontent/createBucket', e);
+    })
     .then(function(res) {
-        //console.log(JSON.stringify(res,null,2));
+        restbase.log('info/pagecontent/createBucket',
+                { msg: 'Buckets created', res: res});
         return {
             status: 201, // created
             body: {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -9,10 +9,15 @@ var util = require('util');
 var RouteSwitch = require('routeswitch');
 
 function Storage (options) {
+    var self = this;
     this.conf = options.conf;
     this.log = options.log;
     this.setup = this.setup.bind(this);
-    this.bucketHandlers = {};
+    this.bucketHandlers = {
+        table: function(restbase, req) {
+            return self.stores.default(restbase, req);
+        }
+    };
     this.stores = {};
     this.handler = {
         paths: {


### PR DESCRIPTION
Somehow we were running without a revision table for a while now, with a
fall-back request to the PHP API for each revision request.

This patch fixes the breakage first, better tests in a follow-up.
