### PR TITLE
Purge remainder of calls to `new Date`.

### DIFF
--- a/lib/filters/bucket/kv.js
+++ b/lib/filters/bucket/kv.js
@@ -203,7 +203,7 @@ KVBucket.prototype.putLatest = function(restbase, req) {
     if (req.headers['last-modified']) {
         try {
             // XXX: require elevated rights for passing in the revision time
-            tid = rbUtil.tidFromDate(new Date(req.headers['last-modified']));
+            tid = rbUtil.tidFromDate(req.headers['last-modified']);
         } catch (e) { }
     }
 
@@ -281,8 +281,8 @@ function getRevisionPredicate (revString) {
         rev = revString;
     } else if (/^\d{4}-\d{2}-\d{2}/.test(revString)) {
         // timestamp
-        var revTime = new Date(revString);
-        if (isNaN(revTime.valueOf())) {
+        var revTime = Date.parse(revString);
+        if (isNaN(revTime)) {
             // invalid date
             return Promise.resolve({
                 status: 400,

--- a/lib/filters/bucket/pagecontent.js
+++ b/lib/filters/bucket/pagecontent.js
@@ -264,7 +264,7 @@ PCBucket.prototype.getFormatRevision = function(restbase, req) {
                 .then(function(apiRes) {
                     if (apiRes.status === 200) {
                         var apiRev = apiRes.body.items[0].revisions[0];
-                        var tid = rbUtil.tidFromDate(new Date(apiRev.timestamp));
+                        var tid = rbUtil.tidFromDate(apiRev.timestamp);
                         req.uri = '/v1/' + rp.domain + '/' + rp.bucket + '.' + rp.format + '/' +
                             rp.key + '/' + tid;
                         return restbase.put({ // Save / update the revision entry

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -156,11 +156,21 @@ rbUtil.reverseDomain = function reverseDomain (domain) {
 };
 
 rbUtil.tidFromDate = function tidFromDate(date) {
+    if (typeof date === 'object') {
+        // convert Date object to numeric milliseconds
+        date = date.getTime();
+    } else if (typeof date === 'string') {
+        // convert date string to numeric milliseconds
+        date = Date.parse(date);
+    }
+    if (isNaN(+date)) {
+        throw new Error('Invalid date');
+    }
     // Create a new, deterministic timestamp
     return uuid.v1({
         node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
         clockseq: 0x1234,
-        msecs: date.getTime(),
+        msecs: +date,
         nsecs: 0
     });
 };


### PR DESCRIPTION
Use `Date.now` and `Date.parse` instead.