### PR TITLE
New URI structure under v1/page/

### DIFF
--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -193,29 +193,6 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
     // TODO: handle other revision formats (tid)
 };
 
-PRS.prototype.putFormatRevision = function(restbase, req) {
-    var rp = req.params;
-    // Check the local db
-    var revTable = rp.bucket + '.' + rp.format;
-    var beReq = {
-        uri: '/v1/' + rp.domain + '/' + revTable + '/'
-                    + rp.key + '/' + rp.revision,
-        headers: req.headers,
-        body: req.body
-    };
-    return restbase.put(beReq);
-};
-
-PRS.prototype.listItem = function(restbase, req) {
-    return Promise.resolve({
-        status: 200,
-        body: {
-            items: ['html','data-parsoid'],
-            comment: 'TODO: update this dynamically from bucket metadata!'
-        }
-    });
-};
-
 PRS.prototype.listTitleRevisions = function(restbase, req) {
     var rp = req.params;
     return restbase.get({

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -200,17 +200,16 @@ PRS.prototype.listTitleRevisions = function(restbase, req) {
         body: {
             table: this.tableName,
             attributes: {
-                title: rp.key
+                title: rp.title
             },
-            proj: ['tid']
+            proj: ['rev']
         }
     })
     .then(function(res) {
-        if (res.status === 200) {
-            res.body.items = res.body.items.map(function(row) {
-                return row.tid;
-            });
-        }
+        // Flatten to an array of revisions rather than an array of objects
+        res.body.items = res.body.items.map(function(row) {
+            return row.rev;
+        });
         return res;
     });
 };

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -18,13 +18,15 @@ paths:
     get:
       tags:
         - Page content
-      description: List page properties
+      description: List page properties / page content sub-apis
 
   /{module:page}/title/:
     get:
       tags:
         - Page content
       description: List all known pages
+      x-backend-request:
+        uri: /{domain}/sys/page_revisions/page/
 
   /{module:page}/title/{title}/:
     get:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -25,6 +25,8 @@ paths:
       tags:
         - Page content
       description: List all known pages
+      produces:
+        - application/json
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/
 
@@ -32,9 +34,27 @@ paths:
     get:
       tags:
         - Page content
-      description: List page meta-data
+      description: > 
+        List revisions for a title. Currently this lists all
+        revisions that ever used this title, but eventually it should probably
+        return the linear history (across renames) of the page currently using
+        this title. Stability: experimental.
       produces:
         - application/json
+      parameters:
+        - name: domain
+          in: path
+          description: The domain under which the data resides
+          type: string
+          required: true
+          default: en.wikipedia.org
+        - name: title
+          in: path
+          description: the title of page content
+          type: string
+          required: true
+      x-backend-request:
+        uri: /{domain}/sys/page_revisions/page/{title}/
 
   /{module:page}/html/:
     get:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -18,28 +18,23 @@ paths:
     get:
       tags:
         - Page content
-      description: List pages
-      x-backend-request:
-        uri: /{domain}/sys/page_revisions/page/
+      description: List page properties
 
-  /{module:page}/{title}:
+  /{module:page}/title/:
     get:
       tags:
         - Page content
-      description: Redirect to the latest HTML for this page
-      # TODO
-      # x-backend-request:
-      #   uri: /{domain}/sys/page_revisions/page/
+      description: List all known pages
 
-  /{module:page}/{title}/:
+  /{module:page}/title/{title}/:
     get:
       tags:
         - Page content
-      description: List available content types for a page
+      description: List page meta-data
       produces:
         - application/json
 
-  /{module:page}/{title}/html:
+  /{module:page}/html/{title}:
     get:
       tags:
         - Page content
@@ -75,7 +70,7 @@ paths:
         # See also http://tools.ietf.org/html/rfc7231#section-7.1.2
         uri: /{domain}/sys/parsoid/html/{title}/latest
 
-  /{module:page}/{title}/html/:
+  /{module:page}/html/{title}/:
     get:
       tags:
         - Page content
@@ -110,7 +105,7 @@ paths:
         uri: /{domain}/sys/parsoid/html/{title}/
 
 
-  /{module:page}/{title}/html/{revision}{/tid}:
+  /{module:page}/html/{title}/{revision}{/tid}:
     get:
       tags:
         - Page content
@@ -155,7 +150,7 @@ paths:
         headers:
           cache-control: $req.headers.cache-control
 
-  /{module:page}/{title}/data-parsoid:
+  /{module:page}/data-parsoid/{title}:
     get:
       tags:
         - Page content
@@ -190,7 +185,7 @@ paths:
         # See also http://tools.ietf.org/html/rfc7231#section-7.1.2
         uri: /{domain}/sys/parsoid/data-parsoid/{title}/latest
 
-  /{module:page}/{title}/data-parsoid/:
+  /{module:page}/data-parsoid/{title}/:
     get:
       tags:
         - Page content
@@ -223,7 +218,7 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}
 
