### PR TITLE
Drop unnecessary console output from testing

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -176,6 +176,7 @@ function handleRequest (opts, req, resp) {
 function setupConfigDefaults(conf) {
     if (!conf) { conf = {}; }
     if (!conf.logging) { conf.logging = {}; }
+    if (!conf.logging.logger) { conf.logging.logger = rbUtil.makeLogger(conf.logging); }
     if (!conf.logging.name) { conf.logging.name = 'restbase'; }
     if (!conf.logging.level) { conf.logging.level = 'warn'; }
     if (!conf.sysdomain) { conf.sysdomain = "restbase.local"; }
@@ -199,7 +200,7 @@ function main(conf) {
     conf = setupConfigDefaults(conf);
     // Set up the global options object with a logger
     var opts = {
-        log: rbUtil.makeLogger(conf.logging),
+        log: conf.logging.logger,
         conf: conf
     };
 

--- a/test/main.js
+++ b/test/main.js
@@ -31,11 +31,10 @@ var stopRestbase = function () {};
 function startRestbase(offline) {
     stopRestbase();
     offline = offline || false;
-    console.log('starting restbase in ' + (offline ? 'OFFLINE' : 'ONLINE') + ' mode');
     return restbase({
         logging: {
             name: 'restbase-tests',
-            level: offline ? 'fatal' : 'warn', // hide warnings during offline tests
+            level: 'fatal'
         },
         offline: offline
     }).then(function(server){


### PR DESCRIPTION
These console outputs were useful at one point, during the development of certain tests, but now are just noising up the test output.

Ideally, the passing/failing of tests should tell us what we need to know about our test results, so nothing from the console should be needed, except for ad-hoc debugging of tests.