### PR TITLE
Use Parsoid result subcomponent, rather than full result body

### DIFF
--- a/doc/development/README.md
+++ b/doc/development/README.md
@@ -61,26 +61,12 @@ return preq.get({
 The user should then expect a response as described above.  Let's [verify the response body](https://github.com/earldouglas/restbase/blob/56127d0f93034aa5e267bdce2d490c079052dfe3/test/features/parsoid/ondemand.js#L87):
 
 ```javascript
-// Ensure the response status is 200
 assert.deepEqual(res.status, 200);
-
-// Inspect the request/response log to make sure Restbase only made local requests
-assert.deepEqual(localRequestsOnly(), false);
-
-// Inspect the request/response log to make sure Restbase made a request to Parsoid
-assert.deepEqual(wentToParsoid(), true);
-
-// Ensure the response body is an object with the correct spec. content type
-var resBody = JSON.parse(res.body);
-assert.deepEqual(resBody.headers, {
-    "content-type": "text/html;profile=mediawiki.org/specs/html/1.0.0"
-});
-
-// Sanity check that the response body is an object with the right body content
-assert.deepEqual(/^<!DOCTYPE html>/.test(resBody.body), true);
-
-// Sanity check that the response body is an object with the right body content
-assert.deepEqual(/<\/html>$/.test(resBody.body), true);
+assert.deepEqual(localRequestsOnly(slice), false);
+assert.deepEqual(wentToParsoid(slice), true);
+assert.deepEqual(res.headers['content-type'], 'text/html;profile=mediawiki.org/specs/html/1.0.0');
+assert.deepEqual(/^<!DOCTYPE html>/.test(res.body), true);
+assert.deepEqual(/<\/html>$/.test(res.body), true);
 ```
 
 As this is a Node project, we will run the test with npm:

--- a/lib/filters/global/parsoid.js
+++ b/lib/filters/global/parsoid.js
@@ -7,11 +7,6 @@
 var uuid   = require('node-uuid');
 var rbUtil = require('../../rbUtil.js');
 
-var contentTypes = {
-    html: 'text/html; charset=UTF-8',
-    'data-parsoid': 'application/json; profile=mediawiki.org/specs/data-parsoid/1.0'
-};
-
 function pagebundle(parsoidHost, restbase, domain, key, rev) {
     var uri = parsoidHost + '/v2/' + domain + '/pagebundle/' + key + '/' + rev;
     return restbase.get({ uri: uri });
@@ -21,30 +16,33 @@ function saveParsoidResult(restbase, domain, bucket, key, format, tid) {
     return function (parsoidResp) {
         // handle the response from Parsoid
         if (parsoidResp.status === 200) {
-            parsoidResp.headers.etag = tid;
-            Promise.all([
+            if (parsoidResp.body.html) {
                 restbase.put({
                     uri: '/v1/' + domain + '/' + bucket + '.html/' + key + '/' + tid,
-                    headers: rbUtil.extend({}, parsoidResp.headers, {'content-type': contentTypes.html}),
-                    body: parsoidResp.body.html
-                }),
+                    headers: parsoidResp.body.html.headers,
+                    body: parsoidResp.body.html.body,
+                });
+            }
+            if (parsoidResp.body['data-parsoid']) {
                 restbase.put({
                     uri: '/v1/' + domain + '/' + bucket + '.data-parsoid/' + key + '/' + tid,
-                    headers: rbUtil.extend({}, parsoidResp.headers, {'content-type': contentTypes['data-parsoid'] }),
-                    body: parsoidResp.body['data-parsoid']
-                })
-            ]);
+                    headers: parsoidResp.body['data-parsoid'].headers,
+                    body: parsoidResp.body['data-parsoid'].body,
+                });
+            }
+            // And return the response to the client
+            if (parsoidResp.body[format]) {
+                return {
+                    status: 200,
+                    headers: {
+                        etag: tid,
+                        'content-type': parsoidResp.body[format].headers['content-type'],
+                    },
+                    body: parsoidResp.body[format].body,
+                };
+            }
         }
-        // And return the response to the client
-        var resp = {
-            'status': parsoidResp.status,
-            headers: rbUtil.extend({}, parsoidResp.headers),
-            body: parsoidResp.body[format]
-        };
-        // XXX: Fix Parsoid's content-type, so that we don't need to
-        // override this here!
-        resp.headers['content-type'] = contentTypes[format];
-        return resp;
+        return parsoidResp;
     };
 }
 

