### PR TITLE
Expose swagger-ui at /{domain}/v1/?doc & a merged swagger spec at /{domain}/v1/?spec

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -69,7 +69,7 @@ rbUtil.StatsD = function ( statsdHost, statsdPort ) {
 // Optimized URL parsing
 var qs = require('querystring');
 // Should make it into 0.12, see https://github.com/joyent/node/pull/7878
-var SIMPLE_PATH = /^(\/(?!\/)[^\?#\s]*)(\?[^#\s]*)?$/;
+var SIMPLE_PATH = /^(\/(?!\/)[^\?#\s]*)(?:\?([^#\s]*))?$/;
 rbUtil.parseURL = function parseURL (uri) {
     // Fast path for simple path uris
     var fastMatch = SIMPLE_PATH.exec(uri);

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -94,13 +94,24 @@ function cloneRequest(req) {
 
 // A default listing handler for URIs that end in / and don't have any
 // handlers associated with it otherwise.
-RESTBase.prototype.defaultListingHandler = function (restbase, req) {
-    return Promise.resolve({
-        status: 200,
-        body: {
-            items: req.params._ls
-        }
-    });
+RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
+    var rq = req.query;
+    if (rq.spec !== undefined && value.specRoot) {
+        return Promise.resolve({
+            status: 200,
+            body: value.specRoot
+        });
+    } else if (rq.doc) {
+        // TODO: Return swagger UI & load spec from /?spec
+    } else {
+        // Plain listing
+        return Promise.resolve({
+            status: 200,
+            body: {
+                items: req.params._ls
+            }
+        });
+    }
 };
 
 RESTBase.prototype._request = function (req) {
@@ -158,9 +169,10 @@ RESTBase.prototype._request = function (req) {
             && childReq.method === 'get'
             && childReq.uri.path[childReq.uri.path.length - 1] === '') {
         // An URL that ends with /: return a default listing
-        handler = this.defaultListingHandler;
-        match.value = {
-            path: '_defaultListingHandler'
+        if (!match.value) { match.value = {}; }
+        if (!match.value.path) { match.value.path = '_defaultListingHandler'; }
+        handler = function (restbase, req) {
+            return self.defaultListingHandler(match.value, restbase, req);
         };
     }
     if (handler) {

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -7,6 +7,7 @@
 var rbUtil = require('./rbUtil');
 var HTTPError = rbUtil.HTTPError;
 var preq = require('preq');
+var swaggerUI = require('./swaggerUI');
 
 function RESTBase (options, req) {
     if (options && options.constructor === RESTBase) {
@@ -99,10 +100,17 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
     if (rq.spec !== undefined && value.specRoot) {
         return Promise.resolve({
             status: 200,
-            body: value.specRoot
+            body: rbUtil.extend({}, value.specRoot, {
+                // Set the base path dynamically
+                basePath: req.uri.toString().replace(/\/$/, '')
+            })
         });
-    } else if (rq.doc) {
+    } else if (rq.doc !== undefined) {
         // TODO: Return swagger UI & load spec from /?spec
+        if (!req.query.path) {
+            req.query.path = '/index.html';
+        }
+        return swaggerUI(restbase, req);
     } else {
         // Plain listing
         return Promise.resolve({

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -92,6 +92,17 @@ function cloneRequest(req) {
     };
 }
 
+// A default listing handler for URIs that end in / and don't have any
+// handlers associated with it otherwise.
+RESTBase.prototype.defaultListingHandler = function (restbase, req) {
+    return Promise.resolve({
+        status: 200,
+        body: {
+            items: req.params._ls
+        }
+    });
+};
+
 RESTBase.prototype._request = function (req) {
     var self = this;
 
@@ -143,6 +154,15 @@ RESTBase.prototype._request = function (req) {
     var match = priv.router.route(childReq.uri);
     var methods = match && match.value && match.value.methods;
     var handler = methods && (methods[childReq.method] || methods.all);
+    if (match && !handler
+            && childReq.method === 'get'
+            && childReq.uri.path[childReq.uri.path.length - 1] === '') {
+        // An URL that ends with /: return a default listing
+        handler = this.defaultListingHandler;
+        match.value = {
+            path: '_defaultListingHandler'
+        };
+    }
     if (handler) {
         // TODO: check ACLs in the match object
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -151,7 +151,13 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
             // XXX: The basePath is incorrect when shared between domains. Set
             // it dynamically for each request instead?
             // specRoot.basePath = prefixPath;
-            node.value.specRoot = specRoot;
+            var listNode = new Node();
+            listNode.value = {
+                specRoot: specRoot,
+                methods: {},
+                path: undefined
+            };
+            node.setChild('', listNode);
             prefixPath = '';
             subSpecs = [subSpec];
         }

--- a/lib/router.js
+++ b/lib/router.js
@@ -148,6 +148,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
         if (subSpec) {
             specRoot = rbUtil.extend({}, subSpec);
             specRoot.paths = {};
+            specRoot.definitions = {};
             // XXX: The basePath is incorrect when shared between domains. Set
             // it dynamically for each request instead?
             // specRoot.basePath = prefixPath;
@@ -256,10 +257,13 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
 Router.prototype._handleSwaggerSpec = function (rootNode, spec, operations, specRoot, prefixPath) {
     if (!specRoot) {
         specRoot = spec;
-        if (!spec.paths) {
-            spec.paths = {};
-        }
+        if (!spec.paths) { spec.paths = {}; }
+        if (!spec.definitions) { spec.definitions = {}; }
         prefixPath = '';
+    }
+    if (spec.definitions) {
+        // Merge definitions
+        rbUtil.extend(specRoot.definitions, spec.definitions);
     }
     var self = this;
     function handlePaths (paths) {

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -1,0 +1,40 @@
+"use strict";
+
+var fs = Promise.promisifyAll(require('fs'));
+var path = require('path');
+
+var docRoot = __dirname + '/../node_modules/swagger-ui/dist/';
+function staticServe (restbase, req) {
+    // Expand any relative paths for security
+    var filePath = req.query.path.replace(/\.\.\//g, '');
+    return fs.readFileAsync(docRoot + filePath, 'utf8')
+    .then(function(body) {
+        if (filePath === '/index.html') {
+            // Rewrite the HTML to use a query string
+            body = body.replace(/((?:src|href)=['"])/g, '$1?doc=&path=')
+                // Replace the default url with ours
+                .replace(/url = "http/, 'url = "?spec"; //');
+        }
+
+        var contentType = 'text/html';
+        if (/\.js$/.test(filePath)) {
+            contentType = 'text/javascript';
+        } else if (/\.png/.test(filePath)) {
+            contentType = 'image/png';
+        } else if (/\.css/.test(filePath)) {
+            contentType = 'text/css';
+            body = body.replace(/\.\.\/(images|fonts)\//g, '?doc&path=$1/');
+        }
+        return Promise.resolve({
+            status: 200,
+            headers: {
+                'content-type': contentType,
+            },
+            body: body
+        });
+    });
+}
+
+
+module.exports = staticServe;
+

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "restbase-cassandra": "~0.3.7",
     "restbase-mod-table-cassandra": "git+https://github.com/wikimedia/restbase-cassandra#restbase-mod-table-cassandra",
     "swagger-router": "git+https://github.com/wikimedia/swagger-router#master",
+    "swagger-ui": "^2.1.1-M1",
     "url-template": "2.0.4",
     "yargs": "~1.3.0"
   },

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -16,13 +16,15 @@ paths:
 
   /{module:page}/:
     get:
+      tags:
+        - Page content
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/
 
   /{module:page}/{title}/html:
     get:
       tags:
-        - page content
+        - Page content
       description: Redirects to the latest html
       operationId: getLatestFormat
       parameters:
@@ -137,6 +139,8 @@ paths:
 
   /{module:page}/{title}/data-parsoid/:
     get:
+      tags:
+        - Page content
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}
 
@@ -188,16 +192,22 @@ paths:
 
   /{module:transform}/html/to/wikitext{/title}{/revision}:
     post:
+      tags:
+        - Transforms
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/html/to/wikitext{/title}{/revision}
 
   /{module:transform}/wikitext/to/html{/title}{/revision}:
     post:
+      tags:
+        - Transforms
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/wikitext/to/html{/title}{/revision}
 
   /{module:transform}/html/to/html{/title}{/revision}:
     post:
+      tags:
+        - Transforms
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/html/to/html{/title}{/revision}
 

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -18,6 +18,7 @@ paths:
     get:
       tags:
         - Page content
+      description: List pages
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/
 
@@ -25,7 +26,7 @@ paths:
     get:
       tags:
         - Page content
-      description: Redirects to the latest html
+      description: Retrieve the latest html
       operationId: getLatestFormat
       parameters:
         - name: domain
@@ -61,7 +62,7 @@ paths:
     get:
       tags:
         - Page content
-      description: Returns the list of revisions
+      description: List all HTML revisions for a page
       operationId: listKeyRevValueRevisions
       produces:
         - application/json
@@ -96,7 +97,7 @@ paths:
     get:
       tags:
         - Page content
-      description: Returns the html for the given revision
+      description: Retrieve the html for a given revision (and optional timeuuid)
       operationId: getFormatRevision
       produces:
         - text/html
@@ -141,6 +142,7 @@ paths:
     get:
       tags:
         - Page content
+      description: List data-parsoid revisions for a page
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}
 
@@ -148,7 +150,7 @@ paths:
     get:
       tags:
         - Page content
-      description: Returns the Parsoid data for the given revision
+      description: Retrieve data-parsoid (internal Parsoid metadata) for a given page & revision
       operationId: getFormatRevision
       produces:
         - text/html
@@ -194,6 +196,33 @@ paths:
     post:
       tags:
         - Transforms
+      description: Transform HTML to wikitext
+      consumes:
+        - multipart/form-data
+      produces:
+        - text/plain; profile=mediawiki.org/specs/wikitext/1.0.0
+      parameters:
+        - name: domain
+          in: path
+          description: The top-level API domain
+          type: string
+          required: true
+          default: en.wikipedia.org
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: false
+        - name: revision
+          in: path
+          description: The page revision
+          type: integer
+          required: false
+        - name: html
+          in: formData
+          description: The HTML to transform
+          type: string
+          required: true
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/html/to/wikitext{/title}{/revision}
 
@@ -201,6 +230,38 @@ paths:
     post:
       tags:
         - Transforms
+      description: Transform wikitext to HTML
+      consumes:
+        - multipart/form-data
+      produces:
+        - text/html; profile=mediawiki.org/specs/html/1.0.0
+      parameters:
+        - name: domain
+          in: path
+          description: The top-level API domain
+          type: string
+          required: true
+          default: en.wikipedia.org
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: false
+        - name: revision
+          in: path
+          description: The page revision
+          type: integer
+          required: false
+        - name: wikitext
+          in: formData
+          description: The Wikitext to transform to HTML
+          type: string
+          required: true
+        - name: bodyOnly
+          in: formData
+          description: Return only `body.innerHTML`
+          type: boolean
+          required: false
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/wikitext/to/html{/title}{/revision}
 
@@ -208,6 +269,38 @@ paths:
     post:
       tags:
         - Transforms
+      description: Update / refresh / sanitize HTML
+      consumes:
+        - multipart/form-data
+      produces:
+        - text/html; profile=mediawiki.org/specs/html/1.0.0
+      parameters:
+        - name: domain
+          in: path
+          description: The top-level API domain
+          type: string
+          required: true
+          default: en.wikipedia.org
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: false
+        - name: revision
+          in: path
+          description: The page revision
+          type: integer
+          required: false
+        - name: html
+          in: formData
+          description: The HTML to transform
+          type: string
+          required: true
+        - name: bodyOnly
+          in: formData
+          description: Return only `body.innerHTML`
+          type: boolean
+          required: false
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/html/to/html{/title}{/revision}
 


### PR DESCRIPTION
Screenshot of http://localhost:7231/en.wikipedia.org/v1/?doc :

![image](https://cloud.githubusercontent.com/assets/1225898/6052618/ce38a4b0-ac89-11e4-941e-019915c1955e.png)