### PR TITLE
Don't assume that all log entries have a .req member

### DIFF
--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -22,7 +22,7 @@ function localRequests(slice, expected) {
             var entry = JSON.parse(line);
             // if the URI starts with a slash,
             // it's a local request
-            return !/^\//.test(entry.req.uri);
+            return entry.req && !/^\//.test(entry.req.uri);
         }),
         expected,
         expected ?
@@ -39,7 +39,7 @@ function remoteRequests(slice, expected) {
     deepEqual(
         slice.get().some(function(line) {
             var entry = JSON.parse(line);
-            return /^http/.test(entry.req.uri);
+            return entry.req && /^http/.test(entry.req.uri);
         }),
         expected,
         expected ?


### PR DESCRIPTION
The cassandra backend log messages in particular (emitted on startup for
example) don't have a 'req' entry associated with them. Don't crash in that
situation.