### PR TITLE
Minor improvements in tests

### DIFF
--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -115,7 +115,7 @@ PRS.prototype._checkRevReturn = function(res) {
         });
     }
     return true;
-}
+};
 
 // /page/
 PRS.prototype.listTitles = function(restbase, req, options) {
@@ -178,7 +178,7 @@ PRS.prototype.fetchAndStoreMWRevision = function (restbase, req) {
         // the revision info
         var apiRev = dataResp.revisions[0];
         // are there any restrictions set?
-        var restrictions = Object.keys(apiRev).filter(function(key) { return /hidden$/.test(key) });
+        var restrictions = Object.keys(apiRev).filter(function(key) { return /hidden$/.test(key); });
         // the tid to store this info under
         var tid = rbUtil.tidFromDate(apiRev.timestamp);
         return restbase.put({ // Save / update the revision entry

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "preq": "~0.3.6",
     "request": "^2.44.0",
     "restbase-mod-table-cassandra": "^0.4.7",
-    "service-runner": "^0.1.0",
+    "service-runner": "^0.1.4",
     "swagger-router": "^0.0.4",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "url-template": "2.0.4",

--- a/test/features/errors/notfound.js
+++ b/test/features/errors/notfound.js
@@ -18,7 +18,7 @@ describe('404 handling', function() {
         })
         .catch(function(e) {
             assert.deepEqual(e.status, 404);
-            assert.deepEqual(e.headers['content-type'], 'application/problem+json');
+            assert.contentType(e, 'application/problem+json');
         });
     });
     it('should return a proper 404 when trying to list a non-existing domain', function() {
@@ -27,7 +27,7 @@ describe('404 handling', function() {
         })
         .catch(function(e) {
             assert.deepEqual(e.status, 404);
-            assert.deepEqual(e.headers['content-type'], 'application/problem+json');
+            assert.contentType(e, 'application/problem+json');
         });
     });
     it('should return a proper 404 when accessing an unknown bucket', function() {
@@ -36,7 +36,7 @@ describe('404 handling', function() {
         })
         .catch(function(e) {
             assert.deepEqual(e.status, 404);
-            assert.deepEqual(e.headers['content-type'], 'application/problem+json');
+            assert.contentType(e, 'application/problem+json');
         });
     });
     it('should return a proper 404 when trying to list an unknown bucket', function() {
@@ -45,7 +45,7 @@ describe('404 handling', function() {
         })
         .catch(function(e) {
             assert.deepEqual(e.status, 404);
-            assert.deepEqual(e.headers['content-type'], 'application/problem+json');
+            assert.contentType(e, 'application/problem+json');
         });
     });
     it('should return a proper 404 when accessing an item in an unknown bucket', function() {
@@ -54,7 +54,7 @@ describe('404 handling', function() {
         })
         .catch(function(e) {
             assert.deepEqual(e.status, 404);
-            assert.deepEqual(e.headers['content-type'], 'application/problem+json');
+            assert.contentType(e, 'application/problem+json');
         });
     });
     it('should return a proper 404 for the latest revision of a missing page', function() {
@@ -63,7 +63,7 @@ describe('404 handling', function() {
         })
         .catch(function(e) {
             assert.deepEqual(e.status, 404);
-            assert.deepEqual(e.headers['content-type'], 'application/problem+json');
+            assert.contentType(e, 'application/problem+json');
         });
     });
 });

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -44,7 +44,7 @@ describe('item requests', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['content-type'], 'text/html;profile=mediawiki.org/specs/html/1.0.0');
+            assert.contentType(res, 'text/html;profile=mediawiki.org/specs/html/1.0.0');
         });
     });
     it('should return data-parsoid just created by revision 624165266, rev 2', function() {
@@ -53,7 +53,7 @@ describe('item requests', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['content-type'], 'application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1');
+            assert.contentType(res, 'application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1');
         });
     });
 
@@ -63,7 +63,7 @@ describe('item requests', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['content-type'], 'application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1');
+            assert.contentType(res, 'application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1');
         });
     });
 
@@ -73,7 +73,7 @@ describe('item requests', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['content-type'], 'application/json');
+            assert.contentType(res, 'application/json');
             assert.deepEqual(res.body, {
                 items: ['sys', 'v1' ]
             });
@@ -86,7 +86,7 @@ describe('item requests', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['content-type'], 'application/json');
+            assert.contentType(res, 'application/json');
             assert.deepEqual(res.body.swagger, '2.0');
         });
     });
@@ -97,7 +97,7 @@ describe('item requests', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['content-type'], 'text/html');
+            assert.contentType(res, 'text/html');
             assert.deepEqual(/<html/.exec(res.body)[0], '<html');
         });
     });
@@ -108,9 +108,7 @@ describe('item requests', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
-            if (!/^application\/json/.test(res.headers['content-type'])) {
-                throw new Error('Expected JSON content type!');
-            }
+            assert.contentType(res, 'application/json');
             assert.deepEqual(res.body.items, ['Foobar']);
         });
     });
@@ -121,9 +119,7 @@ describe('item requests', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
-            if (!/^application\/json/.test(res.headers['content-type'])) {
-                throw new Error('Expected JSON content type!');
-            }
+            assert.contentType(res, 'application/json');
             assert.deepEqual(res.body.items, [624484477,624165266]);
         });
     });

--- a/test/features/pagecontent/rerendering.js
+++ b/test/features/pagecontent/rerendering.js
@@ -17,10 +17,7 @@ describe('page re-rendering', function () {
 
 
     function hasTextContentType(res) {
-        var ctype = res.headers['content-type'];
-        if (!/text\/html/.test(ctype)) {
-            throw new Error('Content-type does not match text/html: ' + ctype);
-        }
+        assert.contentType(res, 'text/html');
     }
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+
+// Run jshint as part of normal testing
+require('mocha-jshint')();
+


### PR DESCRIPTION
- use `assert.contenType()` to test for returned Content-Type headers
- add the `jshint` test to the suite (apparently it disappeared during test refactorisation)
- bump required `service-runner` version to 0.1.4
