### PR TITLE
Convert getBucketInfo and listBucket tests into spec x-amples

### DIFF
--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -125,45 +125,4 @@ module.exports = function (config) {
 
     });
 
-    describe('pagecontent bucket', function() {
-        it('should provide bucket info', function() {
-            this.timeout(20000);
-            return preq.get({
-                uri: config.bucketURL,
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-            });
-        });
-        it('should list its contents', function() {
-            this.timeout(20000);
-            return preq.get({
-                uri: config.bucketURL + '/',
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-            });
-        });
-    });
-
-    describe('pagecontent/html bucket', function() {
-        it('should provide bucket info', function() {
-            this.timeout(20000);
-            return preq.get({
-                uri: config.bucketURL + '.html',
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-            });
-        });
-        it('should list its contents', function() {
-            this.timeout(20000);
-            return preq.get({
-                uri: config.bucketURL + '.html/',
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-            });
-        });
-    });
 };

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -16,6 +16,84 @@ basePath: /v1
 schemes:
   - http
 paths:
+  /{domain}/{bucket}:
+    get:
+      tags:
+        - Page content
+      description: Returns information about the given bucket
+      operationId: getBucketInfo
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: The bucket info
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/defaultError'
+      x-amples:
+        - request:
+            params:
+              bucket: pages
+              domain: en.wikipedia.test.local
+          response:
+            status: 200
+            headers:
+              content-type: application/json
+            body:
+              domain: en.wikipedia.test.local
+              table: pages
+              type: pagecontent
+        - request:
+            params:
+              bucket: pages.html
+              domain: en.wikipedia.test.local
+          response:
+            status: 200
+            headers:
+              content-type: application/json
+            body:
+              domain: en.wikipedia.test.local
+              table: pages
+              type: kv
+  /{domain}/{bucket}/:
+    get:
+      tags:
+        - Page content
+      description: Returns a list of bucket items
+      operationId: listBucket
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: The bucket items
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/defaultError'
+      x-amples:
+        - request:
+            params:
+              bucket: pages
+              domain: en.wikipedia.test.local
+          response:
+            status: 200
+            headers:
+              content-type: application/json
+            body:
+              items:
+                - .+
+        - request:
+            params:
+              bucket: pages.html
+              domain: en.wikipedia.test.local
+          response:
+            status: 200
+            headers:
+              content-type: application/json
+            body:
+              items:
+                - .+
   /{domain}/pages/{title}/html/:
     get:
       tags:


### PR DESCRIPTION
This shouldn't decrease coverage, but let's fix it if it does.