### PR TITLE
Add storage-backed transform api

### DIFF
--- a/lib/filters/global/parsoid.js
+++ b/lib/filters/global/parsoid.js
@@ -107,7 +107,7 @@ function transformRevision(parsoidHost, from, to) {
         var key    = req.params.key;
         var rev    = req.params.revision;
 
-        var original = {
+        var fromStorage = {
             revid: rev
         };
 
@@ -117,24 +117,11 @@ function transformRevision(parsoidHost, from, to) {
                 if (res.body &&
                     res.body.headers && res.body.headers['content-type'] &&
                     res.body.body) {
-                    return {
-                        status: 200,
+                    fromStorage[format] = {
                         headers: {
                             'content-type': res.body.headers['content-type']
                         },
                         body: res.body.body
-                    };
-                } else {
-                    return {
-                        status: 404
-                    };
-                }
-            })
-            .then(function (res) {
-                if (res.status === 200) {
-                    original[format] = {
-                        headers: res.headers,
-                        body: res.body
                     };
                 }
             });
@@ -142,9 +129,10 @@ function transformRevision(parsoidHost, from, to) {
 
         return Promise.all([ get('html'), get('wikitext'), get('data-parsoid') ])
         .then(function () {
-            var body2 = {};
+            var body2 = {
+                original: fromStorage
+            };
             body2[from] = req.body;
-            body2.original = original;
             return restbase.post({
                 uri: '/v1/' + domain + '/transform/' + from + '/to/' + to,
                 headers: { 'content-type': 'application/json' },

--- a/lib/filters/global/parsoid.js
+++ b/lib/filters/global/parsoid.js
@@ -92,11 +92,70 @@ function transform(parsoidHost, from, to) {
         // fake title to avoid Parsoid error: <400/No title or wikitext was provided>
         var parsoidExtra = (from === 'html') ? '/_' : '';
 
-        return restbase.post({
+        var req2 = {
             uri: parsoidHost + '/v2/' + req.params.domain + '/' + parsoidTo + parsoidExtra,
             headers: { 'content-type': 'application/json' },
             body: req.body
+        };
+        return restbase.post(req2);
+    };
+}
+
+function transformRevision(parsoidHost, from, to) {
+    return function (restbase, req) {
+
+        var domain = req.params.domain;
+        var key    = req.params.key;
+        var rev    = req.params.revision;
+
+        var original = {
+            revid: rev
+        };
+
+        function get(format) {
+            return restbase.get({ uri: '/v1/' + domain + '/pages/' + key + '/' + format + '/' + rev })
+            .then(function (res) {
+                if (
+                    res.body &&
+                    res.body.headers && res.body.headers['content-type'] &&
+                    res.body.body
+                ) {
+                    return {
+                      status: 200,
+                      headers: {
+                          'content-type': res.body.headers['content-type']
+                      },
+                      body: res.body.body
+                    };
+                } else {
+                    return {
+                      status: 404
+                    };
+                }
+            })
+            .then(function (res) {
+                if (res.status === 200) {
+                    original[format] = {
+                        headers: res.headers,
+                        body: res.body
+                    };
+                }
+            });
+        }
+
+        return Promise.all([ get('html'), get('wikitext'), get('data-parsoid') ])
+        .then(function () {
+            var body2 = {};
+            body2[from] = req.body;
+            body2.original = original;
+            var req2 = {
+                uri: '/v1/' + domain + '/transform/' + from + '/to/' + to,
+                headers: { 'content-type': 'application/json' },
+                body: body2
+            };
+            return restbase.post(req2);
         });
+
     };
 }
 
@@ -133,6 +192,15 @@ module.exports = function (conf) {
             },
             '/v1/{domain}/transform/wikitext/to/html': {
                 post: { request_handler: transform(conf.parsoidHost, 'wikitext', 'html') }
+            },
+            '/v1/{domain}/transform/html/to/html/{title}/{revision}': {
+                post: { request_handler: transformRevision(conf.parsoidHost, 'html', 'html') }
+            },
+            '/v1/{domain}/transform/html/to/wikitext/{title}/{revision}': {
+                post: { request_handler: transformRevision(conf.parsoidHost, 'html', 'wikitext') }
+            },
+            '/v1/{domain}/transform/wikitext/to/html/{title}/{revision}': {
+                post: { request_handler: transformRevision(conf.parsoidHost, 'wikitext', 'html') }
             }
         }
     };

--- a/lib/filters/global/parsoid.js
+++ b/lib/filters/global/parsoid.js
@@ -114,21 +114,19 @@ function transformRevision(parsoidHost, from, to) {
         function get(format) {
             return restbase.get({ uri: '/v1/' + domain + '/pages/' + key + '/' + format + '/' + rev })
             .then(function (res) {
-                if (
-                    res.body &&
+                if (res.body &&
                     res.body.headers && res.body.headers['content-type'] &&
-                    res.body.body
-                ) {
+                    res.body.body) {
                     return {
-                      status: 200,
-                      headers: {
-                          'content-type': res.body.headers['content-type']
-                      },
-                      body: res.body.body
+                        status: 200,
+                        headers: {
+                            'content-type': res.body.headers['content-type']
+                        },
+                        body: res.body.body
                     };
                 } else {
                     return {
-                      status: 404
+                        status: 404
                     };
                 }
             })

--- a/lib/filters/global/parsoid.js
+++ b/lib/filters/global/parsoid.js
@@ -92,12 +92,11 @@ function transform(parsoidHost, from, to) {
         // fake title to avoid Parsoid error: <400/No title or wikitext was provided>
         var parsoidExtra = (from === 'html') ? '/_' : '';
 
-        var req2 = {
+        return restbase.post({
             uri: parsoidHost + '/v2/' + req.params.domain + '/' + parsoidTo + parsoidExtra,
             headers: { 'content-type': 'application/json' },
             body: req.body
-        };
-        return restbase.post(req2);
+        });
     };
 }
 
@@ -148,12 +147,11 @@ function transformRevision(parsoidHost, from, to) {
             var body2 = {};
             body2[from] = req.body;
             body2.original = original;
-            var req2 = {
+            return restbase.post({
                 uri: '/v1/' + domain + '/transform/' + from + '/to/' + to,
                 headers: { 'content-type': 'application/json' },
                 body: body2
-            };
-            return restbase.post(req2);
+            });
         });
 
     };

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -96,4 +96,30 @@ module.exports = function (config) {
         x2y(spec);
     });
 
+    describe('transform api', function() {
+        it('should load a specific title/revision from storage to send as the "original"', function () {
+            return preq.post({
+                uri: config.baseURL + '/transform/html/to/wikitext/Main_Page/1',
+                headers: { 'content-type': 'application/json' },
+                body: {
+                    headers: {
+                      'content-type': 'text/html;profile=mediawiki.org/specs/html/1.0.0'
+                    },
+                    body: '<html>The modified HTML</html>'
+                }
+            })
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    wikitext: {
+                        headers: {
+                            'content-type': 'text/plain;profile=mediawiki.org/specs/wikitext/1.0.0'
+                        },
+                        body: 'The modified HTML'
+                    }
+                });
+            });
+        });
+    });
+
 };

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -87,7 +87,7 @@ module.exports = function (config) {
                 assert.deepEqual(res.body, readFile(spec.to.src));
             });
         }
-        describe(spec.name, function() {
+        describe('transform api: ' + spec.name, function() {
             it('should directly convert ' + spec.from.format + ' to ' + spec.to.format, test);
         });
     }
@@ -96,7 +96,7 @@ module.exports = function (config) {
         x2y(spec);
     });
 
-    describe('transform api', function() {
+    describe('storage-backed transform api', function() {
         it('should load a specific title/revision from storage to send as the "original"', function () {
             return preq.post({
                 uri: config.baseURL + '/transform/html/to/wikitext/Main_Page/1',


### PR DESCRIPTION
I'm about 75% certain this is on the right track. :]

This adds three endpoints from [https://phabricator.wikimedia.org/T75955](https://phabricator.wikimedia.org/T75955):

* `POST /{domain}/v1/transform/html/to/html/{title}/{revision}`
* `POST /{domain}/v1/transform/html/to/wikitext/{title}/{revision}`
* `POST /{domain}/v1/transform/wikitext/to/html/{title}/{revision}`