### PR TITLE
reenable listing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-uuid": "git+https://github.com/gwicke/node-uuid#master",
     "preq": "~0.3.6",
     "request": "^2.44.0",
-    "restbase-mod-table-cassandra": "^0.5.0",
+    "restbase-mod-table-cassandra": "^0.5.2",
     "service-runner": "^0.1.4",
     "swagger-router": "^0.0.4",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -102,16 +102,16 @@ describe('item requests', function() {
         });
     });
 
-    //it('should list page titles', function() {
-    //    return preq.get({
-    //        uri: server.config.bucketURL + '/title/'
-    //    })
-    //    .then(function(res) {
-    //        assert.deepEqual(res.status, 200);
-    //        assert.contentType(res, 'application/json');
-    //        assert.deepEqual(res.body.items, ['Foobar']);
-    //    });
-    //});
+    it('should list page titles', function() {
+       return preq.get({
+           uri: server.config.bucketURL + '/title/'
+       })
+       .then(function(res) {
+           assert.deepEqual(res.status, 200);
+           assert.contentType(res, 'application/json');
+           assert.deepEqual(res.body.items, ['Foobar']);
+       });
+    });
 
     it('should list revisions for a title', function() {
         return preq.get({

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -90,21 +90,21 @@ describe('revision requests', function() {
         });
     });
 
-    //it('should list stored revisions', function() {
-    //    return preq.get({ uri: server.config.bucketURL + '/revision/' })
-    //    .then(function(res) {
-    //        assert.deepEqual(res.status, 200);
-	//		assert.contentType(res, 'application/json');
-	//		// at least the revisions from this test file
-	//		// should be present in storage
-	//		assert.deepEqual(res.body.items.some(function(revId) {
-	//			return revId === revOk;
-	//		}), true);
-	//		assert.deepEqual(res.body.items.some(function(revId) {
-	//			return revId === revDeleted;
-	//		}), true);
-    //    });
-    //});
+    it('should list stored revisions', function() {
+       return preq.get({ uri: server.config.bucketURL + '/revision/' })
+       .then(function(res) {
+           assert.deepEqual(res.status, 200);
+			assert.contentType(res, 'application/json');
+			// at least the revisions from this test file
+			// should be present in storage
+			assert.deepEqual(res.body.items.some(function(revId) {
+				return revId === revOk;
+			}), true);
+			assert.deepEqual(res.body.items.some(function(revId) {
+				return revId === revDeleted;
+			}), true);
+       });
+    });
 
 });
 


### PR DESCRIPTION
Bump the version of mod-table-cassandra to a one that supports creation of indexes on the `_domain` attribute, and reenable the corresponding tests.