### PR TITLE
Overhaul spec testing

### DIFF
--- a/lib/filters/bucket/pagecontent.js
+++ b/lib/filters/bucket/pagecontent.js
@@ -165,8 +165,9 @@ PCBucket.prototype.getLatest = function(restbase, req, options) {
 PCBucket.prototype.getLatestFormat = function(restbase, req) {
     var rp = req.params;
     var origURI = req.uri;
+    var apiUri = '/v1/' + rp.domain + '/_svc/action/query';
     return restbase.post({
-        uri: '/v1/' + rp.domain + '/_svc/action/query',
+        uri: apiUri,
         body: {
             format: 'json',
             action: 'query',
@@ -186,7 +187,7 @@ PCBucket.prototype.getLatestFormat = function(restbase, req) {
                 }
             };
         } else {
-            return apiRes;
+            throw rbUtil.httpErrors.notFound(apiUri);
         }
     });
 };

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -291,6 +291,14 @@ rbUtil.httpErrors = {
             description: 'We are offline, but your request needs to be serviced online.'
         }
     }),
+    notFound: function(description) {
+        return new HTTPError({
+            status: 404,
+            type: 'notfound',
+            title: 'Not found',
+            description: description
+        });
+    },
     server: function(description) {
         return new HTTPError({
             status: 500,

--- a/test/features/specification/swagger.js
+++ b/test/features/specification/swagger.js
@@ -9,47 +9,80 @@ var specs  = require('../../utils/specs.js');
 
 module.exports = function (config) {
 
-    // Wrap an HTTP request in a continuation
-    function requestK(req) {
-        return function () {
-            return preq[req.method](req);
-        };
-    }
-
-    var specUrl = 'http://wikimedia.github.io/restbase/v1/swagger.yaml';
+    var prereqs = [
+        { // create the domain
+            method: 'put',
+            uri: config.hostPort + '/v1/en.wikipedia.test.local',
+            headers: { 'content-type': 'application/json' },
+            body: {},
+        },
+        { // create the bucket
+            method: 'put',
+            uri: config.bucketURL,
+            headers: { 'content-type': 'application/json' },
+            body: { type: 'pagecontent' },
+        },
+        { // transparently create HTML revision id 624484477
+            method: 'get',
+            uri: config.bucketURL + '/Foobar/html/624484477',
+            body: 'Hello there, this is revision 624484477!'
+        },
+        { // create an html revision of Foobar
+            method: 'put',
+            uri: config.bucketURL + '/Foobar/html/76f22880-362c-11e4-9234-0123456789ab',
+            body: 'Hello there, this is revision 76f22880-362c-11e4-9234-0123456789ab!',
+        },
+        { // create an html revision of Foobar
+            method: 'put',
+            uri: config.bucketURL + '/Foobar/html/9843f080-3443-11e4-9234-0123456789ab',
+            body: 'Hello there, this is revision 9843f080-3443-11e4-9234-0123456789ab!',
+        },
+        { // create an html revision of Foobar
+            method: 'put',
+            uri: config.bucketURL + '/Foobar/html/b9f3f880-8153-11e4-9234-0123456789ab',
+            body: 'Hello there, this is revision b9f3f880-8153-11e4-9234-0123456789ab!',
+        },
+    ];
 
     describe('swagger spec', function () {
-        this.timeout(20000);
-        var xamples = [];
+        var xamples = specs.parseXamples(specs.get(), config.hostPort);
 
-        it('should provide testable x-amples', function (done) {
-            specs.getSpec(specUrl, function (spec) {
-                xamples = specs.parseXamples(spec, config.hostPort);
-                var expected = xamples.length;
-                var actual = 0;
-                xamples.reduce(
-                    function (p, xample) {
-                        return p.then(function () {
-                            // Chain the prerequesites in order
-                            return xample.prereqs.reduce(function (p, prereq) {
-                                return p.then(requestK(prereq));
-                            }, Promise.resolve(true))
-                            // Fire off the main request
-                            .then(requestK(xample.request))
-                            // Validate the response
-                            .then(function (res) {
-                                assert.isSuperset(res, xample.response);
-                                actual = actual + 1;
-                            });
-                        });
-                    },
-                    Promise.resolve(true)
-                ).then(function () {
-                    assert.deepEqual(actual, expected);
-                    done();
+        it('should run ' + prereqs.length + ' idempotent prerequisites', function() {
+            var count = 0;
+            var reqChain = prereqs.map(function (req) {
+                return function () { 
+                    return preq[req.method](req)
+                    .then(function (res) {
+                        count = count + 1;
+                        return res;
+                    });
+                };
+            })
+            .reduce(function (f1, f2) {
+                return function () { return f1().then(f2); };
+            });
+            return reqChain()
+            .then(function () {
+                assert.deepEqual(count, prereqs.length, 'only ran ' + count);
+            });
+        });
+
+        var xamplesRun = 0;
+        xamples.forEach(function (xample) {
+            it(xample.description, function() {
+                return preq[xample.request.method](xample.request)
+                .then(function (res) {
+                    assert.isSuperset(res, xample.response);
+                    xamplesRun = xamplesRun + 1;
+                    return res;
                 });
             });
         });
+
+        it('should have run ' + xamples.length + ' xamples', function() {
+            assert.deepEqual(xamplesRun, xamples.length);
+        });
+
     });
 
 };

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -1,0 +1,267 @@
+swagger: '2.0'
+info:
+  version: '1.0.0'
+  title: RESTBase
+  description: Distributed storage with REST API & dispatcher for backend service
+  termsOfService: https://github.com/wikimedia/restbase#restbase
+  contact:
+    name: Services
+    email: services@lists.wikimedia.org
+    url: https://www.mediawiki.org/wiki/Services
+  license:
+    name: GNU Affero
+    url: http://opensource.org/licenses/AGPL-3.0
+host: localhost:7231
+basePath: /v1
+schemes:
+  - http
+paths:
+  /{domain}/pages/{title}/html/:
+    get:
+      tags:
+        - Page content
+      description: Returns the list of revisions
+      operationId: listRevisions
+      produces:
+        - application/json
+      parameters:
+        - name: domain
+          in: path
+          description: The domain under which the data resides
+          type: string
+          required: true
+          default: en.wikipedia.org
+        - name: title
+          in: path
+          description: The title of page content
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of revisions
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/revisions'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/defaultError'
+      x-amples:
+        - request:
+            params:
+                domain: en.wikipedia.test.local
+                title: Foobar
+          response:
+            status: 200
+            headers:
+                content-type: application/json
+            body:
+              items:
+                - b9f3f880-8153-11e4-9234-0123456789ab
+                - 76f22880-362c-11e4-9234-0123456789ab
+                - 9843f080-3443-11e4-9234-0123456789ab
+  /{domain}/pages/{title}/html:
+    get:
+      tags:
+        - Page content
+      description: Redirects to the latest html
+      operationId: getLatestFormat
+      parameters:
+        - name: domain
+          in: path
+          description: The domain under which the data resides
+          type: string
+          required: true
+          default: en.wikipedia.org
+        - name: title
+          in: path
+          description: The title of page content
+          type: string
+          required: true
+      responses:
+        '302':
+          description: Redirection to the latest html
+        '404':
+          description: Unknown table, bucket, or domain
+          schema:
+            $ref: '#/definitions/notFound'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/defaultError'
+      x-amples:
+        - request:
+            params:
+                domain: en.wikipedia.test.local
+                title: Foobar
+          response:
+            status: 200
+            headers:
+                content-type: text/html; charset=UTF-8
+  /{domain}/pages/{title}/html/{revision}:
+    get:
+      tags:
+        - Page content
+      description: Returns the html for the given revision
+      operationId: getFormatRevision
+      produces:
+        - text/html
+      parameters:
+        - name: domain
+          in: path
+          description: The domain under which the data resides'
+          type: string
+          required: true
+          default: en.wikipedia.org
+        - name: title
+          in: path
+          description: The title of page content
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: The revision
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The latest html for the given page
+        '400':
+          description: Invalid revision
+          schema:
+            $ref: '#/definitions/invalidRevision'
+        '404':
+          description: Unknown table, bucket, page, or domain
+          schema:
+            $ref: '#/definitions/notFound'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/defaultError'
+      x-amples:
+        - request:
+            params:
+                domain: en.wikipedia.test.local
+                title: Foobar
+                revision: 76f22880-362c-11e4-9234-0123456789ab
+          response:
+            status: 200
+            headers:
+                etag: 76f22880-362c-11e4-9234-0123456789ab
+                content-type: text/html; charset=UTF-8
+            body: Hello there, this is revision 76f22880-362c-11e4-9234-0123456789ab!
+  /{domain}/pages/{title}/data-parsoid/{revision}:
+    get:
+      tags:
+        - Page content
+      description: Returns the Parsoid data for the given revision
+      operationId: getFormatRevision
+      produces:
+        - text/html
+      parameters:
+        - name: domain
+          in: path
+          description: The domain under which the data resides'
+          type: string
+          required: true
+          default: en.wikipedia.org
+        - name: title
+          in: path
+          description: The title of page content
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: The revision
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The latest Parsoid data for the given page
+        '400':
+          description: Invalid revision
+          schema:
+            $ref: '#/definitions/invalidRevision'
+        '404':
+          description: Unknown table, bucket, page, or domain
+          schema:
+            $ref: '#/definitions/notFound'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/defaultError'
+      x-amples:
+        - request:
+            params:
+                domain: en.wikipedia.test.local
+                title: Foobar
+                revision: 76f22880-362c-11e4-9234-0123456789ab
+          response:
+            status: 200
+            headers:
+                etag: 76f22880-362c-11e4-9234-0123456789ab
+                content-type: application/json; profile=mediawiki.org/specs/data-parsoid/1.0
+definitions:
+  defaultError:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+  invalidRevision:
+    required:
+      - code
+      - method
+      - title
+      - type
+      - uri
+    properties:
+      code:
+        type: integer
+        format: int32
+      method:
+        type: string
+      title:
+        type: string
+      type:
+        type: string
+      uri:
+        type: string
+  notFound:
+    required:
+      - code
+      - method
+      - title
+      - type
+      - uri
+    properties:
+      code:
+        type: integer
+        format: int32
+      type:
+        type: string
+      title:
+        type: string
+      description:
+        type: string
+      localURI:
+        type: string
+      table:
+        type: string
+      uri:
+        type: string
+      method:
+        type: string
+  revisions:
+    required:
+      - items
+    properties:
+      items:
+        type: array
+        items:
+          type: string

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -2,6 +2,16 @@
 
 var assert = require('assert');
 
+function deepEqual(result, expected) {
+    try {
+        assert.deepEqual(result, expected);
+    } catch (e) {
+        console.log('Expected:\n' + JSON.stringify(expected,null,2));
+        console.log('Result:\n' + JSON.stringify(result,null,2));
+        throw e;
+    }
+}
+
 function isSuperset(parent, child) {
     var result = true;
     if (child instanceof Object) {
@@ -14,16 +24,6 @@ function isSuperset(parent, child) {
         }
     } else {
         deepEqual(parent, child); 
-    }
-}
-
-function deepEqual(result, expected) {
-    try {
-        assert.deepEqual(result, expected);
-    } catch (e) {
-        console.log('Expected:\n' + JSON.stringify(expected,null,2));
-        console.log('Result:\n' + JSON.stringify(result,null,2));
-        throw e;
     }
 }
 
@@ -51,6 +51,7 @@ function fails(promise, onRejected) {
     return promise.catch(trackFailure).then(check);
 }
 
+module.exports.ok           = assert.ok;
 module.exports.fails        = fails;
 module.exports.deepEqual    = deepEqual;
 module.exports.notDeepEqual = notDeepEqual;

--- a/test/utils/specs.js
+++ b/test/utils/specs.js
@@ -3,8 +3,16 @@
 var yaml = require('js-yaml');
 var http = require('http');
 var template = require('url-template');
+var fs = require('fs');
 
-function getSpec(url, k) {
+var specUrl = 'http://wikimedia.github.io/restbase/v1/swagger.yaml';
+
+function getLocalSpec() {
+    var buffer = fs.readFileSync(__dirname + '/../features/specification/swagger.yaml');
+    return yaml.safeLoad(buffer);
+}
+
+function getRemoteSpec(url, k) {
     var buffer = [];
     http.get(url, function (response) {
         response.setEncoding('utf8');
@@ -37,7 +45,7 @@ function parseXamples(spec, host) {
                         xample.request.method = method;
                         xample.request.uri = host + spec.basePath + expandedUri;
                         xamples.push({
-                            desc: method + ' ' + uri,
+                            description: method + ' ' + uri,
                             prereqs: prereqs,
                             request: xample.request,
                             response: xample.response
@@ -50,5 +58,7 @@ function parseXamples(spec, host) {
     return xamples;
 }
 
-module.exports.getSpec = getSpec;
 module.exports.parseXamples = parseXamples;
+
+// TODO: switch this to getRemoteSpec() prior to v1 release
+module.exports.get = getLocalSpec;


### PR DESCRIPTION
This is prep work to convert a bunch of test code into spec tests (using `x-ample`s).  It includes a few changes:

**Source the spec from a file local to the branch**

This makes it easier to keep the spec up to date with the code, but we'll need to remember to push it to the web prior to v1 release, once the v1 API is finalized

**Drop prerequisite requests from specs**

To keep things clean, we'll have all spec tests share a single set of prerequisite requests.  This vastly shortens the spec file, and maintains James' sanity when juggling collisions between tests.

**Cleanup the spec test creation**

The prerequisites are separated into their own Mocha `it()` block, each spec test has its own `it()` block, and there is a final `it()` block that verifies the total number of specs that were run.