### PR TITLE
Use swagger-ui's dist path export

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -3,8 +3,9 @@
 var P = require('bluebird');
 var fs = P.promisifyAll(require('fs'));
 var path = require('path');
+// swagger-ui helpfully exports the absolute path of its dist directory
+var docRoot = require('swagger-ui').dist + '/';
 
-var docRoot = __dirname + '/../node_modules/swagger-ui/dist/';
 function staticServe (restbase, req) {
     // Expand any relative paths for security
     var filePath = req.query.path.replace(/\.\.\//g, '');


### PR DESCRIPTION
This makes the docs work in setups (like prod) where the node_modules checkout
is not inside the restbase repository.