### PR TITLE
Bug fix and test case for restricting access to /{domain}/sys/

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -53,9 +53,9 @@ RESTBase.prototype.request = function (req) {
     // Protect the sys api from direct access
     // Could consider opening this up with a specific permission later.
     if (this._recursionDepth === 0 &&
-            (req.uri.params.api
+            ((req.uri.params && req.uri.params.api === 'sys')
              // TODO: Remove once params.api is reliable
-             || req.uri.segments[1]) === 'sys') {
+             || req.uri.segments[1] === 'sys')) {
         return Promise.reject(new rbUtil.HTTPError({
             status: 403,
             body: {

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var assert = require('../../utils/assert.js');
+var preq = require('preq');
+
+module.exports = function (config) {
+    
+    describe('router - misc', function() {
+        
+        it('should deny access to /{domain}/sys', function() {
+            return preq.get({
+                uri: config.hostPort + '/en.wikipedia.org/sys/table'
+            }).catch(function(err) {
+                assert.deepEqual(err.status, 403);
+            });
+        });
+        
+    });
+    
+};


### PR DESCRIPTION
`restbase.request()` assumed `req.uri.params` and `req.uri.params.api` exist, but they do not (yet). This was causing a problem when evaluating whether a direct call to `/{domain}/sys` had been made. This PR proposes a fix for this issue, together with a test case.