### PR TITLE
Limit the size of swagger sandbox responses to syntax highlight

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -19,8 +19,9 @@ function staticServe (restbase, req) {
                         '<a id="logo" href="http://restbase.org">RESTBase</a>')
                 .replace(/<title>[^<]*<\/title>/,
                         '<title>RESTBase docs</title>')
-                // Replace the default url with ours
-                .replace(/url: url,/, 'url: "?spec", validatorUrl: null,');
+                // Replace the default url with ours, switch off validation &
+                // limit the size of documents to apply syntax highlighting to
+                .replace(/url: url,/, 'url: "?spec", validatorUrl: null, highlightSizeThreshold: 10000,');
         }
 
         var contentType = 'text/html';


### PR DESCRIPTION
On large responses syntax highlighting can freeze the browser, which isn't
such a great demo for a fast API. Avoid this by limiting the size of responses
to highlight to 10k.