### PR TITLE
Default to deflate compression for key_rev_value

### DIFF
--- a/mods/key_rev_value.js
+++ b/mods/key_rev_value.js
@@ -34,6 +34,14 @@ KRVBucket.prototype.makeSchema = function (opts) {
     return {
         // Associate this bucket with the table
         bucket: opts,
+        options: {
+            compression: [
+                {
+                    algorithm: 'deflate',
+                    block_size: 256
+                }
+            ]
+        },
         attributes: {
             key: opts.keyType || 'string',
             rev: 'int',

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-uuid": "git+https://github.com/gwicke/node-uuid#master",
     "preq": "~0.3.6",
     "request": "^2.44.0",
-    "restbase-mod-table-cassandra": "^0.4.5",
+    "restbase-mod-table-cassandra": "^0.4.7",
     "service-runner": "^0.0.2",
     "swagger-router": "^0.0.3",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",


### PR DESCRIPTION
Deflate compression is highly effective for blob storage with repetitive patterns smaller than deflate's 32k window size. For typical HTML
documents it reduces the stored size by almost 50%. Lets use it by default for
our key_rev_value buckets.