-  /{module:page}/{title}/data-parsoid/{revision}{/tid}:
+  /{module:page}/data-parsoid/{title}/{revision}{/tid}:
     get:
       tags:
         - Page content

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -36,6 +36,14 @@ paths:
       produces:
         - application/json
 
+  /{module:page}/html/:
+    get:
+      tags:
+        - Page content
+      description: List titles for which the HTML property is available
+      x-backend-request:
+        uri: /{domain}/sys/page_revisions/page/
+
   /{module:page}/html/{title}:
     get:
       tags:
@@ -151,6 +159,16 @@ paths:
         uri: /{domain}/sys/parsoid/html/{title}/{revision}{/tid}
         headers:
           cache-control: $req.headers.cache-control
+
+  /{module:page}/data-parsoid/:
+    get:
+      tags:
+        - Page content
+      description: List titles for which the data-parsoid property is available
+      x-backend-request:
+        # Fixme: only list pages that have at least one revision with content
+        # model 'wikitext'
+        uri: /{domain}/sys/page_revisions/page/
 
   /{module:page}/data-parsoid/{title}:
     get:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -262,7 +262,51 @@ paths:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}/{revision}{/tid}
         headers:
           cache-control: $req.headers.cache-control
-              
+
+  /{module:page}/revision/:
+    get:
+      tags:
+        - Page content
+        - Revision
+      description: List available revisions
+      produces:
+        - application/json
+
+  /{module:page}/revision/{revision}:
+    get:
+      tags:
+        - Page content
+        - Revision
+      description: Get meta-data about a specific revision
+      produces:
+        - application/json
+      parameters:
+        - name: domain
+          in: path
+          description: The domain under which the data resides
+          type: string
+          required: true
+          default: en.wikipedia.org
+        - name: revision
+          in: path
+          description: The revision id
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The revision's properties
+        '404':
+          description: Unknown revision id or domain
+          schema:
+            $ref: '#/definitions/notFound'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/defaultError'
+      # x-backend-request:
+      #   uri: /{domain}/sys/key_rev_value/{revision}
+      #   headers:
+      #     cache-control: $req.headers.cache-control
 
   /{module:transform}/html/to/wikitext{/title}{/revision}:
     post:

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -13,7 +13,7 @@ describe('item requests', function() {
     before(function () { return server.start(); });
 
     it('should respond to OPTIONS request with CORS headers', function() {
-        return preq.options({ uri: server.config.bucketURL + '/Foobar/html/624484477' })
+        return preq.options({ uri: server.config.bucketURL + '/html/Foobar/624484477' })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers['access-control-allow-origin'], '*');
@@ -23,7 +23,7 @@ describe('item requests', function() {
     });
     it('should transparently create a new HTML revision with id 624484477', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/Foobar/html/624484477',
+            uri: server.config.bucketURL + '/html/Foobar/624484477',
             body: 'Hello there'
         })
         .then(function(res) {
@@ -32,7 +32,7 @@ describe('item requests', function() {
     });
     it('should transparently create data-parsoid with id 624165266, rev 2', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/Foobar/html/624165266'
+            uri: server.config.bucketURL + '/html/Foobar/624165266'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
@@ -40,7 +40,7 @@ describe('item requests', function() {
     });
     it('should return HTML just created by revision 624165266', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/Foobar/html/624165266'
+            uri: server.config.bucketURL + '/html/Foobar/624165266'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
@@ -49,7 +49,7 @@ describe('item requests', function() {
     });
     it('should return data-parsoid just created by revision 624165266, rev 2', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/Foobar/data-parsoid/624165266'
+            uri: server.config.bucketURL + '/data-parsoid/Foobar/624165266'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
@@ -59,7 +59,7 @@ describe('item requests', function() {
 
     it('should return data-parsoid just created with revision 624484477, rev 2', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/Foobar/data-parsoid/624484477'
+            uri: server.config.bucketURL + '/data-parsoid/Foobar/624484477'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -115,6 +115,19 @@ describe('item requests', function() {
         });
     });
 
+    it('should list revisions for a title', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/title/Foobar/'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            if (!/^application\/json/.test(res.headers['content-type'])) {
+                throw new Error('Expected JSON content type!');
+            }
+            assert.deepEqual(res.body.items, [624484477,624165266]);
+        });
+    });
+
     //it('should return a new wikitext revision using proxy handler with id 624165266', function() {
     //    this.timeout(20000);
     //    return preq.get({

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -102,6 +102,19 @@ describe('item requests', function() {
         });
     });
 
+    it('should list page titles', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/title/'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            if (!/^application\/json/.test(res.headers['content-type'])) {
+                throw new Error('Expected JSON content type!');
+            }
+            assert.deepEqual(res.body.items, ['Foobar']);
+        });
+    });
+
     //it('should return a new wikitext revision using proxy handler with id 624165266', function() {
     //    this.timeout(20000);
     //    return preq.get({

