### PR TITLE
Parrot interesting ( >= warn ) log entries to stdout during testing

### DIFF
--- a/test/utils/logStream.js
+++ b/test/utils/logStream.js
@@ -1,10 +1,29 @@
 'use strict';
 
+var bunyan = require('bunyan');
+
 function logStream() {
 
   var log = [];
+  var parrot = bunyan.createLogger({
+    name: 'test-logger',
+    level: 'warn'
+  });
   
   function write(chunk, encoding, callback) {
+    try {
+        var entry = JSON.parse(chunk);
+        var levelMatch = /^(\w+)/.exec(entry.levelPath);
+        if (levelMatch) {
+            var level = levelMatch[1];
+            if (parrot[level]) {
+                parrot[level](entry);
+            }
+        }
+    } catch (e) {
+        console.error('something went wrong trying to parrot a log entry', e);
+    }
+
     log.push(chunk);
   }
 

--- a/test/utils/logStream.js
+++ b/test/utils/logStream.js
@@ -21,7 +21,7 @@ function logStream() {
             }
         }
     } catch (e) {
-        console.error('something went wrong trying to parrot a log entry', e);
+        console.error('something went wrong trying to parrot a log entry', e, chunk);
     }
 
     log.push(chunk);


### PR DESCRIPTION
This way we still see potentially unexpected `warn/error/fatal` log entries on stdout during testing, so that they don't go unnoticed with the new `logStream` feature.