### PR TITLE
Hacky listing implementation

### DIFF
--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -124,19 +124,24 @@ PRS.prototype.listTitles = function(restbase, req, options) {
         uri: this.tableURI(rp.domain),
         body: {
             table: this.tableName,
-            proj: ['title'],
-            distinct: true,
+            proj: ['title','rev'],
+            //distinct: true,
             limit: 1000
         }
     };
 
     return restbase.get(listReq)
     .then(function(res) {
-        if (res.status === 200) {
-            res.body.items = res.body.items.map(function(row) {
-                return row.title;
-            });
-        }
+        // Hacky distinct implementation as workaround
+        var items = [];
+        var lastTitle;
+        res.body.items.forEach(function(row) {
+            if (row.title !== lastTitle) {
+                items.push(row.title);
+                lastTitle = row.title;
+            }
+        });
+        res.body.items = items;
         return res;
     });
 };
@@ -310,18 +315,23 @@ PRS.prototype.listRevisions = function(restbase, req) {
         body: {
             table: this.tableName,
             index: 'by_rev',
-            proj: ['rev'],
-            distinct: true,
+            proj: ['rev','tid'],
+            //distinct: true,
             limit: 1000
         }
     };
     return restbase.get(listReq)
     .then(function(res) {
-        if (res.status === 200) {
-            res.body.items = res.body.items.map(function(row) {
-                return row.rev;
-            });
-        }
+        // Hacky distinct implementation as workaround
+        var items = [];
+        var lastRev;
+        res.body.items.forEach(function(row) {
+            if (row.rev !== lastRev) {
+                items.push(row.rev);
+                lastRev = row.rev;
+            }
+        });
+        res.body.items = items;
         return res;
     });
 };


### PR DESCRIPTION
This implementation provides stop-gap title and revision listings with
manually-created Cassandra secondary indexes on the _domain column on the
revision data & index tables.