### PR TITLE
Load the restbase-mod-table-cassandra module

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -51,19 +51,20 @@ templates:
         x-restbase:
           specs:
             - restbase/sys/table
-#          modules:
-#            # There can be multiple modules too per stanza, as long as the
-#            # exported symbols don't conflict. The operationIds from the spec
-#            # will be resolved against all of the modules.
-#            - name: restbase-cassandra
-#              version: 1.0.0
-#              type: npm
-#              options: # Passed to the module constructor
-#                hosts: [localhost]
-#                keyspace: system
-#                username: cassandra
-#                password: cassandra
-#                defaultConsistency: localQuorum # or 'one' for single-node testing
+          modules:
+            # There can be multiple modules too per stanza, as long as the
+            # exported symbols don't conflict. The operationIds from the spec
+            # will be resolved against all of the modules.
+            - name: restbase-mod-table-cassandra
+              version: 1.0.0
+              type: npm
+              options: # Passed to the module constructor
+                conf:
+                  hosts: [localhost]
+                  keyspace: system
+                  username: cassandra
+                  password: cassandra
+                  defaultConsistency: localQuorum # or 'one' for single-node testing
 
       /sys/page_revisions: &wp-page-revisions
         x-restbase:

--- a/lib/router.js
+++ b/lib/router.js
@@ -77,18 +77,14 @@ Router.prototype._loadModule = function (modDef, symbols) {
     // let the error propagate in case the module cannot be loaded
     var modObj = require(loadPath)(modDef.options);
     this._modules.set(modDef, modObj);
-    for (var symbol in modObj) {
-        if (!modObj.hasOwnProperty(symbol)) {
-            // toString() or something else, skip this
-            continue;
-        }
+    Object.keys(modObj).forEach(function(symbol) {
         // check for duplicate symbols
         if (symbols[symbol]) {
             throw new Error("Duplicate symbol " + symbol + " in module " + modDef.name);
         } else {
             symbols[symbol] = modObj[symbol];
         }
-    }
+    });
     return true;
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -70,10 +70,18 @@ Router.prototype._loadModule = function (modDef, symbols) {
         default:
             throw new Error('unknown module type ' + modDef.type + ' (for module ' + modDef.name + ').');
     }
+    // append the log property to module options, if it is not present
+    if (modDef.options) {
+        modDef.options.log = modDef.options.log || this._options.log;
+    }
     // let the error propagate in case the module cannot be loaded
     var modObj = require(loadPath)(modDef.options);
     this._modules.set(modDef, modObj);
     for (var symbol in modObj) {
+        if (!modObj.hasOwnProperty(symbol)) {
+            // toString() or something else, skip this
+            continue;
+        }
         // check for duplicate symbols
         if (symbols[symbol]) {
             throw new Error("Duplicate symbol " + symbol + " in module " + modDef.name);

--- a/lib/server.js
+++ b/lib/server.js
@@ -206,7 +206,7 @@ function main(conf) {
     };
 
     // TODO: actually make tree building / spec loading async!
-    return Promise.resolve(new Router().loadSpec(conf.spec))
+    return Promise.resolve(new Router(opts).loadSpec(conf.spec))
     .then(function(router) {
         opts.router = router;
         app.restbase = new Restbase(opts);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "preq": "~0.3.0",
     "request": "^2.44.0",
     "restbase-cassandra": "~0.3.7",
+    "restbase-mod-table-cassandra": "git+https://github.com/wikimedia/restbase-cassandra#restbase-mod-table-cassandra",
     "routeswitch": "~0.6.1",
     "swagger-router": "git+https://github.com/wikimedia/swagger-router#restbase-loader",
     "url-template": "2.0.4",

--- a/specs/restbase/sys/table.yaml
+++ b/specs/restbase/sys/table.yaml
@@ -4,21 +4,21 @@ info:
   title: RESTBase table storage interface
   description: Generic table storage interface optimized for distributed backends 
 paths:
-#  /{table}:
-#    put:
-#      operationId: createTable
-#    delete:
-#      operationId: dropTable
-#
-#  /{table}/:
-#    get: &get
-#      operationId: get
-#    post: *get
-#    put:
-#      operationId: put
-#
-#  /{table}/{+rest}:
-#    get:
-#      operationId: get
-#    put:
-#      operationId: put
+  /{table}:
+    put:
+      operationId: createTable
+    delete:
+      operationId: dropTable
+
+  /{table}/:
+    get: &get
+      operationId: get
+    post: *get
+    put:
+      operationId: put
+
+  /{table}/{+rest}:
+    get:
+      operationId: get
+    put:
+      operationId: put


### PR DESCRIPTION
This PR activates the loading of the restbase-mod-table-cassandra module. Beware that, while this loads the module, **the actual module loading procedure is still incomplete**. Concretely, the procedure needs to be promisified, since restbase-mod-table-cassandra actually returns a Promise object.