### PR TITLE
Ignore Node.js module dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.yaml
+node_modules


### PR DESCRIPTION
This PR adds a line to .gitignore in order to exclude node.js module dependencies, which are automatically installed with npm install, in this way keeping our repository clean. As an added bonus, you can profit from it directly if you use Ag (https://github.com/ggreer/the_silver_searcher).
