### PR TITLE
Test KV Bucket request validation

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -460,7 +460,9 @@ Storage.prototype.putBucket = function (restbase, req) {
     //    valueType: 'blob'
     //};
     // Check whether we have a backend for the requested type
-    var type = req.body && req.body.type;
+    var type = req.body && req.body.type ||
+               req.headers && req.headers.type;
+
     var handler = this.bucketHandlers[type];
 
     if (handler) {

--- a/test/features/buckets.js
+++ b/test/features/buckets.js
@@ -21,6 +21,28 @@ module.exports = function (config) {
         });
     });
     describe('Bucket creation', function() {
+        it('should require a valid request body for a kv bucket', function() {
+            this.timeout(20000);
+            return assert.fails(
+                preq.put({
+                    uri: config.bucketURL,
+                    headers: {
+                        'type': 'kv',
+                        'content-type': 'application/json'
+                    },
+                    body: {}
+                }),
+                function (e) {
+                    assert.deepEqual(e.status, 400);
+                    assert.deepEqual(e.body.example, {
+                        type: 'kv',
+                        revisioned: true,
+                        keyType: 'string',
+                        valueType: 'blob',
+                    });
+                }
+            );
+        });
         it('should require a bucket type', function() {
             this.timeout(20000);
             return assert.fails(

--- a/test/features/buckets.js
+++ b/test/features/buckets.js
@@ -82,42 +82,6 @@ module.exports = function (config) {
                 assert.deepEqual(res.status, 201);
             });
         });
-        it('should retrieve the pages bucket info', function() {
-            this.timeout(20000);
-            return preq.get({
-                uri: config.bucketURL,
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-            });
-        });
-        it('should retrieve the pages bucket listing', function() {
-            this.timeout(20000);
-            return preq.get({
-                uri: config.bucketURL + '/',
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-            });
-        });
-        it('should retrieve the pages.html bucket info', function() {
-            this.timeout(20000);
-            return preq.get({
-                uri: config.bucketURL + '.html',
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-            });
-        });
-        it('should retrieve the pages.html bucket listing', function() {
-            this.timeout(20000);
-            return preq.get({
-                uri: config.bucketURL + '.html/',
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-            });
-        });
     });
 
 };

--- a/test/features/buckets.js
+++ b/test/features/buckets.js
@@ -82,6 +82,42 @@ module.exports = function (config) {
                 assert.deepEqual(res.status, 201);
             });
         });
+        it('should retrieve the pages bucket info', function() {
+            this.timeout(20000);
+            return preq.get({
+                uri: config.bucketURL,
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+        it('should retrieve the pages bucket listing', function() {
+            this.timeout(20000);
+            return preq.get({
+                uri: config.bucketURL + '/',
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+        it('should retrieve the pages.html bucket info', function() {
+            this.timeout(20000);
+            return preq.get({
+                uri: config.bucketURL + '.html',
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+        it('should retrieve the pages.html bucket listing', function() {
+            this.timeout(20000);
+            return preq.get({
+                uri: config.bucketURL + '.html/',
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
     });
 
 };

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -126,4 +126,46 @@ module.exports = function (config) {
         });
 
     });
+
+    describe('pagecontent bucket', function() {
+        it('should provide bucket info', function() {
+            this.timeout(20000);
+            return preq.get({
+                uri: config.bucketURL,
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+        it('should list its contents', function() {
+            this.timeout(20000);
+            return preq.get({
+                uri: config.bucketURL + '/',
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+    });
+
+    describe('pagecontent/html bucket', function() {
+        it('should provide bucket info', function() {
+            this.timeout(20000);
+            return preq.get({
+                uri: config.bucketURL + '.html',
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+        it('should list its contents', function() {
+            this.timeout(20000);
+            return preq.get({
+                uri: config.bucketURL + '.html/',
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+    });
 };


### PR DESCRIPTION
This required adding a second means of detecting
the bucket type -- by looking it up in a request
header. Without this change, there's no way to test
this valiation without introducing another handler
written specifically for this test case, since
the kv bucket won't be triggered by storage.js
without it.