### PR TITLE
Disable the swagger validator

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -20,7 +20,7 @@ function staticServe (restbase, req) {
                 .replace(/<title>[^<]*<\/title>/,
                         '<title>RESTBase docs</title>')
                 // Replace the default url with ours
-                .replace(/url = "http/, 'url = "?spec"; //');
+                .replace(/url: url,/, 'url: "?spec", validatorUrl: null,');
         }
 
         var contentType = 'text/html';

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -17,6 +17,8 @@ function staticServe (restbase, req) {
                 // Some self-promotion
                 .replace(/<a id="logo".*?<\/a>/,
                         '<a id="logo" href="http://restbase.org">RESTBase</a>')
+                .replace(/<title>[^<]*<\/title>/,
+                        '<title>RESTBase docs</title>')
                 // Replace the default url with ours
                 .replace(/url = "http/, 'url = "?spec"; //');
         }


### PR DESCRIPTION
The swagger validator is currently http-only, which means that it causes mixed
content warnings when accessing the docs using https. It's also not a good
idea to call out to external services.