### PR TITLE
Add the 'count' field to listing results

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -93,6 +93,7 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
         return Promise.resolve({
             status: 200,
             body: {
+                count: req.params._ls.length,
                 items: req.params._ls
             }
         });

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -75,6 +75,7 @@ describe('item requests', function() {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers['content-type'], 'application/json');
             assert.deepEqual(res.body, {
+                count: 2,
                 items: ['sys', 'v1' ]
             });
         });


### PR DESCRIPTION
All of our non-generic listings include an object comprising the `count` and `items` fields. Add the former to generic listing results for uniformity.