### PR TITLE
Use the restbase-mod-table-cassandra npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "node-uuid": "git+https://github.com/gwicke/node-uuid#master",
     "preq": "~0.3.6",
     "request": "^2.44.0",
-    "restbase-cassandra": "~0.3.7",
-    "restbase-mod-table-cassandra": "git+https://github.com/wikimedia/restbase-cassandra#restbase-mod-table-cassandra",
+    "restbase-mod-table-cassandra": "0.0.x",
     "swagger-router": "git+https://github.com/wikimedia/swagger-router#master",
     "url-template": "2.0.4",
     "yargs": "~1.3.0"


### PR DESCRIPTION
The npm package has been published [here](https://www.npmjs.com/package/restbase-mod-table-cassandra). Use it instead of the GitHub repo. Also, remove the dependency on restbase-cassandra.