### PR TITLE
Put URI parameter names

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,7 +26,7 @@ templates:
       - mediaWikiAuth:
         - user:read
     paths:
-      /v1:
+      /{api:v1}:
         x-restbase:
           specs:
             - mediawiki/v1/content
@@ -46,7 +46,7 @@ templates:
                       #
                       # This stanza defines the /{domain}/sys/ hierarchy.
 
-      /sys/table: &wp/sys/table # Can use this anchor to share the table
+      /{api:sys}/{module:table}: &wp/sys/table # Can use this anchor to share the table
                                 # backend even if other parts differ
         x-restbase:
           specs:
@@ -66,7 +66,7 @@ templates:
                   password: cassandra
                   defaultConsistency: localQuorum # or 'one' for single-node testing
 
-      /sys/page_revisions: &wp-page-revisions
+      /{api:sys}/{module:page_revisions}: &wp-page-revisions
         x-restbase:
           specs:
             - mediawiki/sys/page_revisions
@@ -77,7 +77,7 @@ templates:
 #              options:
 #                apiURL: http://{domain}/w/api.php
 
-      /sys/key_value: &wp/sys/key_value
+      /{api:sys}/{module:key_value}: &wp/sys/key_value
         x-restbase:
           specs:
             - restbase/sys/key_value
@@ -87,7 +87,7 @@ templates:
               type: file
 
 
-      /sys/parsoid:
+      /{api:sys}/{module:parsoid}:
         x-restbase:
           specs:
             - mediawiki/sys/parsoid
@@ -99,7 +99,7 @@ templates:
 #                parsoidHost: http://parsoid-lb.wikimedia.org
 #                apiURL: http://{domain}/w/api.php
 
-#      /sys/revscore:
+#      /{api:sys}/{module:revscore}:
 #        title: Simple revscore service wrapper
 #        x-restbase:
 #          # Generic revision service interface; Expects requests of the form

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -14,7 +14,7 @@ info:
 
 paths:
 
-  /page/{title}/html:
+  /{module:page}/{title}/html:
     get:
       tags:
         - page content
@@ -51,7 +51,7 @@ paths:
           # See also http://tools.ietf.org/html/rfc7231#section-7.1.2
           uri: /{domain}/sys/parsoid/html/{title}/latest
 
-  /page/{title}/html/:
+  /{module:page}/{title}/html/:
     get:
       tags:
         - Page content
@@ -86,7 +86,7 @@ paths:
         service:
           uri: /{domain}/sys/parsoid/html/{title}/
 
-  /page/{title}/data-parsoid/{revision}:
+  /{module:page}/{title}/data-parsoid/{revision}:
     get:
       tags:
         - Page content
@@ -133,7 +133,7 @@ paths:
             cache-control: $req.headers.cache-control
               
 
-  /page/{title}/html/{revision}:
+  /{module:page}/{title}/html/{revision}:
     get:
       tags:
         - Page content
@@ -179,7 +179,7 @@ paths:
           headers:
             cache-control: $req.headers.cache-control
 
-  /dummy/get:
+  /{module:dummy}/get:
     get:
       tags:
         - dummy get
@@ -204,7 +204,7 @@ paths:
           schema:
             $ref: '#/definitions/defaulterror'
 
-  /dummy/set:
+  /{module:dummy}/set:
     get:
       tags:
         - dummy set


### PR DESCRIPTION
As discussed, the structure of URI's should be:
* `/{domain}/{api}/{module}/...`

This PR names URI path portions in the spec