--- a/test/features/pagecontent/idempotent.js
+++ b/test/features/pagecontent/idempotent.js
@@ -12,7 +12,7 @@ module.exports = function (config) {
         it('should accept a new html save with a revision', function() {
             return preq.put({
                 uri: config.bucketURL + '/Idempotent/html/76f22880-362c-11e4-9234-0123456789ab',
-                headers: { 'content-type': 'text/html; charset=UTF-8' },
+                headers: { 'content-type': 'text/html;profile=mediawiki.org/specs/html/1.0.0' },
                 body: 'Hello there'
             })
             .then(function(res) {
@@ -29,7 +29,7 @@ module.exports = function (config) {
             })
             .then(function(res) {
                 assert.deepEqual(res.status, 200);
-                assert.deepEqual(res.headers['content-type'], 'text/html; charset=UTF-8');
+                assert.deepEqual(res.headers['content-type'], 'text/html;profile=mediawiki.org/specs/html/1.0.0');
                 assert.deepEqual(res.headers.etag, '76f22880-362c-11e4-9234-0123456789ab');
                 assert.deepEqual(res.body, 'Hello there');
             });

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -65,7 +65,7 @@ module.exports = function (config) {
             })
             .then(function(res) {
                 assert.deepEqual(res.status, 200);
-                assert.deepEqual(res.headers['content-type'], 'text/html; charset=UTF-8');
+                assert.deepEqual(res.headers['content-type'], 'text/html;profile=mediawiki.org/specs/html/1.0.0');
             });
         });
         it('should return data-parsoid just created by revision 624165266, rev 2', function() {
@@ -74,7 +74,7 @@ module.exports = function (config) {
             })
             .then(function(res) {
                 assert.deepEqual(res.status, 200);
-                assert.deepEqual(res.headers['content-type'], 'application/json; profile=mediawiki.org/specs/data-parsoid/1.0');
+                assert.deepEqual(res.headers['content-type'], 'application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1');
             });
         });
 
@@ -84,7 +84,7 @@ module.exports = function (config) {
             })
             .then(function(res) {
                 assert.deepEqual(res.status, 200);
-                assert.deepEqual(res.headers['content-type'], 'application/json; profile=mediawiki.org/specs/data-parsoid/1.0');
+                assert.deepEqual(res.headers['content-type'], 'application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1');
             });
         });
 
@@ -100,7 +100,7 @@ module.exports = function (config) {
         it('should accept a new html save with a revision', function() {
             return preq.put({
                 uri: config.bucketURL + '/Foobar/html/76f22880-362c-11e4-9234-0123456789ab',
-                headers: { 'content-type': 'text/html; charset=UTF-8' },
+                headers: { 'content-type': 'text/html;profile=mediawiki.org/specs/html/1.0.0' },
                 body: 'Hello there'
             })
             .then(function(res) {
@@ -117,7 +117,7 @@ module.exports = function (config) {
             })
             .then(function(res) {
                 assert.deepEqual(res.status, 200);
-                assert.deepEqual(res.headers['content-type'], 'text/html; charset=UTF-8');
+                assert.deepEqual(res.headers['content-type'], 'text/html;profile=mediawiki.org/specs/html/1.0.0');
                 assert.deepEqual(res.headers.etag, '76f22880-362c-11e4-9234-0123456789ab');
                 assert.deepEqual(res.body, 'Hello there');
             });

--- a/test/features/parsoid/ondemand.js
+++ b/test/features/parsoid/ondemand.js
@@ -97,27 +97,12 @@ module.exports = function (config) {
             .then(function (res) {
                 // Stop watching for new log entries
                 slice.halt();
-
-                // Ensure the response status is 200
                 assert.deepEqual(res.status, 200);
-                
-                // Inspect the request/response log to make sure Restbase only made local requests
                 assert.deepEqual(localRequestsOnly(slice), false);
-                
-                // Inspect the request/response log to make sure Restbase made a request to Parsoid
                 assert.deepEqual(wentToParsoid(slice), true);
-                
-                // Ensure the response body is an object with the correct spec. content type
-                var resBody = JSON.parse(res.body);
-                assert.deepEqual(resBody.headers, {
-                    "content-type": "text/html;profile=mediawiki.org/specs/html/1.0.0"
-                });
-                
-                // Sanity check that the response body is an object with the right body content
-                assert.deepEqual(/^<!DOCTYPE html>/.test(resBody.body), true);
-                
-                // Sanity check that the response body is an object with the right body content
-                assert.deepEqual(/<\/html>$/.test(resBody.body), true);
+                assert.deepEqual(res.headers['content-type'], 'text/html;profile=mediawiki.org/specs/html/1.0.0');
+                assert.deepEqual(/^<!DOCTYPE html>/.test(res.body), true);
+                assert.deepEqual(/<\/html>$/.test(res.body), true);
             });
         });
 

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -98,7 +98,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: text/html; charset=UTF-8
+                content-type: text/html;profile=mediawiki.org/specs/html/1.0.0
   /{domain}/pages/{title}/html/{revision}:
     get:
       tags:
@@ -149,7 +149,7 @@ paths:
             status: 200
             headers:
                 etag: 76f22880-362c-11e4-9234-0123456789ab
-                content-type: text/html; charset=UTF-8
+                content-type: text/html;profile=mediawiki.org/specs/html/1.0.0
             body: Hello there, this is revision 76f22880-362c-11e4-9234-0123456789ab!
   /{domain}/pages/{title}/data-parsoid/{revision}:
     get:
@@ -201,7 +201,7 @@ paths:
             status: 200
             headers:
                 etag: 76f22880-362c-11e4-9234-0123456789ab
-                content-type: application/json; profile=mediawiki.org/specs/data-parsoid/1.0
+                content-type: application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1
 definitions:
   defaultError:
     required:


### PR DESCRIPTION
I uncovered this one while fleshing out some spec tests.  We were storing the entire Parsoid result response rather than the body of the response.

This fixes some erroneous content, and problematic/inconsistent headers.