### PR TITLE
Promote RESTBase instead of Swagger

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -12,6 +12,9 @@ function staticServe (restbase, req) {
         if (filePath === '/index.html') {
             // Rewrite the HTML to use a query string
             body = body.replace(/((?:src|href)=['"])/g, '$1?doc=&path=')
+                // Some self-promotion
+                .replace(/<a id="logo".*?<\/a>/,
+                        '<a id="logo" href="http://restbase.org">RESTBase</a>')
                 // Replace the default url with ours
                 .replace(/url = "http/, 'url = "?spec"; //');
         }


### PR DESCRIPTION
Show RESTBase in the logo & link to the repo.