### PR TITLE
Use ES6 Object.assign instead of the custom extend package

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -130,8 +130,6 @@ rbUtil.isTimeUUID = function (s) {
     return uuidRe.test(s);
 };
 
-rbUtil.extend = require('extend');
-
 /*
  * Error instance wrapping HTTP error responses
  *

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -70,7 +70,7 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
     if (rq.spec !== undefined && value.specRoot) {
         return P.resolve({
             status: 200,
-            body: rbUtil.extend({}, value.specRoot, {
+            body: Object.assign({}, value.specRoot, {
                 // Set the base path dynamically
                 basePath: req.uri.toString().replace(/\/$/, '')
             })

--- a/lib/router.js
+++ b/lib/router.js
@@ -151,7 +151,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
         var subSpec = pathspec['x-subspec'];
         if (subSpec) {
             var specRootBasePath = specRoot.basePath || '';
-            specRoot = rbUtil.extend({}, subSpec);
+            specRoot = Object.assign({}, subSpec);
             specRoot.paths = {};
             specRoot.definitions = {};
             specRoot.basePath = specRootBasePath + prefixPath;
@@ -270,7 +270,7 @@ Router.prototype._handleSwaggerSpec = function (rootNode, spec, operations, spec
     }
     if (spec.definitions) {
         // Merge definitions
-        rbUtil.extend(specRoot.definitions, spec.definitions);
+        Object.assign(specRoot.definitions, spec.definitions);
     }
     var self = this;
     function handlePaths (paths) {
@@ -389,7 +389,7 @@ Router.prototype.handleResources = function(restbase) {
                     throw new Error("Missing resource URI in spec for "
                             + JSON.stringify(path));
                 }
-                var req = rbUtil.extend({}, reqTemplate);
+                var req = Object.assign({}, reqTemplate);
                 req.uri = new URI(req.uri, {
                     domain: path[0]
                 }, true).expand();

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "bluebird": "~2.2.2",
     "bunyan": "~1.1.3",
     "busboy": "~0.2.8",
-    "extend": "~1.3.0",
     "gelf-stream": "~0.2.4",
     "js-yaml": "~3.2.2",
     "node-txstatsd": "~0.1.5",


### PR DESCRIPTION
There is now a static `Object.assign({}, someObj, otherObj)` method, which is
shimmed by the `core-js` shim pulled in by service-runner. Lets use the
upcoming standard and get rid of an unnecessary dependency.