### PR TITLE
Clean up: Remove sysdomain and storage config options

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,9 +2,6 @@
 
 port: 7231
 
-# System domain (used to store restbase metadata)
-sysdomain: restbase.local
-
 templates:
 
   wmf-content-1.0.0: &wp/content/1.0.0

--- a/lib/server.js
+++ b/lib/server.js
@@ -209,19 +209,6 @@ function setupConfigDefaults(conf) {
     if (!conf.logging) { conf.logging = {}; }
     if (!conf.logging.name) { conf.logging.name = 'restbase'; }
     if (!conf.logging.level) { conf.logging.level = 'warn'; }
-    if (!conf.sysdomain) { conf.sysdomain = "restbase.local"; }
-    if (!conf.storage) { conf.storage = {}; }
-    if (!conf.storage['default']) {
-        conf.storage['default'] = {
-            // module name
-            type: "restbase-cassandra",
-            hosts: ["localhost"],
-            keyspace: "system",
-            username: "cassandra",
-            password: "cassandra",
-            defaultConsistency: 'one' // use localQuorum in production
-        };
-    }
     return conf;
 }
 


### PR DESCRIPTION
`sysdomain` was in use with the layered request router. However, with the move of storage functionality to /{domain}/sys/table, it is no longer used. Idem for the `storage` configuration property.