### PR TITLE
Revision suppression / deletion detection

### DIFF
--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -140,6 +140,46 @@ describe('item requests', function() {
 
 });
 
+describe('page content access', function() {
+
+    var deniedTitle = 'User%20talk:DivineAlpha';
+    var deniedRev = '645504917';
+
+    this.timeout(30000);
+
+    function contentURI(format) {
+        return [server.config.bucketURL, format, deniedTitle, deniedRev].join('/');
+    }
+
+    it('should deny access to the HTML of a restricted revision', function() {
+        return preq.get({ uri: contentURI('html') }).then(function(res) {
+            throw new Error('Expected status 403, but gotten ' + res.status);
+        }, function(res) {
+            assert.deepEqual(res.status, 403);
+        });
+    });
+
+    it('should deny access to the same HTML even after re-fetching it', function() {
+        return preq.get({
+            uri: contentURI('html'),
+            headers: { 'cache-control': 'no-cache' }
+        }).then(function(res) {
+            throw new Error('Expected status 403, but gotten ' + res.status);
+        }, function(res) {
+            assert.deepEqual(res.status, 403);
+        });
+    });
+
+    it('should deny access to the data-parsoid of a restricted revision', function() {
+        return preq.get({ uri: contentURI('data-parsoid') }).then(function(res) {
+            throw new Error('Expected status 403, but gotten ' + res.status);
+        }, function(res) {
+            assert.deepEqual(res.status, 403);
+        });
+    });
+
+});
+
 describe('page content hierarchy', function() {
     this.timeout(20000);
     it('should list available properties', function() {

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -64,5 +64,28 @@ describe('revision requests', function() {
         });
     });
 
+    it('should fail for a restricted revision fetched from MW API', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/revision/645504917',
+            headers: { 'cache-control': 'no-cache' }
+        })
+        .then(function(res) {
+            throw new Error('Expected status 403 for a restricted revision, got ' + res.status);
+        },
+        function(res) {
+            assert.deepEqual(res.status, 403);
+        });
+    });
+
+    it('should fail for a restricted revision present in storage', function() {
+        return preq.get({ uri: server.config.bucketURL + '/revision/645504917' })
+        .then(function(res) {
+            throw new Error('Expected status 403 for a restricted revision, got ' + res.status);
+        },
+        function(res) {
+            assert.deepEqual(res.status, 403);
+        });
+    });
+
 });
 

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -2,14 +2,6 @@
 
 var assert = require('assert');
 
-function exists(xs, f) {
-    for (var i = 0; i < xs.length; i++) {
-        if (f(xs[i])) {
-            return true;
-        }
-    }
-    return false;
-}
 
 /**
  * Asserts whether content type was as expected
@@ -26,7 +18,7 @@ function contentType(res, expected) {
  */
 function localRequests(slice, expected) {
     deepEqual(
-        !exists(slice.get(), function(line) {
+        !slice.get().some(function(line) {
             var entry = JSON.parse(line);
             // if the URI starts with a slash,
             // it's a local request
@@ -45,7 +37,7 @@ function localRequests(slice, expected) {
  */
 function remoteRequests(slice, expected) {
     deepEqual(
-        exists(slice.get(), function(line) {
+        slice.get().some(function(line) {
             var entry = JSON.parse(line);
             return /^http/.test(entry.req.uri);
         }),


### PR DESCRIPTION
This PR build on #169 and provides the mechanism needed to deny access to revisions with restrictions. It is enforced both when requesting info about a specific revision (with or without providing a title), as well as its contents.

If a specific revision is passed in, a second, parallel request is made to the *page_revisions* module to determine whether the sought revision is accessible. In case it is restricted, access in denied to the user. Note that the content itself is fetched and stored regardless of access restrictions.