### PR TITLE
Extract spec-based test generation into an npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "heapdump": "0.3.3",
     "istanbul": "0.3.5",
     "mocha-lcov-reporter": "0.0.1",
-    "coveralls": "2.11.2"
+    "coveralls": "2.11.2",
+    "swagger-test": "0.2.0"
   }
 }

--- a/test/features/specification/swagger.js
+++ b/test/features/specification/swagger.js
@@ -6,6 +6,7 @@
 var preq   = require('preq');
 var assert = require('../../utils/assert.js');
 var specs  = require('../../utils/specs.js');
+var swaggerTest = require('swagger-test');
 var server = require('../../utils/server.js');
 
     var prereqs = [
@@ -21,7 +22,10 @@ describe('swagger spec', function () {
 
     before(function () { return server.start(); });
 
-    var xamples = specs.parseXamples(specs.get(), server.config.hostPort);
+    var swaggerSpec = specs.get();
+    swaggerSpec.host = server.config.hostPort;
+
+    var xamples = swaggerTest.parse(swaggerSpec);
 
     it('should run ' + prereqs.length + ' idempotent prerequisites', function() {
         var count = 0;

--- a/test/utils/specs.js
+++ b/test/utils/specs.js
@@ -24,41 +24,5 @@ function getRemoteSpec(url, k) {
     });
 }
 
-function parseXamples(spec, host) {
-    var xamples = [];
-    if (spec.paths) {
-        for (var uri in spec.paths) {
-            var path = spec.paths[uri];
-            for (var method in path) {
-                var operation = path[method];
-                if (operation['x-amples']) {
-                    operation['x-amples'].forEach(function (xample) {
-                        var prereqs = [];
-                        if (xample.prerequisites) {
-                            xample.prerequisites.forEach(function(prereq) {
-                                prereq.uri = host + prereq.uri;
-                                prereqs.push(prereq);
-                            });
-                        }
-                        var uriTemplate = template.parse(uri);
-                        var expandedUri = uriTemplate.expand(xample.request.params);
-                        xample.request.method = method;
-                        xample.request.uri = host + spec.basePath + expandedUri;
-                        xamples.push({
-                            description: method + ' ' + uri,
-                            prereqs: prereqs,
-                            request: xample.request,
-                            response: xample.response
-                        });
-                    });
-                }
-            }
-        }
-    }
-    return xamples;
-}
-
-module.exports.parseXamples = parseXamples;
-
 // TODO: switch this to getRemoteSpec() prior to v1 release
 module.exports.get = getLocalSpec;


### PR DESCRIPTION
There are lots of advancements we can make on the spec-driven testing front.  To encourage modularity and promote community adoption/feedback, this PR moves the logic to a new npm module called swagger-test.