### PR TITLE
Enable log tracking during tests, add simple test cases

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -225,7 +225,7 @@ rbUtil.makeLogger = function(conf) {
     function bindAndChild (logger) {
         var log = logger.log.bind(logger);
         log.child = function(args) {
-            return bindAndChild(new Logger(null, logger.logger.child(args)));
+            return bindAndChild(new Logger(conf, logger.logger.child(args)));
         };
         return log;
     }

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -35,6 +35,23 @@ RESTBase.prototype.request = function (req) {
 
 RESTBase.prototype._request = function (req) {
     var self = this;
+    return self.__request(req).then(function (res) {
+        req.uri = req.uri;
+        self.log('trace', {
+          req: {
+              method: req.method,
+              uri: req.uri,
+          },
+          res: {
+              status: res.status
+          }
+        });
+        return res;
+    });
+};
+
+RESTBase.prototype.__request = function (req) {
+    var self = this;
     if (this.__depth > this._options.maxDepth) {
         return Promise.resolve({
             status: 500,

--- a/test/features/parsoid/ondemand.js
+++ b/test/features/parsoid/ondemand.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+// These tests are derived from https://phabricator.wikimedia.org/T75955,
+// section 'On-demand generation of HTML and data-parsoid'
+
+var assert = require('../../utils/assert.js');
+var preq = require('preq');
+var fs = require('fs');
+
+function dump(slice) {
+  slice.get().forEach(function (line) {
+    var entry = JSON.parse(line);
+    console.log('req:', entry.req.method, entry.req.uri,
+                'res:', (entry.res ? entry.res.status : undefined));
+  });
+}
+
+function exists(xs, f) {
+    for (var i = 0; i < xs.length; i++) {
+        if (f(xs[i])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// returns true if all requests in this slice went to
+// /v1/en.wikipedia.test.local/***
+function localRequestsOnly(slice) {
+    return !exists(slice.get(), function(line) {
+      var entry = JSON.parse(line);
+      return !/^\/v1\/en\.wikipedia\.test\.local\//.test(entry.req.uri);
+    });
+}
+
+// return true if some requests in this slice went to 
+// http://parsoid-lb.eqiad.wikimedia.org/v2/**
+function wentToParsoid(slice) {
+    return exists(slice.get(), function(line) {
+      var entry = JSON.parse(line);
+      return /^http:\/\/parsoid-lb\.eqiad\.wikimedia\.org\/v2\//.test(entry.req.uri);
+
+    });
+}
+
+module.exports = function (config) {
+
+    var contentUrl = config.bucketURL + '/Main_Page';
+    var revA = '139992';
+    var revB = '139993';
+
+    describe('on-demand generation of html and data-parsoid', function() {
+
+        it('should transparently create revision A via Parsoid', function () {
+            var slice = config.logStream.slice();
+            return preq.get({
+                uri: contentUrl + '/html/' + revA,
+            })
+            .then(function (res) {
+                slice.halt();
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(localRequestsOnly(slice), false);
+            });
+        });
+
+        it('should transparently create revision B via Parsoid', function () {
+            var slice = config.logStream.slice();
+            return preq.get({
+                uri: contentUrl + '/html/' + revB,
+            })
+            .then(function (res) {
+                slice.halt();
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(localRequestsOnly(slice), false);
+            });
+        });
+
+        it('should retrieve revision B from storage', function () {
+            var slice = config.logStream.slice();
+            return preq.get({
+                uri: contentUrl + '/html/' + revB,
+            })
+            .then(function (res) {
+                slice.halt();
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(localRequestsOnly(slice), true);
+            });
+        });
+
+    });
+
+};

--- a/test/features/parsoid/ondemand.js
+++ b/test/features/parsoid/ondemand.js
@@ -10,14 +10,6 @@ var assert = require('../../utils/assert.js');
 var preq = require('preq');
 var fs = require('fs');
 
-function dump(slice) {
-  slice.get().forEach(function (line) {
-    var entry = JSON.parse(line);
-    console.log('req:', entry.req.method, entry.req.uri,
-                'res:', (entry.res ? entry.res.status : undefined));
-  });
-}
-
 function exists(xs, f) {
     for (var i = 0; i < xs.length; i++) {
         if (f(xs[i])) {

--- a/test/features/parsoid/ondemand.js
+++ b/test/features/parsoid/ondemand.js
@@ -34,7 +34,6 @@ function wentToParsoid(slice) {
     return exists(slice.get(), function(line) {
       var entry = JSON.parse(line);
       return /^http:\/\/parsoid-lb\.eqiad\.wikimedia\.org\/v2\//.test(entry.req.uri);
-
     });
 }
 
@@ -55,6 +54,7 @@ module.exports = function (config) {
                 slice.halt();
                 assert.deepEqual(res.status, 200);
                 assert.deepEqual(localRequestsOnly(slice), false);
+                assert.deepEqual(wentToParsoid(slice), true);
             });
         });
 
@@ -67,6 +67,7 @@ module.exports = function (config) {
                 slice.halt();
                 assert.deepEqual(res.status, 200);
                 assert.deepEqual(localRequestsOnly(slice), false);
+                assert.deepEqual(wentToParsoid(slice), true);
             });
         });
 
@@ -79,6 +80,7 @@ module.exports = function (config) {
                 slice.halt();
                 assert.deepEqual(res.status, 200);
                 assert.deepEqual(localRequestsOnly(slice), true);
+                assert.deepEqual(wentToParsoid(slice), false);
             });
         });
 

--- a/test/main.js
+++ b/test/main.js
@@ -13,8 +13,9 @@
 
 require('mocha-jshint')(); // run JSHint as part of testing
 
-var restbase = require('../lib/server.js');
-var dir      = require('./utils/dir');
+var restbase  = require('../lib/server.js');
+var dir       = require('./utils/dir');
+var logStream = require('./utils/logStream');
 
 var hostPort  = 'http://localhost:7231';
 var baseURL   = hostPort + '/v1/en.wikipedia.test.local';
@@ -23,7 +24,8 @@ var bucketURL = baseURL + '/pages';
 var config = {
     hostPort: hostPort,
     baseURL: baseURL,
-    bucketURL: bucketURL
+    bucketURL: bucketURL,
+    logStream: logStream(),
 };
 
 var stopRestbase = function () {};
@@ -35,7 +37,8 @@ function startRestbase(offline) {
     return restbase({
         logging: {
             name: 'restbase-tests',
-            level: offline ? 'fatal' : 'warn', // hide warnings during offline tests
+            level: 'trace',
+            stream: config.logStream
         },
         offline: offline
     }).then(function(server){

--- a/test/utils/logStream.js
+++ b/test/utils/logStream.js
@@ -1,0 +1,49 @@
+'use strict';
+
+function logStream() {
+
+  var log = [];
+  
+  function write(chunk, encoding, callback) {
+    log.push(chunk);
+  }
+
+  // to implement the stream writer interface
+  function end(chunk, encoding, callback) {
+  } 
+
+  function get() {
+    return log;
+  }
+
+  function slice() {
+
+    var begin = log.length;
+    var end   = null;
+
+    function halt() {
+      if (end === null) {
+        end = log.length;
+      }
+    }
+
+    function get() {
+      return log.slice(begin, end);
+    }
+
+    return {
+      halt: halt,
+      get: get
+    };
+
+  }
+
+  return {
+    write: write,
+    end: end,
+    slice: slice,
+    get: get
+  };
+}
+
+module.exports = logStream;


### PR DESCRIPTION
I'm doing a final pass of phabriactor/T75955, which calls for a few missing test cases.  Part of these test cases calls for ensuring that we go to Parsoid in some cases, and ensuring that we do not go to Parsoid in other cases.

This reveals a more general pattern of needing to inspect the log, and in this case inspect the requests/responses that occurred, so I added a way to trace all requests/responses, and a way to inspect arbitrary slices of the log during testing.

This PR includes the infrastructure for this kind of testing, and some very basic tests that will be expanded further to complete the testing for phabriactor/T75955.