### PR TITLE
Add sequence diagram for current VE page edit workflow

### DIFF
--- a/doc/visualeditor/page-edit.svg
+++ b/doc/visualeditor/page-edit.svg
@@ -1,0 +1,906 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg height="1668" version="1.1" width="1834" xmlns="http://www.w3.org/2000/svg">
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="63" y2="68"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="73" y2="78"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="83" y2="88"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="93" y2="98"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="103" y2="108"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="113" y2="118"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="123" y2="128"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="133" y2="138"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="143" y2="148"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="153" y2="158"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="163" y2="168"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="173" y2="178"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="183" y2="188"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="193" y2="198"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="203" y2="208"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="213" y2="218"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="223" y2="228"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="233" y2="238"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="243" y2="248"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="253" y2="258"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="263" y2="268"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="273" y2="278"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="283" y2="288"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="293" y2="298"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="303" y2="308"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="313" y2="318"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="323" y2="328"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="333" y2="338"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="343" y2="348"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="353" y2="358"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="363" y2="368"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="373" y2="378"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="383" y2="388"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="393" y2="398"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="403" y2="408"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="413" y2="418"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="423" y2="428"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="433" y2="438"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="443" y2="448"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="453" y2="458"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="463" y2="468"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="473" y2="478"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="483" y2="488"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="493" y2="498"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="503" y2="508"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="513" y2="518"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="523" y2="528"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="533" y2="538"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="543" y2="548"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="553" y2="558"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="563" y2="568"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="573" y2="578"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="583" y2="588"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="593" y2="598"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="603" y2="608"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="613" y2="618"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="623" y2="628"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="633" y2="638"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="643" y2="648"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="653" y2="658"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="663" y2="668"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="673" y2="678"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="683" y2="688"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="693" y2="698"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="703" y2="708"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="713" y2="718"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="723" y2="728"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="733" y2="738"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="743" y2="748"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="753" y2="758"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="763" y2="768"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="773" y2="778"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="783" y2="788"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="793" y2="798"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="803" y2="808"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="813" y2="818"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="823" y2="828"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="833" y2="838"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="843" y2="848"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="853" y2="858"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="863" y2="868"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="873" y2="878"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="883" y2="888"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="893" y2="898"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="903" y2="908"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="913" y2="918"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="923" y2="928"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="933" y2="938"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="943" y2="948"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="953" y2="958"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="963" y2="968"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="973" y2="978"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="983" y2="988"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="993" y2="998"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1003" y2="1008"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1013" y2="1018"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1023" y2="1028"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1033" y2="1038"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1043" y2="1048"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1053" y2="1058"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1063" y2="1068"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1073" y2="1078"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1083" y2="1088"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1093" y2="1098"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1103" y2="1108"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1113" y2="1118"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1123" y2="1128"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1133" y2="1138"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1143" y2="1148"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1153" y2="1158"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1163" y2="1168"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1173" y2="1178"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1183" y2="1188"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1193" y2="1198"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1203" y2="1208"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1213" y2="1218"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1223" y2="1228"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1233" y2="1238"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1243" y2="1248"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1253" y2="1258"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1263" y2="1268"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1273" y2="1278"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1283" y2="1288"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1293" y2="1298"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1303" y2="1308"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1313" y2="1318"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1323" y2="1328"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1333" y2="1338"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1343" y2="1348"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1353" y2="1358"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1363" y2="1368"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1373" y2="1378"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1383" y2="1388"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1393" y2="1398"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1403" y2="1408"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1413" y2="1418"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1423" y2="1428"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1433" y2="1438"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1443" y2="1448"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1453" y2="1458"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1463" y2="1468"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1473" y2="1478"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1483" y2="1488"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1493" y2="1498"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1503" y2="1508"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1513" y2="1518"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1523" y2="1528"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1533" y2="1538"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1543" y2="1548"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1553" y2="1558"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1563" y2="1568"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1573" y2="1578"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1583" y2="1588"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1593" y2="1598"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1603" y2="1608"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1613" y2="1618"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1623" y2="1628"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1633" y2="1638"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="146" x2="146" y1="1643" y2="1648"/>
+<rect fill="#ffffff" height="1590" stroke="#ffffff" stroke-width="1" width="20" x="136" y="63"/>
+<rect fill="none" height="1590" stroke="#000000" stroke-width="1" width="20" x="136" y="63"/>
+<rect fill="#ffffff" height="50" stroke="#ffffff" stroke-width="1" width="264" x="14" y="14"/>
+<rect fill="none" height="50" stroke="#000000" stroke-width="1" width="264" x="14" y="14"/>
+<text font-family="Dialog" font-size="12" x="119" y="27">
+/Browser</text>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="63" y2="68"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="73" y2="78"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="83" y2="88"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="93" y2="98"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="103" y2="108"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="113" y2="118"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="123" y2="128"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="133" y2="138"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="143" y2="148"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="153" y2="158"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="163" y2="168"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="173" y2="178"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="183" y2="188"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="193" y2="198"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="203" y2="208"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="213" y2="218"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="223" y2="228"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="233" y2="238"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="243" y2="248"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="253" y2="258"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="263" y2="268"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="273" y2="278"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="283" y2="288"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="293" y2="298"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="303" y2="308"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="313" y2="318"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="323" y2="328"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="333" y2="338"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="343" y2="348"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="353" y2="358"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="363" y2="368"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="373" y2="378"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="383" y2="388"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="393" y2="398"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="403" y2="408"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="413" y2="418"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="423" y2="428"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="433" y2="438"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="443" y2="448"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="453" y2="458"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="463" y2="468"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="473" y2="478"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="483" y2="488"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="493" y2="498"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="503" y2="508"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="513" y2="518"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="523" y2="528"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="533" y2="538"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="543" y2="548"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="553" y2="558"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="563" y2="568"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="573" y2="578"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="583" y2="588"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="593" y2="598"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="603" y2="608"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="613" y2="618"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="623" y2="628"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="633" y2="638"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="643" y2="648"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="653" y2="658"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="663" y2="668"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="673" y2="678"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="683" y2="688"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="693" y2="698"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="703" y2="708"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="713" y2="718"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="723" y2="728"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="733" y2="738"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="743" y2="748"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="753" y2="758"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="763" y2="768"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="773" y2="778"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="783" y2="788"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="793" y2="798"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="803" y2="808"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="813" y2="818"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="823" y2="828"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="833" y2="838"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="843" y2="848"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="853" y2="858"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="863" y2="868"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="873" y2="878"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="883" y2="888"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="893" y2="898"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="903" y2="908"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="913" y2="918"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="923" y2="928"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="933" y2="938"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="943" y2="948"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="953" y2="958"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="963" y2="968"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="973" y2="978"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="983" y2="988"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="993" y2="998"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1003" y2="1008"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1013" y2="1018"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1023" y2="1028"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1033" y2="1038"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1043" y2="1048"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1053" y2="1058"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1063" y2="1068"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1073" y2="1078"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1083" y2="1088"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1093" y2="1098"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1103" y2="1108"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1113" y2="1118"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1123" y2="1128"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1133" y2="1138"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1143" y2="1148"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1153" y2="1158"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1163" y2="1168"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1173" y2="1178"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1183" y2="1188"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1193" y2="1198"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1203" y2="1208"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1213" y2="1218"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1223" y2="1228"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1233" y2="1238"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1243" y2="1248"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1253" y2="1258"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1263" y2="1268"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1273" y2="1278"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1283" y2="1288"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1293" y2="1298"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1303" y2="1308"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1313" y2="1318"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1323" y2="1328"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1333" y2="1338"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1343" y2="1348"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1353" y2="1358"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1363" y2="1368"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1373" y2="1378"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1383" y2="1388"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1393" y2="1398"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1403" y2="1408"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1413" y2="1418"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1423" y2="1428"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1433" y2="1438"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1443" y2="1448"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1453" y2="1458"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1463" y2="1468"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1473" y2="1478"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1483" y2="1488"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1493" y2="1498"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1503" y2="1508"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1513" y2="1518"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1523" y2="1528"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1533" y2="1538"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1543" y2="1548"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1553" y2="1558"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1563" y2="1568"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1573" y2="1578"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1583" y2="1588"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1593" y2="1598"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1603" y2="1608"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1613" y2="1618"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1623" y2="1628"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1633" y2="1638"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="854" x2="854" y1="1643" y2="1648"/>
+<rect fill="#ffffff" height="192" stroke="#ffffff" stroke-width="1" width="20" x="844" y="302"/>
+<rect fill="none" height="192" stroke="#000000" stroke-width="1" width="20" x="844" y="302"/>
+<rect fill="#ffffff" height="198" stroke="#ffffff" stroke-width="1" width="20" x="844" y="1046"/>
+<rect fill="none" height="198" stroke="#000000" stroke-width="1" width="20" x="844" y="1046"/>
+<rect fill="#ffffff" height="30" stroke="#ffffff" stroke-width="1" width="20" x="854" y="1194"/>
+<rect fill="none" height="30" stroke="#000000" stroke-width="1" width="20" x="854" y="1194"/>
+<rect fill="#ffffff" height="50" stroke="#ffffff" stroke-width="1" width="208" x="750" y="14"/>
+<rect fill="none" height="50" stroke="#000000" stroke-width="1" width="208" x="750" y="14"/>
+<text font-family="Dialog" font-size="12" x="754" y="27">
+/api.php#Extension:VisualEditor</text>
+<polyline fill="none" points="156,302 844,302" stroke="#000000" stroke-width="1"/>
+<polygon fill="#000000" points="844,302 832,309 832,295" stroke="#000000" stroke-width="1"/>
+<polygon fill="none" points="844,302 832,309 832,295" stroke="#000000" stroke-width="1"/>
+<ellipse cx="500" cy="300" fill="#000000" rx="0.5" ry="0.5" stroke="#000000" stroke-width="1"/>
+<ellipse cx="501" cy="301" fill="#ffffff" rx="-0.5" ry="-0.5" stroke="#ffffff" stroke-width="1"/>
+<polyline fill="none" points="844,494 156,494" stroke="#000000" stroke-width="1"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="168" x2="156" y1="487" y2="494"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="168" x2="156" y1="501" y2="494"/>
+<ellipse cx="500" cy="492" fill="#000000" rx="0.5" ry="0.5" stroke="#000000" stroke-width="1"/>
+<ellipse cx="501" cy="493" fill="#ffffff" rx="-0.5" ry="-0.5" stroke="#ffffff" stroke-width="1"/>
+<polygon fill="#ffffff" points="350,62 619,62 629,72 629,247 350,247 350,62" stroke="#ffffff" stroke-width="1"/>
+<polyline fill="none" points="350,62 619,62 629,72 629,247 350,247 350,62" stroke="#000000" stroke-width="1"/>
+<polygon fill="#b2b2b2" points="619,62 629,72 619,72 619,62" stroke="#b2b2b2" stroke-width="1"/>
+<polyline fill="none" points="619,62 629,72 619,72 619,62" stroke="#000000" stroke-width="1"/>
+<text font-family="Dialog" font-size="12" x="353" y="77">
+POST https://www.mediawiki.org/w/api.php</text>
+<text font-family="Dialog" font-size="12" x="353" y="107">
+Content-Type: multipart/form-data</text>
+<text font-family="Dialog" font-size="12" x="353" y="122">
+Accept: application/json</text>
+<text font-family="Dialog" font-size="12" x="353" y="152">
+format=json</text>
+<text font-family="Dialog" font-size="12" x="353" y="167">
+uselang=en</text>
+<text font-family="Dialog" font-size="12" x="353" y="182">
+action=visualeditor</text>
+<text font-family="Dialog" font-size="12" x="353" y="197">
+paction=serializeforcache</text>
+<text font-family="Dialog" font-size="12" x="353" y="212">
+html=...</text>
+<text font-family="Dialog" font-size="12" x="353" y="227">
+page=...</text>
+<text font-family="Dialog" font-size="12" x="353" y="242">
+oldid=1389155</text>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="248" y2="253"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="258" y2="263"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="268" y2="273"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="278" y2="283"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="288" y2="293"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="298" y2="300"/>
+<polygon fill="#ffffff" points="302,526 651,526 661,536 661,681 302,681 302,526" stroke="#ffffff" stroke-width="1"/>
+<polyline fill="none" points="302,526 651,526 661,536 661,681 302,681 302,526" stroke="#000000" stroke-width="1"/>
+<polygon fill="#b2b2b2" points="651,526 661,536 651,536 651,526" stroke="#b2b2b2" stroke-width="1"/>
+<polyline fill="none" points="651,526 661,536 651,536 651,526" stroke="#000000" stroke-width="1"/>
+<text font-family="Dialog" font-size="12" x="305" y="541">
+200 OK</text>
+<text font-family="Dialog" font-size="12" x="305" y="571">
+Content-Type: application/json</text>
+<text font-family="Dialog" font-size="12" x="305" y="601">
+{</text>
+<text font-family="Dialog" font-size="12" x="305" y="616">
+  "visualeditor": {</text>
+<text font-family="Dialog" font-size="12" x="305" y="631">
+    "result": "success",</text>
+<text font-family="Dialog" font-size="12" x="305" y="646">
+    "cachekey": "9e91b9c71cfaf60693bc27488c2e0a07"</text>
+<text font-family="Dialog" font-size="12" x="305" y="661">
+  }</text>
+<text font-family="Dialog" font-size="12" x="305" y="676">
+}</text>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="526" y2="521"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="516" y2="511"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="506" y2="501"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="496" y2="492"/>
+<polyline fill="none" points="156,1046 844,1046" stroke="#000000" stroke-width="1"/>
+<polygon fill="#000000" points="844,1046 832,1053 832,1039" stroke="#000000" stroke-width="1"/>
+<polygon fill="none" points="844,1046 832,1053 832,1039" stroke="#000000" stroke-width="1"/>
+<ellipse cx="500" cy="1044" fill="#000000" rx="0.5" ry="0.5" stroke="#000000" stroke-width="1"/>
+<ellipse cx="501" cy="1045" fill="#ffffff" rx="-0.5" ry="-0.5" stroke="#ffffff" stroke-width="1"/>
+<polyline fill="none" points="844,1244 156,1244" stroke="#000000" stroke-width="1"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="168" x2="156" y1="1237" y2="1244"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="168" x2="156" y1="1251" y2="1244"/>
+<ellipse cx="500" cy="1242" fill="#000000" rx="0.5" ry="0.5" stroke="#000000" stroke-width="1"/>
+<ellipse cx="501" cy="1243" fill="#ffffff" rx="-0.5" ry="-0.5" stroke="#ffffff" stroke-width="1"/>
+<polygon fill="#ffffff" points="350,758 619,758 629,768 629,1003 350,1003 350,758" stroke="#ffffff" stroke-width="1"/>
+<polyline fill="none" points="350,758 619,758 629,768 629,1003 350,1003 350,758" stroke="#000000" stroke-width="1"/>
+<polygon fill="#b2b2b2" points="619,758 629,768 619,768 619,758" stroke="#b2b2b2" stroke-width="1"/>
+<polyline fill="none" points="619,758 629,768 619,768 619,758" stroke="#000000" stroke-width="1"/>
+<text font-family="Dialog" font-size="12" x="353" y="773">
+POST https://www.mediawiki.org/w/api.php</text>
+<text font-family="Dialog" font-size="12" x="353" y="803">
+Content-Type: multipart/form-data</text>
+<text font-family="Dialog" font-size="12" x="353" y="818">
+Accept: application/json</text>
+<text font-family="Dialog" font-size="12" x="353" y="848">
+format=json</text>
+<text font-family="Dialog" font-size="12" x="353" y="863">
+uselang=en</text>
+<text font-family="Dialog" font-size="12" x="353" y="878">
+summary=...</text>
+<text font-family="Dialog" font-size="12" x="353" y="893">
+minor=...</text>
+<text font-family="Dialog" font-size="12" x="353" y="908">
+action=visualeditoredit</text>
+<text font-family="Dialog" font-size="12" x="353" y="923">
+page=...</text>
+<text font-family="Dialog" font-size="12" x="353" y="938">
+oldid=1389155</text>
+<text font-family="Dialog" font-size="12" x="353" y="953">
+basetimestamp=...</text>
+<text font-family="Dialog" font-size="12" x="353" y="968">
+starttimestamp=...</text>
+<text font-family="Dialog" font-size="12" x="353" y="983">
+token=...</text>
+<text font-family="Dialog" font-size="12" x="353" y="998">
+cachekey=...</text>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="1004" y2="1009"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="1014" y2="1019"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="1024" y2="1029"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="1034" y2="1039"/>
+<polygon fill="#ffffff" points="374,1302 643,1302 653,1312 653,1622 374,1622 374,1302" stroke="#ffffff" stroke-width="1"/>
+<polyline fill="none" points="374,1302 643,1302 653,1312 653,1622 374,1622 374,1302" stroke="#000000" stroke-width="1"/>
+<polygon fill="#b2b2b2" points="643,1302 653,1312 643,1312 643,1302" stroke="#b2b2b2" stroke-width="1"/>
+<polyline fill="none" points="643,1302 653,1312 643,1312 643,1302" stroke="#000000" stroke-width="1"/>
+<text font-family="Dialog" font-size="12" x="377" y="1317">
+200 OK</text>
+<text font-family="Dialog" font-size="12" x="377" y="1347">
+Content-Type: application/json</text>
+<text font-family="Dialog" font-size="12" x="377" y="1377">
+{</text>
+<text font-family="Dialog" font-size="12" x="377" y="1392">
+  "visualeditoredit": {</text>
+<text font-family="Dialog" font-size="12" x="377" y="1407">
+    "content": "&lt;&lt;html&gt;&gt;",</text>
+<text font-family="Dialog" font-size="12" x="377" y="1422">
+    "categorieshtml": "&lt;&lt;html&gt;&gt;",</text>
+<text font-family="Dialog" font-size="12" x="377" y="1437">
+    "basetimestamp": "20150202173621",</text>
+<text font-family="Dialog" font-size="12" x="377" y="1452">
+    "starttimestamp": "20150202173621",</text>
+<text font-family="Dialog" font-size="12" x="377" y="1467">
+    "displayTitleHtml": "VisualEditor:Test",</text>
+<text font-family="Dialog" font-size="12" x="377" y="1482">
+    "isRedirect": false,</text>
+<text font-family="Dialog" font-size="12" x="377" y="1497">
+    "contentSub": "",</text>
+<text font-family="Dialog" font-size="12" x="377" y="1512">
+    "lastModified": {</text>
+<text font-family="Dialog" font-size="12" x="377" y="1527">
+      "date": "2 February 2015",</text>
+<text font-family="Dialog" font-size="12" x="377" y="1542">
+      "time": "17:36"</text>
+<text font-family="Dialog" font-size="12" x="377" y="1557">
+    },</text>
+<text font-family="Dialog" font-size="12" x="377" y="1572">
+    "newrevid": 1389562,</text>
+<text font-family="Dialog" font-size="12" x="377" y="1587">
+    "result": "success"</text>
+<text font-family="Dialog" font-size="12" x="377" y="1602">
+  }</text>
+<text font-family="Dialog" font-size="12" x="377" y="1617">
+}</text>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="1302" y2="1297"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="1292" y2="1287"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="1282" y2="1277"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="1272" y2="1267"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="1262" y2="1257"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="500" x2="500" y1="1252" y2="1247"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="63" y2="68"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="73" y2="78"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="83" y2="88"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="93" y2="98"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="103" y2="108"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="113" y2="118"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="123" y2="128"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="133" y2="138"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="143" y2="148"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="153" y2="158"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="163" y2="168"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="173" y2="178"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="183" y2="188"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="193" y2="198"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="203" y2="208"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="213" y2="218"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="223" y2="228"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="233" y2="238"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="243" y2="248"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="253" y2="258"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="263" y2="268"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="273" y2="278"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="283" y2="288"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="293" y2="298"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="303" y2="308"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="313" y2="318"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="323" y2="328"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="333" y2="338"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="343" y2="348"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="353" y2="358"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="363" y2="368"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="373" y2="378"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="383" y2="388"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="393" y2="398"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="403" y2="408"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="413" y2="418"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="423" y2="428"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="433" y2="438"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="443" y2="448"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="453" y2="458"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="463" y2="468"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="473" y2="478"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="483" y2="488"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="493" y2="498"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="503" y2="508"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="513" y2="518"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="523" y2="528"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="533" y2="538"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="543" y2="548"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="553" y2="558"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="563" y2="568"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="573" y2="578"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="583" y2="588"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="593" y2="598"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="603" y2="608"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="613" y2="618"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="623" y2="628"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="633" y2="638"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="643" y2="648"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="653" y2="658"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="663" y2="668"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="673" y2="678"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="683" y2="688"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="693" y2="698"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="703" y2="708"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="713" y2="718"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="723" y2="728"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="733" y2="738"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="743" y2="748"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="753" y2="758"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="763" y2="768"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="773" y2="778"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="783" y2="788"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="793" y2="798"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="803" y2="808"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="813" y2="818"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="823" y2="828"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="833" y2="838"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="843" y2="848"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="853" y2="858"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="863" y2="868"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="873" y2="878"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="883" y2="888"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="893" y2="898"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="903" y2="908"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="913" y2="918"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="923" y2="928"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="933" y2="938"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="943" y2="948"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="953" y2="958"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="963" y2="968"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="973" y2="978"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="983" y2="988"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="993" y2="998"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1003" y2="1008"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1013" y2="1018"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1023" y2="1028"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1033" y2="1038"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1043" y2="1048"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1053" y2="1058"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1063" y2="1068"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1073" y2="1078"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1083" y2="1088"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1093" y2="1098"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1103" y2="1108"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1113" y2="1118"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1123" y2="1128"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1133" y2="1138"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1143" y2="1148"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1153" y2="1158"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1163" y2="1168"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1173" y2="1178"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1183" y2="1188"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1193" y2="1198"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1203" y2="1208"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1213" y2="1218"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1223" y2="1228"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1233" y2="1238"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1243" y2="1248"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1253" y2="1258"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1263" y2="1268"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1273" y2="1278"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1283" y2="1288"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1293" y2="1298"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1303" y2="1308"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1313" y2="1318"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1323" y2="1328"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1333" y2="1338"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1343" y2="1348"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1353" y2="1358"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1363" y2="1368"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1373" y2="1378"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1383" y2="1388"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1393" y2="1398"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1403" y2="1408"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1413" y2="1418"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1423" y2="1428"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1433" y2="1438"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1443" y2="1448"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1453" y2="1458"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1463" y2="1468"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1473" y2="1478"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1483" y2="1488"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1493" y2="1498"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1503" y2="1508"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1513" y2="1518"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1523" y2="1528"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1533" y2="1538"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1543" y2="1548"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1553" y2="1558"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1563" y2="1568"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1573" y2="1578"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1583" y2="1588"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1593" y2="1598"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1603" y2="1608"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1613" y2="1618"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1623" y2="1628"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1633" y2="1638"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1497" x2="1497" y1="1643" y2="1648"/>
+<rect fill="#ffffff" height="50" stroke="#ffffff" stroke-width="1" width="20" x="1487" y="322"/>
+<rect fill="none" height="50" stroke="#000000" stroke-width="1" width="20" x="1487" y="322"/>
+<rect fill="#ffffff" height="50" stroke="#ffffff" stroke-width="1" width="150" x="1422" y="14"/>
+<rect fill="none" height="50" stroke="#000000" stroke-width="1" width="150" x="1422" y="14"/>
+<text font-family="Dialog" font-size="12" x="1471" y="27">
+/Parsoid</text>
+<polyline fill="none" points="864,322 1487,322" stroke="#000000" stroke-width="1"/>
+<polygon fill="#000000" points="1487,322 1475,329 1475,315" stroke="#000000" stroke-width="1"/>
+<polygon fill="none" points="1487,322 1475,329 1475,315" stroke="#000000" stroke-width="1"/>
+<ellipse cx="1175" cy="320" fill="#000000" rx="0.5" ry="0.5" stroke="#000000" stroke-width="1"/>
+<ellipse cx="1176" cy="321" fill="#ffffff" rx="-0.5" ry="-0.5" stroke="#ffffff" stroke-width="1"/>
+<polyline fill="none" points="1487,372 864,372" stroke="#000000" stroke-width="1"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="876" x2="864" y1="365" y2="372"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="876" x2="864" y1="379" y2="372"/>
+<text font-family="Dialog" font-size="12" x="1131" y="367">
+content</text>
+<polygon fill="#ffffff" points="1006,198 1368,198 1378,208 1378,263 1006,263 1006,198" stroke="#ffffff" stroke-width="1"/>
+<polyline fill="none" points="1006,198 1368,198 1378,208 1378,263 1006,263 1006,198" stroke="#000000" stroke-width="1"/>
+<polygon fill="#b2b2b2" points="1368,198 1378,208 1368,208 1368,198" stroke="#b2b2b2" stroke-width="1"/>
+<polyline fill="none" points="1368,198 1378,208 1368,208 1368,198" stroke="#000000" stroke-width="1"/>
+<text font-family="Dialog" font-size="12" x="1009" y="213">
+POST {parsoid}/transform/html/to/wikitext/{title#db-key}</text>
+<text font-family="Dialog" font-size="12" x="1009" y="243">
+html=...</text>
+<text font-family="Dialog" font-size="12" x="1009" y="258">
+oldid=...</text>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1175" x2="1175" y1="264" y2="269"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1175" x2="1175" y1="274" y2="279"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1175" x2="1175" y1="284" y2="289"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1175" x2="1175" y1="294" y2="299"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1175" x2="1175" y1="304" y2="309"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1175" x2="1175" y1="314" y2="319"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="63" y2="68"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="73" y2="78"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="83" y2="88"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="93" y2="98"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="103" y2="108"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="113" y2="118"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="123" y2="128"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="133" y2="138"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="143" y2="148"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="153" y2="158"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="163" y2="168"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="173" y2="178"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="183" y2="188"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="193" y2="198"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="203" y2="208"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="213" y2="218"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="223" y2="228"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="233" y2="238"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="243" y2="248"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="253" y2="258"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="263" y2="268"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="273" y2="278"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="283" y2="288"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="293" y2="298"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="303" y2="308"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="313" y2="318"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="323" y2="328"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="333" y2="338"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="343" y2="348"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="353" y2="358"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="363" y2="368"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="373" y2="378"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="383" y2="388"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="393" y2="398"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="403" y2="408"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="413" y2="418"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="423" y2="428"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="433" y2="438"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="443" y2="448"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="453" y2="458"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="463" y2="468"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="473" y2="478"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="483" y2="488"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="493" y2="498"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="503" y2="508"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="513" y2="518"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="523" y2="528"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="533" y2="538"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="543" y2="548"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="553" y2="558"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="563" y2="568"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="573" y2="578"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="583" y2="588"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="593" y2="598"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="603" y2="608"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="613" y2="618"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="623" y2="628"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="633" y2="638"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="643" y2="648"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="653" y2="658"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="663" y2="668"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="673" y2="678"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="683" y2="688"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="693" y2="698"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="703" y2="708"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="713" y2="718"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="723" y2="728"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="733" y2="738"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="743" y2="748"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="753" y2="758"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="763" y2="768"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="773" y2="778"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="783" y2="788"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="793" y2="798"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="803" y2="808"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="813" y2="818"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="823" y2="828"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="833" y2="838"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="843" y2="848"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="853" y2="858"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="863" y2="868"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="873" y2="878"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="883" y2="888"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="893" y2="898"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="903" y2="908"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="913" y2="918"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="923" y2="928"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="933" y2="938"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="943" y2="948"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="953" y2="958"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="963" y2="968"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="973" y2="978"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="983" y2="988"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="993" y2="998"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1003" y2="1008"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1013" y2="1018"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1023" y2="1028"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1033" y2="1038"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1043" y2="1048"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1053" y2="1058"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1063" y2="1068"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1073" y2="1078"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1083" y2="1088"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1093" y2="1098"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1103" y2="1108"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1113" y2="1118"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1123" y2="1128"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1133" y2="1138"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1143" y2="1148"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1153" y2="1158"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1163" y2="1168"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1173" y2="1178"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1183" y2="1188"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1193" y2="1198"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1203" y2="1208"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1213" y2="1218"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1223" y2="1228"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1233" y2="1238"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1243" y2="1248"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1253" y2="1258"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1263" y2="1268"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1273" y2="1278"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1283" y2="1288"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1293" y2="1298"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1303" y2="1308"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1313" y2="1318"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1323" y2="1328"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1333" y2="1338"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1343" y2="1348"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1353" y2="1358"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1363" y2="1368"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1373" y2="1378"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1383" y2="1388"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1393" y2="1398"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1403" y2="1408"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1413" y2="1418"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1423" y2="1428"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1433" y2="1438"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1443" y2="1448"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1453" y2="1458"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1463" y2="1468"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1473" y2="1478"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1483" y2="1488"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1493" y2="1498"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1503" y2="1508"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1513" y2="1518"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1523" y2="1528"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1533" y2="1538"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1543" y2="1548"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1553" y2="1558"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1563" y2="1568"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1573" y2="1578"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1583" y2="1588"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1593" y2="1598"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1603" y2="1608"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1613" y2="1618"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1623" y2="1628"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1633" y2="1638"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="1745" x2="1745" y1="1643" y2="1648"/>
+<rect fill="#ffffff" height="50" stroke="#ffffff" stroke-width="1" width="20" x="1735" y="414"/>
+<rect fill="none" height="50" stroke="#000000" stroke-width="1" width="20" x="1735" y="414"/>
+<rect fill="#ffffff" height="50" stroke="#ffffff" stroke-width="1" width="20" x="1735" y="1078"/>
+<rect fill="none" height="50" stroke="#000000" stroke-width="1" width="20" x="1735" y="1078"/>
+<rect fill="#ffffff" height="50" stroke="#ffffff" stroke-width="1" width="150" x="1670" y="14"/>
+<rect fill="none" height="50" stroke="#000000" stroke-width="1" width="150" x="1670" y="14"/>
+<text font-family="Dialog" font-size="12" x="1705" y="27">
+/Memcached</text>
+<polyline fill="none" points="864,414 1735,414" stroke="#000000" stroke-width="1"/>
+<polygon fill="#000000" points="1735,414 1723,421 1723,407" stroke="#000000" stroke-width="1"/>
+<polygon fill="none" points="1735,414 1723,421 1723,407" stroke="#000000" stroke-width="1"/>
+<text font-family="Dialog" font-size="12" x="1252" y="409">
+set(..., content, ...)</text>
+<polyline fill="none" points="1735,464 864,464" stroke="#000000" stroke-width="1"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="876" x2="864" y1="457" y2="464"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="876" x2="864" y1="471" y2="464"/>
+<polyline fill="none" points="864,1078 1735,1078" stroke="#000000" stroke-width="1"/>
+<polygon fill="#000000" points="1735,1078 1723,1085 1723,1071" stroke="#000000" stroke-width="1"/>
+<polygon fill="none" points="1735,1078 1723,1085 1723,1071" stroke="#000000" stroke-width="1"/>
+<text font-family="Dialog" font-size="12" x="1259" y="1073">
+get</text>
+<polyline fill="none" points="1735,1128 864,1128" stroke="#000000" stroke-width="1"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="876" x2="864" y1="1121" y2="1128"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="876" x2="864" y1="1135" y2="1128"/>
+<text font-family="Dialog" font-size="12" x="1257" y="1123">
+wikitext</text>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="864" x2="882" y1="1174" y2="1174"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="882" x2="899" y1="1174" y2="1175"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="899" x2="913" y1="1175" y2="1176"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="913" x2="924" y1="1176" y2="1178"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="924" x2="932" y1="1178" y2="1180"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="932" x2="937" y1="1180" y2="1182"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="937" x2="938" y1="1182" y2="1183"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="938" x2="937" y1="1183" y2="1185"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="937" x2="932" y1="1185" y2="1187"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="932" x2="924" y1="1187" y2="1189"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="924" x2="905" y1="1189" y2="1190"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="905" x2="889" y1="1190" y2="1192"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="889" x2="875" y1="1192" y2="1193"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="875" x2="864" y1="1193" y2="1194"/>
+<polygon fill="#ffffff" points="864,1194 876,1187 876,1201" stroke="#ffffff" stroke-width="1"/>
+<polygon fill="none" points="864,1194 876,1187 876,1201" stroke="#000000" stroke-width="1"/>
+<text font-family="Dialog" font-size="12" x="967" y="1189">
+saveWikitext</text>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="864" x2="882" y1="1224" y2="1224"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="882" x2="899" y1="1224" y2="1225"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="899" x2="913" y1="1225" y2="1226"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="913" x2="924" y1="1226" y2="1228"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="924" x2="932" y1="1228" y2="1230"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="932" x2="937" y1="1230" y2="1232"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="937" x2="938" y1="1232" y2="1233"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="938" x2="937" y1="1233" y2="1235"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="937" x2="932" y1="1235" y2="1237"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="932" x2="924" y1="1237" y2="1239"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="924" x2="905" y1="1239" y2="1240"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="905" x2="889" y1="1240" y2="1242"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="889" x2="875" y1="1242" y2="1243"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="875" x2="864" y1="1243" y2="1244"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="876" x2="864" y1="1237" y2="1244"/>
+<line fill="#000000" stroke="#000000" stroke-width="1" x1="876" x2="864" y1="1251" y2="1244"/>
+</svg>

--- a/doc/visualeditor/visual-editor.xmi
+++ b/doc/visualeditor/visual-editor.xmi
@@ -1,0 +1,639 @@
+<?xml version = '1.0' encoding = 'UTF-8' ?>
+<XMI xmi.version = '1.2' xmlns:UML = 'org.omg.xmi.namespace.UML' timestamp = 'Mon Feb 02 11:24:01 PST 2015'>
+  <XMI.header>    <XMI.documentation>
+      <XMI.exporter>ArgoUML (using Netbeans XMI Writer version 1.0)</XMI.exporter>
+      <XMI.exporterVersion>0.34(6) revised on $Date: 2010-01-11 22:20:14 +0100 (Mon, 11 Jan 2010) $ </XMI.exporterVersion>
+    </XMI.documentation>
+    <XMI.metamodel xmi.name="UML" xmi.version="1.4"/></XMI.header>
+  <XMI.content>
+    <UML:Model xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000865'
+      name = 'VisualEditor' isSpecification = 'false' isRoot = 'false' isLeaf = 'false'
+      isAbstract = 'false'>
+      <UML:Namespace.ownedElement>
+        <UML:Collaboration xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000087F'
+          name = 'Retrieve page' isSpecification = 'false' isRoot = 'false' isLeaf = 'false'
+          isAbstract = 'false'>
+          <UML:Namespace.ownedElement>
+            <UML:ClassifierRole xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000881'
+              name = 'Browser' isSpecification = 'false' isRoot = 'false' isLeaf = 'false'
+              isAbstract = 'false'>
+              <UML:ClassifierRole.multiplicity>
+                <UML:Multiplicity xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000883'>
+                  <UML:Multiplicity.range>
+                    <UML:MultiplicityRange xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000882'
+                      lower = '1' upper = '1'/>
+                  </UML:Multiplicity.range>
+                </UML:Multiplicity>
+              </UML:ClassifierRole.multiplicity>
+            </UML:ClassifierRole>
+            <UML:ClassifierRole xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000884'
+              name = 'api.php#Extension:VisualEditor' isSpecification = 'false' isRoot = 'false'
+              isLeaf = 'false' isAbstract = 'false'>
+              <UML:ClassifierRole.multiplicity>
+                <UML:Multiplicity xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000886'>
+                  <UML:Multiplicity.range>
+                    <UML:MultiplicityRange xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000885'
+                      lower = '1' upper = '1'/>
+                  </UML:Multiplicity.range>
+                </UML:Multiplicity>
+              </UML:ClassifierRole.multiplicity>
+            </UML:ClassifierRole>
+            <UML:AssociationRole xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000088A'
+              isSpecification = 'false' isRoot = 'false' isLeaf = 'false' isAbstract = 'false'>
+              <UML:Association.connection>
+                <UML:AssociationEndRole xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000088B'
+                  isSpecification = 'false' isNavigable = 'false'>
+                  <UML:AssociationEnd.participant>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000881'/>
+                  </UML:AssociationEnd.participant>
+                </UML:AssociationEndRole>
+                <UML:AssociationEndRole xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000088C'
+                  isSpecification = 'false' isNavigable = 'false'>
+                  <UML:AssociationEnd.participant>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000884'/>
+                  </UML:AssociationEnd.participant>
+                </UML:AssociationEndRole>
+              </UML:Association.connection>
+              <UML:AssociationRole.message>
+                <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C6'/>
+                <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C8'/>
+              </UML:AssociationRole.message>
+            </UML:AssociationRole>
+            <UML:ClassifierRole xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000089C'
+              name = 'Parsoid' isSpecification = 'false' isRoot = 'false' isLeaf = 'false'
+              isAbstract = 'false'>
+              <UML:ClassifierRole.multiplicity>
+                <UML:Multiplicity xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000089E'>
+                  <UML:Multiplicity.range>
+                    <UML:MultiplicityRange xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000089D'
+                      lower = '1' upper = '1'/>
+                  </UML:Multiplicity.range>
+                </UML:Multiplicity>
+              </UML:ClassifierRole.multiplicity>
+            </UML:ClassifierRole>
+            <UML:AssociationRole xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008A0'
+              isSpecification = 'false' isRoot = 'false' isLeaf = 'false' isAbstract = 'false'>
+              <UML:Association.connection>
+                <UML:AssociationEndRole xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008A1'
+                  isSpecification = 'false' isNavigable = 'false'>
+                  <UML:AssociationEnd.participant>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000884'/>
+                  </UML:AssociationEnd.participant>
+                </UML:AssociationEndRole>
+                <UML:AssociationEndRole xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008A2'
+                  isSpecification = 'false' isNavigable = 'false'>
+                  <UML:AssociationEnd.participant>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000089C'/>
+                  </UML:AssociationEnd.participant>
+                </UML:AssociationEndRole>
+              </UML:Association.connection>
+              <UML:AssociationRole.message>
+                <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CA'/>
+                <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CC'/>
+              </UML:AssociationRole.message>
+            </UML:AssociationRole>
+            <UML:CallAction xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C4'
+              isSpecification = 'false' isAsynchronous = 'false'/>
+            <UML:ReturnAction xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C7'
+              isSpecification = 'false' isAsynchronous = 'true'/>
+            <UML:CallAction xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C9'
+              isSpecification = 'false' isAsynchronous = 'false'/>
+            <UML:ReturnAction xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CB'
+              isSpecification = 'false' isAsynchronous = 'true'>
+              <UML:Action.script>
+                <UML:ActionExpression xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008D1'
+                  language = '' body = ''/>
+              </UML:Action.script>
+            </UML:ReturnAction>
+            <UML:Comment xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CD'
+              isSpecification = 'false' body = 'GET https://www.mediawiki.org/w/api.php&#10;Query parameters:&#10;* format=json&#10;* uselang=en&#10;* action=visualeditor&#10;* paction=parse&#10;* page=VisualEditor%3ATest'>
+              <UML:Comment.annotatedElement>
+                <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C6'/>
+              </UML:Comment.annotatedElement>
+            </UML:Comment>
+            <UML:Comment xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CF'
+              isSpecification = 'false' body = 'visualeditor: {&#10;  result: &quot;...&quot;,&#10;  notices: [...],&#10;  checkboxes: {...},&#10;  links: {...},&#10;  protectedClasses: &quot;...&quot;,&#10;  content: &quot;...&quot;,&#10;  basetimestamp: &quot;...&quot;,&#10;  starttimestamp: &quot;...&quot;,&#10;  oldid: ...&#10;}'>
+              <UML:Comment.annotatedElement>
+                <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C8'/>
+              </UML:Comment.annotatedElement>
+            </UML:Comment>
+            <UML:Comment xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008D0'
+              isSpecification = 'false' body = ' /{wiki}/{page}?oldid=123'>
+              <UML:Comment.annotatedElement>
+                <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CA'/>
+              </UML:Comment.annotatedElement>
+            </UML:Comment>
+          </UML:Namespace.ownedElement>
+          <UML:Collaboration.interaction>
+            <UML:Interaction xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C5'
+              name = 'newInteraction' isSpecification = 'false'>
+              <UML:Interaction.message>
+                <UML:Message xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C6'
+                  isSpecification = 'false'>
+                  <UML:ModelElement.comment>
+                    <UML:Comment xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CD'/>
+                  </UML:ModelElement.comment>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000881'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000884'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000088A'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:CallAction xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C4'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C8'
+                  isSpecification = 'false'>
+                  <UML:ModelElement.comment>
+                    <UML:Comment xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CF'/>
+                  </UML:ModelElement.comment>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C6'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000884'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000881'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000088A'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:ReturnAction xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C7'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CA'
+                  isSpecification = 'false'>
+                  <UML:ModelElement.comment>
+                    <UML:Comment xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008D0'/>
+                  </UML:ModelElement.comment>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C6'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000884'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000089C'/>
+                  </UML:Message.receiver>
+                  <UML:Message.predecessor>
+                    <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C8'/>
+                  </UML:Message.predecessor>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008A0'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:CallAction xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008C9'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CC'
+                  name = 'html decorated with data-parsoid' isSpecification = 'false'>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CA'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:000000000000089C'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:0000000000000884'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008A0'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:ReturnAction xmi.idref = '127-0-1-1-438d5645:14b38518db8:-8000:00000000000008CB'/>
+                  </UML:Message.action>
+                </UML:Message>
+              </UML:Interaction.message>
+            </UML:Interaction>
+          </UML:Collaboration.interaction>
+        </UML:Collaboration>
+        <UML:Collaboration xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7B'
+          name = 'Edit page' isSpecification = 'false' isRoot = 'false' isLeaf = 'false'
+          isAbstract = 'false'>
+          <UML:Namespace.ownedElement>
+            <UML:ClassifierRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7C'
+              name = 'Browser' isSpecification = 'false' isRoot = 'false' isLeaf = 'false'
+              isAbstract = 'false'>
+              <UML:ClassifierRole.multiplicity>
+                <UML:Multiplicity xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7E'>
+                  <UML:Multiplicity.range>
+                    <UML:MultiplicityRange xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7D'
+                      lower = '1' upper = '1'/>
+                  </UML:Multiplicity.range>
+                </UML:Multiplicity>
+              </UML:ClassifierRole.multiplicity>
+            </UML:ClassifierRole>
+            <UML:ClassifierRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'
+              name = 'api.php#Extension:VisualEditor' isSpecification = 'false' isRoot = 'false'
+              isLeaf = 'false' isAbstract = 'false'>
+              <UML:ClassifierRole.multiplicity>
+                <UML:Multiplicity xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A81'>
+                  <UML:Multiplicity.range>
+                    <UML:MultiplicityRange xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A80'
+                      lower = '1' upper = '1'/>
+                  </UML:Multiplicity.range>
+                </UML:Multiplicity>
+              </UML:ClassifierRole.multiplicity>
+            </UML:ClassifierRole>
+            <UML:AssociationRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A83'
+              isSpecification = 'false' isRoot = 'false' isLeaf = 'false' isAbstract = 'false'>
+              <UML:Association.connection>
+                <UML:AssociationEndRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A84'
+                  isSpecification = 'false' isNavigable = 'false'>
+                  <UML:AssociationEnd.participant>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7C'/>
+                  </UML:AssociationEnd.participant>
+                </UML:AssociationEndRole>
+                <UML:AssociationEndRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A85'
+                  isSpecification = 'false' isNavigable = 'false'>
+                  <UML:AssociationEnd.participant>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:AssociationEnd.participant>
+                </UML:AssociationEndRole>
+              </UML:Association.connection>
+              <UML:AssociationRole.message>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A87'/>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A89'/>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8D'/>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8F'/>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAD'/>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAF'/>
+              </UML:AssociationRole.message>
+            </UML:AssociationRole>
+            <UML:CallAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A82'
+              isSpecification = 'false' isAsynchronous = 'false'/>
+            <UML:ReturnAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A88'
+              isSpecification = 'false' isAsynchronous = 'true'/>
+            <UML:Comment xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8A'
+              isSpecification = 'false' body = 'POST https://www.mediawiki.org/w/api.php&#10;&#10;Content-Type: multipart/form-data&#10;Accept: application/json&#10;&#10;format=json&#10;uselang=en&#10;action=visualeditor&#10;paction=serializeforcache&#10;html=...&#10;page=...&#10;oldid=1389155'>
+              <UML:Comment.annotatedElement>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A87'/>
+              </UML:Comment.annotatedElement>
+            </UML:Comment>
+            <UML:Comment xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8B'
+              isSpecification = 'false' body = '200 OK&#10;&#10;Content-Type: application/json&#10;&#10;{&#10;  &quot;visualeditor&quot;: {&#10;    &quot;result&quot;: &quot;success&quot;,&#10;    &quot;cachekey&quot;: &quot;9e91b9c71cfaf60693bc27488c2e0a07&quot;&#10;  }&#10;}'>
+              <UML:Comment.annotatedElement>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A89'/>
+              </UML:Comment.annotatedElement>
+            </UML:Comment>
+            <UML:CallAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8C'
+              isSpecification = 'false' isAsynchronous = 'false'/>
+            <UML:ReturnAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8E'
+              isSpecification = 'false' isAsynchronous = 'true'/>
+            <UML:Comment xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A90'
+              isSpecification = 'false' body = 'POST https://www.mediawiki.org/w/api.php&#10;&#10;Content-Type: multipart/form-data&#10;Accept: application/json&#10;&#10;format=json&#10;uselang=en&#10;summary=...&#10;minor=...&#10;action=visualeditoredit&#10;page=...&#10;oldid=1389155&#10;basetimestamp=...&#10;starttimestamp=...&#10;token=...&#10;cachekey=...'>
+              <UML:Comment.annotatedElement>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8D'/>
+              </UML:Comment.annotatedElement>
+            </UML:Comment>
+            <UML:Comment xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A91'
+              name = 'Parsoid' isSpecification = 'false' body = '200 OK&#10;&#10;Content-Type: application/json&#10;&#10;{&#10;  &quot;visualeditoredit&quot;: {&#10;    &quot;content&quot;: &quot;&lt;&lt;html&gt;&gt;&quot;,&#10;    &quot;categorieshtml&quot;: &quot;&lt;&lt;html&gt;&gt;&quot;,&#10;    &quot;basetimestamp&quot;: &quot;20150202173621&quot;,&#10;    &quot;starttimestamp&quot;: &quot;20150202173621&quot;,&#10;    &quot;displayTitleHtml&quot;: &quot;VisualEditor:Test&quot;,&#10;    &quot;isRedirect&quot;: false,&#10;    &quot;contentSub&quot;: &quot;&quot;,&#10;    &quot;lastModified&quot;: {&#10;      &quot;date&quot;: &quot;2 February 2015&quot;,&#10;      &quot;time&quot;: &quot;17:36&quot;&#10;    },&#10;    &quot;newrevid&quot;: 1389562,&#10;    &quot;result&quot;: &quot;success&quot;&#10;  }&#10;}'>
+              <UML:Comment.annotatedElement>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8F'/>
+              </UML:Comment.annotatedElement>
+            </UML:Comment>
+            <UML:ClassifierRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A92'
+              name = 'Parsoid' isSpecification = 'false' isRoot = 'false' isLeaf = 'false'
+              isAbstract = 'false'>
+              <UML:ClassifierRole.multiplicity>
+                <UML:Multiplicity xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A94'>
+                  <UML:Multiplicity.range>
+                    <UML:MultiplicityRange xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A93'
+                      lower = '1' upper = '1'/>
+                  </UML:Multiplicity.range>
+                </UML:Multiplicity>
+              </UML:ClassifierRole.multiplicity>
+            </UML:ClassifierRole>
+            <UML:AssociationRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A96'
+              isSpecification = 'false' isRoot = 'false' isLeaf = 'false' isAbstract = 'false'>
+              <UML:Association.connection>
+                <UML:AssociationEndRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A97'
+                  isSpecification = 'false' isNavigable = 'false'>
+                  <UML:AssociationEnd.participant>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:AssociationEnd.participant>
+                </UML:AssociationEndRole>
+                <UML:AssociationEndRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A98'
+                  isSpecification = 'false' isNavigable = 'false'>
+                  <UML:AssociationEnd.participant>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A92'/>
+                  </UML:AssociationEnd.participant>
+                </UML:AssociationEndRole>
+              </UML:Association.connection>
+              <UML:AssociationRole.message>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A99'/>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9B'/>
+              </UML:AssociationRole.message>
+            </UML:AssociationRole>
+            <UML:CallAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A95'
+              isSpecification = 'false' isAsynchronous = 'false'/>
+            <UML:ReturnAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9A'
+              isSpecification = 'false' isAsynchronous = 'true'/>
+            <UML:Comment xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9C'
+              isSpecification = 'false' body = 'POST {parsoid}/transform/html/to/wikitext/{title#db-key}&#10;&#10;html=...&#10;oldid=...'>
+              <UML:Comment.annotatedElement>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A99'/>
+              </UML:Comment.annotatedElement>
+            </UML:Comment>
+            <UML:ClassifierRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9D'
+              name = 'Memcached' isSpecification = 'false' isRoot = 'false' isLeaf = 'false'
+              isAbstract = 'false'>
+              <UML:ClassifierRole.multiplicity>
+                <UML:Multiplicity xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9F'>
+                  <UML:Multiplicity.range>
+                    <UML:MultiplicityRange xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9E'
+                      lower = '1' upper = '1'/>
+                  </UML:Multiplicity.range>
+                </UML:Multiplicity>
+              </UML:ClassifierRole.multiplicity>
+            </UML:ClassifierRole>
+            <UML:AssociationRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA1'
+              isSpecification = 'false' isRoot = 'false' isLeaf = 'false' isAbstract = 'false'>
+              <UML:Association.connection>
+                <UML:AssociationEndRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA2'
+                  isSpecification = 'false' isNavigable = 'false'>
+                  <UML:AssociationEnd.participant>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:AssociationEnd.participant>
+                </UML:AssociationEndRole>
+                <UML:AssociationEndRole xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA3'
+                  isSpecification = 'false' isNavigable = 'false'>
+                  <UML:AssociationEnd.participant>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9D'/>
+                  </UML:AssociationEnd.participant>
+                </UML:AssociationEndRole>
+              </UML:Association.connection>
+              <UML:AssociationRole.message>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA4'/>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA6'/>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA9'/>
+                <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAB'/>
+              </UML:AssociationRole.message>
+            </UML:AssociationRole>
+            <UML:CallAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA0'
+              isSpecification = 'false' isAsynchronous = 'false'>
+              <UML:Action.script>
+                <UML:ActionExpression xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA7'
+                  language = '' body = ''/>
+              </UML:Action.script>
+            </UML:CallAction>
+            <UML:ReturnAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA5'
+              isSpecification = 'false' isAsynchronous = 'true'/>
+            <UML:CallAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA8'
+              isSpecification = 'false' isAsynchronous = 'false'/>
+            <UML:ReturnAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAA'
+              isSpecification = 'false' isAsynchronous = 'true'/>
+            <UML:CallAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAC'
+              isSpecification = 'false' isAsynchronous = 'false'/>
+            <UML:ReturnAction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAE'
+              isSpecification = 'false' isAsynchronous = 'true'/>
+          </UML:Namespace.ownedElement>
+          <UML:Collaboration.interaction>
+            <UML:Interaction xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A86'
+              name = 'newInteraction' isSpecification = 'false'>
+              <UML:Interaction.message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A87'
+                  isSpecification = 'false'>
+                  <UML:ModelElement.comment>
+                    <UML:Comment xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8A'/>
+                  </UML:ModelElement.comment>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7C'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A83'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:CallAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A82'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A89'
+                  isSpecification = 'false'>
+                  <UML:ModelElement.comment>
+                    <UML:Comment xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8B'/>
+                  </UML:ModelElement.comment>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A87'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7C'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A83'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:ReturnAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A88'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8D'
+                  isSpecification = 'false'>
+                  <UML:ModelElement.comment>
+                    <UML:Comment xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A90'/>
+                  </UML:ModelElement.comment>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A89'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7C'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A83'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:CallAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8C'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8F'
+                  isSpecification = 'false'>
+                  <UML:ModelElement.comment>
+                    <UML:Comment xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A91'/>
+                  </UML:ModelElement.comment>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8D'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7C'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A83'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:ReturnAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8E'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A99'
+                  isSpecification = 'false'>
+                  <UML:ModelElement.comment>
+                    <UML:Comment xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9C'/>
+                  </UML:ModelElement.comment>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8D'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A92'/>
+                  </UML:Message.receiver>
+                  <UML:Message.predecessor>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8F'/>
+                  </UML:Message.predecessor>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A96'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:CallAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A95'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9B'
+                  name = 'content' isSpecification = 'false'>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A99'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A92'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A96'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:ReturnAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9A'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA4'
+                  name = 'set(..., content, ...)' isSpecification = 'false'>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9B'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9D'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA1'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:CallAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA0'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA6'
+                  isSpecification = 'false'>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA4'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9D'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA1'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:ReturnAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA5'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA9'
+                  name = 'get' isSpecification = 'false'>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA6'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9D'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA1'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:CallAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA8'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAB'
+                  name = 'wikitext' isSpecification = 'false'>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA9'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A9D'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AA1'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:ReturnAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAA'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAD'
+                  name = 'saveWikitext' isSpecification = 'false'>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A8F'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A83'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:CallAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAC'/>
+                  </UML:Message.action>
+                </UML:Message>
+                <UML:Message xmi.id = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAF'
+                  isSpecification = 'false'>
+                  <UML:Message.activator>
+                    <UML:Message xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAD'/>
+                  </UML:Message.activator>
+                  <UML:Message.sender>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.sender>
+                  <UML:Message.receiver>
+                    <UML:ClassifierRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A7F'/>
+                  </UML:Message.receiver>
+                  <UML:Message.communicationConnection>
+                    <UML:AssociationRole xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000A83'/>
+                  </UML:Message.communicationConnection>
+                  <UML:Message.action>
+                    <UML:ReturnAction xmi.idref = '127-0-1-1--531df0b1:14b4b50dc39:-8000:0000000000000AAE'/>
+                  </UML:Message.action>
+                </UML:Message>
+              </UML:Interaction.message>
+            </UML:Interaction>
+          </UML:Collaboration.interaction>
+        </UML:Collaboration>
+      </UML:Namespace.ownedElement>
+    </UML:Model>
+  </XMI.content>
+</XMI>


### PR DESCRIPTION
This was reverse-engineered from the VE sandbox and the VE extension source.  Needs a quick double-check for accuracy.

See the diagram here: https://github.com/earldouglas/restbase/blob/be707e4e8136ce7e6c8176792d5bd993e137d356/doc/visualeditor/page-edit.svg