### PR TITLE
Add tests for bodyOnly field

### DIFF
--- a/test/features/parsoid/html2html-bodyOnly/request.json
+++ b/test/features/parsoid/html2html-bodyOnly/request.json
@@ -1,0 +1,32 @@
+{
+    "bodyOnly": true,
+    "html": {
+        "headers": {
+            "content-type": "text/html;profile=mediawiki.org/specs/html/1.0.0"
+        },
+        "body": "<html>The modified HTML</html>"
+    },
+    "original": {
+        "revid": 12345,
+        "wikitext": {
+            "headers": {
+                "content-type": "text/plain;profile=mediawiki.org/specs/wikitext/1.0.0"
+            },
+            "body": "the original wikitext"
+        },
+        "html": {
+            "headers": {
+                "content-type": "text/html;profile=mediawiki.org/specs/html/1.0.0"
+            },
+            "body": "the original HTML"
+        },
+        "data-parsoid": {
+            "headers": {
+                "content-type": "application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1"
+            },
+            "body": {
+                "ids": {}
+            }
+        }
+    }
+}

--- a/test/features/parsoid/html2html-bodyOnly/response.html
+++ b/test/features/parsoid/html2html-bodyOnly/response.html
@@ -1,0 +1,1 @@
+<body data-parsoid='{"dsr":[0,949,0,0]}' lang="en" class="mw-content-ltr sitedir-ltr ltr mw-body mw-body-content mediawiki" dir="ltr"><p data-parsoid='{"dsr":[928,949,0,0]}'>the original wikitext</p></body>

--- a/test/features/parsoid/html2html-bodyOnly/response.html
+++ b/test/features/parsoid/html2html-bodyOnly/response.html
@@ -1,1 +1,1 @@
-<body data-parsoid='{"dsr":[0,949,0,0]}' lang="en" class="mw-content-ltr sitedir-ltr ltr mw-body mw-body-content mediawiki" dir="ltr"><p data-parsoid='{"dsr":[928,949,0,0]}'>the original wikitext</p></body>
+<p data-parsoid='{"dsr":[928,949,0,0]}'>the original wikitext</p>

--- a/test/features/parsoid/wikitext2html-bodyOnly/request.json
+++ b/test/features/parsoid/wikitext2html-bodyOnly/request.json
@@ -1,0 +1,9 @@
+{
+    "bodyOnly": true,
+    "wikitext": {
+        "body": "The modified HTML",
+        "headers": {
+            "content-type": "text/plain;profile=mediawiki.org/specs/wikitext/1.0.0"
+        }
+    }
+}

--- a/test/features/parsoid/wikitext2html-bodyOnly/response.html
+++ b/test/features/parsoid/wikitext2html-bodyOnly/response.html
@@ -1,0 +1,1 @@
+<body data-parsoid='{"dsr":[0,17,0,0]}' lang="en" class="mw-content-ltr sitedir-ltr ltr mw-body mw-body-content mediawiki" dir="ltr"><p data-parsoid='{"dsr":[0,17,0,0]}'>The modified HTML</p></body>

--- a/test/features/parsoid/wikitext2html-bodyOnly/response.html
+++ b/test/features/parsoid/wikitext2html-bodyOnly/response.html
@@ -1,1 +1,1 @@
-<body data-parsoid='{"dsr":[0,17,0,0]}' lang="en" class="mw-content-ltr sitedir-ltr ltr mw-body mw-body-content mediawiki" dir="ltr"><p data-parsoid='{"dsr":[0,17,0,0]}'>The modified HTML</p></body>
+<p data-parsoid='{"dsr":[0,17,0,0]}'>The modified HTML</p>


### PR DESCRIPTION
Candidate tests to cover the *allow an optional bodyOnly field* requirement from https://phabricator.wikimedia.org/T75955.

Note: test failure is expected, as these tests are to-be-resolved in the TDD workflow.