--- a/test/features/pagecontent/rerendering.js
+++ b/test/features/pagecontent/rerendering.js
@@ -29,7 +29,7 @@ describe('page re-rendering', function () {
         var r1tid2;
         var r2tid1;
         return preq.get({
-            uri: server.config.bucketURL + '/Main_Page/html/' + r1
+            uri: server.config.bucketURL + '/html/Main_Page/' + r1
         })
         .then(function (res) {
             assert.deepEqual(res.status, 200);
@@ -37,7 +37,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + '/Main_Page/html/' + r1,
+                uri: server.config.bucketURL + '/html/Main_Page/' + r1,
                 headers: { 'cache-control': 'no-cache' }
             }).delay(500);
         })
@@ -48,7 +48,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + '/Main_Page/html/' + r1 + '/' + r1tid1
+                uri: server.config.bucketURL + '/html/Main_Page/' + r1 + '/' + r1tid1
             });
         })
         .then(function (res) {
@@ -56,7 +56,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + '/Main_Page/html/' + r1
+                uri: server.config.bucketURL + '/html/Main_Page/' + r1
             });
         })
         .then(function (res) {
@@ -64,7 +64,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + '/Main_Page/html/' + r1 + '/' + r1tid2
+                uri: server.config.bucketURL + '/html/Main_Page/' + r1 + '/' + r1tid2
             });
         })
         .then(function (res) {
@@ -72,7 +72,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + '/Main_Page/html/' + r2
+                uri: server.config.bucketURL + '/html/Main_Page/' + r2
             }).delay(500);
         })
         .then(function (res) {
@@ -82,7 +82,7 @@ describe('page re-rendering', function () {
 
             // Delay a bit to give the async save time to complete
             return preq.get({
-                uri: server.config.bucketURL + '/Main_Page/html/' + r2 + '/' + r2tid1
+                uri: server.config.bucketURL + '/html/Main_Page/' + r2 + '/' + r2tid1
             });
         })
         .then(function (res) {
@@ -90,7 +90,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + '/Main_Page/html/' + r1
+                uri: server.config.bucketURL + '/html/Main_Page/' + r1
             });
         })
         .then(function (res) {

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -59,7 +59,8 @@ function assertWentToParsoid(slice, expected) {
 
 var revA = '45451075';
 var revB = '623616192';
-var contentUrl = server.config.bucketURL + '/LCX';
+var title = 'LCX';
+var pageUrl = server.config.bucketURL;
 
 describe('on-demand generation of html and data-parsoid', function() {
     this.timeout(20000);
@@ -69,7 +70,7 @@ describe('on-demand generation of html and data-parsoid', function() {
     it('should transparently create revision A via Parsoid', function () {
         var slice = server.config.logStream.slice();
         return preq.get({
-            uri: contentUrl + '/data-parsoid/' + revA,
+            uri: pageUrl + '/data-parsoid/' + title + '/' + revA,
         })
         .then(function (res) {
             slice.halt();
@@ -84,7 +85,7 @@ describe('on-demand generation of html and data-parsoid', function() {
     it('should transparently create revision B via Parsoid', function () {
         var slice = server.config.logStream.slice();
         return preq.get({
-            uri: contentUrl + '/html/' + revB,
+            uri: pageUrl + '/html/' + title + '/' + revB,
         })
         .then(function (res) {
             slice.halt();
@@ -99,7 +100,7 @@ describe('on-demand generation of html and data-parsoid', function() {
     it('should retrieve html revision B from storage', function () {
         var slice = server.config.logStream.slice();
         return preq.get({
-            uri: contentUrl + '/html/' + revB,
+            uri: pageUrl + '/html/' + title + '/' + revB,
         })
         .then(function (res) {
             slice.halt();
@@ -114,7 +115,7 @@ describe('on-demand generation of html and data-parsoid', function() {
     it('should retrieve data-parsoid revision B from storage', function () {
         var slice = server.config.logStream.slice();
         return preq.get({
-            uri: contentUrl + '/data-parsoid/' + revB,
+            uri: pageUrl + '/data-parsoid/' + title + '/' + revB,
         })
         .then(function (res) {
             slice.halt();
@@ -131,7 +132,7 @@ describe('on-demand generation of html and data-parsoid', function() {
         // Start watching for new log entries
         var slice = server.config.logStream.slice();
         return preq.get({
-            uri: contentUrl + '/html/' + revB,
+            uri: pageUrl + '/html/' + title + '/' + revB,
             headers: {
                 'cache-control': 'no-cache'
             },
@@ -152,7 +153,7 @@ describe('on-demand generation of html and data-parsoid', function() {
         // Start watching for new log entries
         var slice = server.config.logStream.slice();
         return preq.get({
-            uri: contentUrl + '/data-parsoid/' + revB,
+            uri: pageUrl + '/data-parsoid/' + title + '/' + revB,
             headers: {
                 'cache-control': 'no-cache'
             },

--- a/test/features/parsoid/transform/transform.js
+++ b/test/features/parsoid/transform/transform.js
@@ -70,7 +70,7 @@ function findSpecs() {
                 to: { format: specDir.toFormat, src: response }
             });
         }
-       
+
     });
     return specs;
 }
@@ -93,7 +93,7 @@ function x2y(spec) {
         it('should directly convert ' + spec.from.format + ' to ' + spec.to.format, test);
     });
 }
-   
+
 findSpecs().forEach(function (spec) {
     x2y(spec);
 });

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -74,7 +74,7 @@ describe('tree building', function() {
         })
         .then(function() {
             //console.log(JSON.stringify(router.tree, null, 2));
-            var handler = router.route('/en.wikipedia.org/v1/page/Foo/html');
+            var handler = router.route('/en.wikipedia.org/v1/page/html/Foo');
             //console.log(handler);
             assert.equal(resourceRequests.length > 0, true);
             assert.equal(!!handler.value.methods.get, true);

--- a/test/features/specification/swagger.js
+++ b/test/features/specification/swagger.js
@@ -12,7 +12,7 @@ var server = require('../../utils/server.js');
     var prereqs = [
         { // transparently create HTML revision id 624484477
             method: 'get',
-            uri: server.config.bucketURL + '/Foobar/html/624484477',
+            uri: server.config.bucketURL + '/html/Foobar/624484477',
             body: 'Hello there, this is revision 624484477!'
         }
     ];

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -16,7 +16,7 @@ basePath: ''
 schemes:
   - http
 paths:
-  /{domain}/v1/page/{title}/html/:
+  /{domain}/v1/page/html/{title}/:
     get:
       tags:
         - Page content
@@ -59,7 +59,7 @@ paths:
             body:
               items: []
 
-  /{domain}/v1/page/{title}/html:
+  /{domain}/v1/page/html/{title}:
     get:
       tags:
         - Page content
@@ -98,7 +98,7 @@ paths:
             headers:
                 content-type: text/html;profile=mediawiki.org/specs/html/1.0.0
 
-  /{domain}/v1/page/{title}/html/{revision}:
+  /{domain}/v1/page/html/{title}/{revision}:
     get:
       tags:
         - Page content
@@ -149,7 +149,7 @@ paths:
             headers:
                 content-type: text/html;profile=mediawiki.org/specs/html/1.0.0
 
-  /{domain}/v1/page/{title}/data-parsoid/{revision}:
+  /{domain}/v1/page/data-parsoid/{title}/{revision}:
     get:
       tags:
         - Page content


### PR DESCRIPTION
This PR addresses [T88652](https://phabricator.wikimedia.org/T88652). Specifically, it creates the new `/page/{html,data-parsoid,...}` structure and modifies the URIs used in tests to conform to the new specification. Additionally, two new endpoints are defined - `/page/revision/` and `/page/revision/{revision}` - which should list known revisions and get meta-data about a specific one, respectively. Note that the latter endpoint is not currently functional, additional work is going to be needed in the *page_revisions* module to support it.