### PR TITLE
Don't assume that the body returned by preq is a String

### DIFF
--- a/test/features/pagecontent/idempotent.js
+++ b/test/features/pagecontent/idempotent.js
@@ -31,7 +31,7 @@ module.exports = function (config) {
                 assert.deepEqual(res.status, 200);
                 assert.deepEqual(res.headers['content-type'], 'text/html; charset=UTF-8');
                 assert.deepEqual(res.headers.etag, '76f22880-362c-11e4-9234-0123456789ab');
-                assert.deepEqual(res.body, 'Hello there');
+                assert.deepEqual(res.body.toString(), 'Hello there');
             });
         });
 

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -121,7 +121,7 @@ module.exports = function (config) {
                 assert.deepEqual(res.status, 200);
                 assert.deepEqual(res.headers['content-type'], 'text/html; charset=UTF-8');
                 assert.deepEqual(res.headers.etag, '76f22880-362c-11e4-9234-0123456789ab');
-                assert.deepEqual(res.body, 'Hello there');
+                assert.deepEqual(res.body.toString(), 'Hello there');
             });
         });
 

--- a/test/features/specification/swagger.js
+++ b/test/features/specification/swagger.js
@@ -12,6 +12,9 @@ module.exports = function (config) {
     // Wrap an HTTP request in a continuation
     function requestK(req) {
         return function () {
+            // Decode the buffer to a string, as the JSON we are comparing
+            // with expects strings.
+            req.encoding = 'utf8';
             return preq[req.method](req);
         };
     }


### PR DESCRIPTION
I'm changing preq to return buffers by default. This is more efficient, as
those are allocated off-heap. JS strings above a certain size (80k IIRC) are
directly allocated in the old space of the JS heap, so are not collected very
quickly or efficiently. To make this work in restbase, we need to call
.toString() when comparing the body with strings.
