### PR TITLE
Use the 'master' branch status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-[![build status](https://travis-ci.org/wikimedia/restbase.svg)](https://travis-ci.org/wikimedia/restbase)
-[![coverage status](https://coveralls.io/repos/wikimedia/restbase/badge.png)](https://coveralls.io/r/wikimedia/restbase)
+# RESTBase [![Build Status](https://travis-ci.org/wikimedia/restbase.svg?branch=master)](https://travis-ci.org/wikimedia/restbase) [![Coverage Status](https://coveralls.io/repos/wikimedia/restbase/badge.svg?branch=master)](https://coveralls.io/r/wikimedia/restbase?branch=master)
 
-# RESTBase 
 
 [REST content
 API](https://www.mediawiki.org/wiki/Requests_for_comment/Content_API) and [storage service](https://www.mediawiki.org/wiki/Requests_for_comment/Storage_service) prototype.


### PR DESCRIPTION
This points the build status badges to the results for the 'master' branch, regardless of which branch built most recently.

It would be rad if we could show badges for whichever branch is currently selected, but I don't think there's an easy way to do it, so this at least keeps things consistent.

Since most people will look at the 'master' version of README.md, we can just default to showing 'master' badges.