### PR TITLE
Add tests for offline mode Web request blocking

### DIFF
--- a/lib/filters/bucket/pagecontent.js
+++ b/lib/filters/bucket/pagecontent.js
@@ -186,7 +186,7 @@ PCBucket.prototype.getLatestFormat = function(restbase, req) {
                 }
             };
         } else {
-            return { status: 404 };
+            return apiRes;
         }
     });
 };

--- a/lib/filters/global/actions.js
+++ b/lib/filters/global/actions.js
@@ -9,12 +9,7 @@ module.exports = {
         '/v1/{domain}/_svc/action/query': {
             all: {
                 request_handler: function(restbase, req) {
-                    if (restbase._options.conf.offline) {
-                        throw new Error("We are offline, you are trying to fallback to the dynamic API.");
-                    }
-
                     var rp = req.params;
-
                     req.uri = 'http://' + rp.domain + '/w/api.php';
                     var body = req.body || req.query;
                     body.action = 'query';

--- a/lib/filters/global/web.js
+++ b/lib/filters/global/web.js
@@ -14,7 +14,12 @@ function handleAll (restbase, req) {
                     'http://parsoid-lb.eqiad.wikimedia.org/v2/en.wikipedia.org/');
 
     if (restbase._options.conf.offline) {
-        throw new Error("We are offline, you are tring to fallback to dynamic api");
+        return Promise.resolve({
+            status: 500,
+            body: {
+                error: 'We are offline, but your request needs to be serviced online.'
+            }
+        });
     }
 
     //yield requestPr(req);

--- a/test/main.js
+++ b/test/main.js
@@ -35,7 +35,7 @@ function startRestbase(offline) {
     return restbase({
         logging: {
             name: 'restbase-tests',
-            level: 'warn',
+            level: offline ? 'fatal' : 'warn', // hide warnings during offline tests
         },
         offline: offline
     }).then(function(server){


### PR DESCRIPTION
This revealed a couple of issues with the way we
were enabling offline mode in our tests, the way
we were handling offline requests to be blocked,
and the way we respond to blocked requests.  All
have been fixed and are now under test.