### PR TITLE
List revision end points only in 'Page content' section

### DIFF
--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -355,7 +355,6 @@ paths:
     get:
       tags:
         - Page content
-        - Revision
       description: List available revisions
       produces:
         - application/json
@@ -379,7 +378,6 @@ paths:
     get:
       tags:
         - Page content
-        - Revision
       description: Get meta-data about a specific revision
       produces:
         - application/json


### PR DESCRIPTION
Swagger-ui uses ids to expand/collapse sections, and this doesn't work
reliably if an ID is not unique in a page. This was the case with the revision
end points, as they were listed in both the 'Page content' and 'Revision'
sections.

Given the choice between only listing them in the 'Page content' or 'Revision'
section, I went with 'Page content', as these revisions are really
page-specific. There might be other types of revisions for other kinds of
non-page content.