### PR TITLE
Temporarily hold heapdump version at 0.3.3 to avoid breakage on node 0.1...

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "mocha": "~1.x.x",
     "mocha-jshint": "0.0.9",
-    "heapdump": "~0.3.3",
+    "heapdump": "0.3.3",
     "istanbul": "0.3.5",
     "mocha-lcov-reporter": "0.0.1",
     "coveralls": "2.11.2"


### PR DESCRIPTION
...1

Version 0.3.4 of heapdump broke node 0.11 compatibility in favor of iojs.
Since we are not testing (yet) with iojs (waiting for
https://github.com/travis-ci/travis-ci/issues/3108), hold heapdump at the
working version so that our tests against node 0.11 continue to pass.