### PR TITLE
Split coverage and coveralls scripts for local coverage use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ notifications:
   email:
     - services@wikimedia.org
 
-script: npm run-script coverage
+script: npm run-script coverage && npm run-script coveralls

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "sh test/utils/cleandb.sh && mocha",
     "coverage": "sh test/utils/cleandb.sh && istanbul cover _mocha -- -R spec",
-    "coveralls": "cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
+    "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "test": "sh test/utils/cleandb.sh && mocha",
-    "coverage": "sh test/utils/cleandb.sh && istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
+    "coverage": "sh test/utils/cleandb.sh && istanbul cover _mocha -- -R spec",
+    "coveralls": "cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This lets us run `npm run-script coverage` locally to generage a useful HTML coverage report under *./coverage/lcov-report/*, without sending anything off to Coveralls.