### PR TITLE
Don't create unnecessary Date objects if you just need # milliseconds.

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -36,7 +36,7 @@ rbUtil.StatsD = function ( statsdHost, statsdPort ) {
     }
 
     this.startTimer = function (name) {
-        timers[name] = new Date();
+        timers[name] = Date.now();
     };
 
     this.stopTimer = function (name, suffix) {
@@ -44,7 +44,7 @@ rbUtil.StatsD = function ( statsdHost, statsdPort ) {
         if (!startTime) {
             throw new Error('Tried to stop a timer that does not exist: ' + name);
         }
-        var delta = new Date() - startTime;
+        var delta = Date.now() - startTime;
 
         name = makeName(name);
         if (Array.isArray(suffix)) {


### PR DESCRIPTION
No need to create unnecessary garbage.  Plus the implicit numeric conversion of the Date objects is kinda WAT.