### PR TITLE
Extract some common functions

### DIFF
--- a/lib/filters/bucket/pagecontent.js
+++ b/lib/filters/bucket/pagecontent.js
@@ -10,7 +10,8 @@
  */
 
 var RouteSwitch = require('routeswitch');
-var rbUtil = require('../../rbUtil.js');
+var rbUtil      = require('../../rbUtil.js');
+var revs        = require('../../util/revs.js');
 
 var backend;
 var config;
@@ -209,73 +210,30 @@ PCBucket.prototype.getFormatRevision = function(restbase, req) {
     var self = this;
     var rp = req.params;
     if (/^[0-9]+$/.test(rp.revision)) {
-        // Check the local db
-        var revTable = rp.bucket + '.rev';
-        return restbase.get({
-            uri: '/v1/' + rp.domain + '/' + revTable + '/' + rp.key,
-            body: {
-                table: revTable,
-                index: 'rev',
-                proj: ['tid'],
-                attributes: {
-                    page: rp.key,
-                    rev: parseInt(rp.revision)
-                },
-                limit: 2
-            }
-        })
-        .then(function(res) {
-            if (res.status === 200) {
-                var tid = res.body.items[0].tid;
+        return revs.getTidFromDb(restbase, rp.domain, rp.bucket, rp.key, rp.revision)
+        .then(function (tid) {
+            if (tid) {
                 req.uri = '/v1/' + rp.domain + '/' + rp.bucket + '.' + rp.format + '/' +
                     rp.key + '/' + tid;
                 return restbase.get(req);
             } else {
-                // Try to resolve MW oldids to tids
-                return restbase.post({
-                    uri: '/v1/' + rp.domain + '/_svc/action/query',
-                    body: {
-                        format: 'json',
-                        action: 'query',
-                        prop: 'revisions',
-                        rvprop: 'ids|timestamp|user|userid|size|sha1|contentmodel|comment',
-                            //titles: rp.key,
-                        revids: rp.revision
-                    }
-                })
-                .then(function(apiRes) {
-                    if (apiRes.status === 200) {
-                        var apiRev = apiRes.body.items[0].revisions[0];
-                        var tid = rbUtil.tidFromDate(new Date(apiRev.timestamp));
-                        req.uri = '/v1/' + rp.domain + '/' + rp.bucket + '.' + rp.format + '/' +
-                            rp.key + '/' + tid;
-                        return restbase.put({ // Save / update the revision entry
-                            uri: '/v1/' + rp.domain + '/' + rp.bucket + '.rev'
-                                + '/' + rp.key,
-                            body: {
-                                table: rp.bucket + '.rev',
-                                attributes: {
-                                    page: rp.key,
-                                    rev: parseInt(rp.revision),
-                                    tid: tid,
-                                    user_id: apiRev.userid,
-                                    user_text: apiRev.user,
-                                    comment: apiRev.comment
-                                }
-                            }
-                        }).then(function(res) {
-                            return restbase.get(req);
-                        }).then(function(res) {
-                            if (!res.headers) {
-                                res.headers = {};
-                            }
-                            res.headers.etag = tid;
-                            return res;
-                        });
-                    } else {
-                        // XXX: Return a proper error instead
-                        return apiRes;
-                    }
+                return revs.resolveMWOldid(restbase, rp.domain, rp.revision)
+                .then(function (apiRev) {
+                    return revs.updateRevTable(
+                        restbase,
+                        rp.domain, rp.bucket, rp.key, rp.revision,
+                        apiRev.userid, apiRev.user, apiRev.comment, apiRev.tid
+                    ).then(function(res) {
+                        req.uri = '/v1/' + rp.domain + '/' + rp.bucket + '.'
+                                  + rp.format + '/' + rp.key + '/' + apiRev.tid;
+                        return restbase.get(req);
+                    }).then(function(res) {
+                        if (!res.headers) {
+                            res.headers = {};
+                        }
+                        res.headers.etag = apiRev.tid;
+                        return res;
+                    });
                 });
             }
         });

--- a/lib/util/revs.js
+++ b/lib/util/revs.js
@@ -1,0 +1,77 @@
+"use strict";
+
+var rbUtil = require('../rbUtil.js');
+
+function updateRevTable(restbase, domain, bucket, key, revision, userId, userText, comment, tid) {
+    return restbase.put({ // Save / update the revision entry
+        uri: '/v1/' + domain + '/' + bucket + '.rev' + '/' + key,
+        body: {
+            table: bucket + '.rev',
+            attributes: {
+                page: key,
+                rev: parseInt(revision),
+                tid: tid,
+                user_id: userId,
+                user_text: userText,
+                comment: comment
+            }
+        }
+    });
+}
+
+function resolveMWOldid(restbase, domain, revision) {
+    // Try to resolve MW oldids to tids
+    return restbase.post({
+        uri: '/v1/' + domain + '/_svc/action/query',
+        body: {
+            format: 'json',
+            action: 'query',
+            prop: 'revisions',
+            rvprop: 'ids|timestamp|user|userid|size|sha1|contentmodel|comment',
+                //titles: rp.key,
+            revids: revision
+        }
+    })
+    .then(function(apiRes) {
+        if (apiRes.status === 200) {
+            var apiRev = apiRes.body.items[0].revisions[0];
+            return {
+                tid: rbUtil.tidFromDate(new Date(apiRev.timestamp)),
+                userId: apiRev.userid,
+                userText: apiRev.user,
+                comment: apiRev.comment
+            };
+        } else {
+            throw new Error("Couldn't resolve MW oldid", apiRes);
+        }
+        });
+}
+
+function getTidFromDb(restbase, domain, bucket, key, revision) {
+    // Check the local db
+    var revTable = bucket + '.rev';
+    return restbase.get({
+        uri: '/v1/' + domain + '/' + revTable + '/' + key,
+        body: {
+            table: revTable,
+            index: 'rev',
+            proj: ['tid'],
+            attributes: {
+                page: key,
+                rev: parseInt(revision)
+            },
+            limit: 2
+        }
+    }).then(function (res) {
+        if (res.status === 200) {
+            var tid = res.body.items[0].tid;
+            return tid;
+        } else {
+            return null;
+        }
+    });
+}
+
+module.exports.updateRevTable = updateRevTable;
+module.exports.resolveMWOldid = resolveMWOldid;
+module.exports.getTidFromDb   = getTidFromDb;


### PR DESCRIPTION
These functions are all loosely related to revisions and the
revisions table.  They are currently used by pagecontent.js
and will later be used as well by parsoid.js (and possibly
others) when we start respecting cache-control: no-cache.

Does it make sense to treat these as library functions, or
should they be moved into a new handler of some sort?
