### PR TITLE
Minor fixes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,7 +15,7 @@
 	"curly": true,
 	"eqeqeq": true,
 	"immed": true,
-	"latedef": true,
+	"latedef": "nofunc",
 	"newcap": true,
 	"noarg": true,
 	"noempty": true,

--- a/lib/router.js
+++ b/lib/router.js
@@ -388,7 +388,14 @@ Router.prototype.handleResources = function(restbase) {
                 }, true).expand();
                 req.method = req.method || 'put';
                 //console.log(path, req.uri);
-                return restbase.request(req);
+                return restbase.request(req)
+                // Workaround (forces setTimeout) to avoid excessive nextTick
+                // recursion in bluebird with node 0.10. Otherwise, we see errors
+                // like this with >~500 domains:
+                // (node) warning: Recursive process.nextTick detected. This will
+                // break in the next version of node. Please use setImmediate for
+                // recursive deferral.
+                .delay(0);
             });
         } else {
             return P.resolve();

--- a/mods/key_rev_value.js
+++ b/mods/key_rev_value.js
@@ -32,8 +32,6 @@ KRVBucket.prototype.getBucketInfo = function(restbase, req, options) {
 KRVBucket.prototype.makeSchema = function (opts) {
     opts.schemaVersion = 1;
     return {
-        // Associate this bucket with the table
-        bucket: opts,
         options: {
             compression: [
                 {


### PR DESCRIPTION
- remove a stray / old 'bucket' parameter in the schema generated by key_rev_value
- break nextTick recursion in resource processing when everything is perfectly cached / sync
- tweak jshintrc to allow out-of-order function definitions