### PR TITLE
Delegate to getRevision(latest)

### DIFF
--- a/lib/filters/bucket/kv.js
+++ b/lib/filters/bucket/kv.js
@@ -160,25 +160,9 @@ KVBucket.prototype.returnRevision = function(req, dbResult) {
     }
 };
 
-KVBucket.prototype.getLatest = function(restbase, req, options) {
-    // XXX: check params!
-    var query = {
-        table: req.params.bucket,
-        attributes: {
-            key: req.params.key
-        },
-        limit: 1
-    };
-
-    return restbase.get({
-        uri: req.uri,
-        body: query
-    })
-    .then(this.returnRevision.bind(this, req))
-    .catch(function(error) {
-        restbase.log('error/kv/getLatest', error);
-        return { status: 404 };
-    });
+KVBucket.prototype.getLatest = function(restbase, req) {
+    var rp = req.params;
+    return restbase.get('/v1/' + rp.domain + '/' + rp.bucket + '/' + rp.format +'/' + 'latest');
 };
 
 KVBucket.prototype.putLatest = function(restbase, req) {


### PR DESCRIPTION
The implementation of `KVBucket.prototype.getLatest` is a bit redundant, as `KVBucket.prototype.getRevision` knows how to retrieve the latest revision when specified via `"latest"`.

This PR cleans up the redundancy, which will be helpful later when we add support for range queries against `'/v1/{domain}/{bucket}/{key}'`.
