### PR TITLE
Drop unneeded content-type request headers from test requests

### DIFF
--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -23,7 +23,6 @@ module.exports = function (config) {
             this.timeout(20000);
             return preq.get({
                 uri: config.bucketURL + '/Foobar/html/624484477',
-                headers: { 'content-type': 'text/html' },
                 body: 'Hello there'
             })
             .then(function(res) {
@@ -92,8 +91,7 @@ module.exports = function (config) {
         it('should return a new wikitext revision using proxy handler with id 624165266', function() {
             this.timeout(20000);
             return preq.get({
-                uri: config.baseURL + '/test/Foobar/wikitext/624165266',
-                headers: { 'content-type': 'text/wikitext' },
+                uri: config.baseURL + '/test/Foobar/wikitext/624165266'
             })
             .then(function(res) {
                 assert.deepEqual(res.status, 200);


### PR DESCRIPTION
Ain't no such thing as a content-type header for a get request.