### PR TITLE
Store content using the canonical title only

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -81,6 +81,43 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
             req.query.path = '/index.html';
         }
         return swaggerUI(restbase, req);
+    } else if (/\btext\/html\b/.test(req.headers.accept)
+            && req.uri.path.length <= 2) {
+        // Browser request and above api level
+        req.query.path = '/index.html';
+        var html = '<div id="swagger-ui-container" class="swagger-ui-wrap">'
+                    + '<div class="info_title">Wikimedia REST API</div>';
+        if (req.uri.path.length === 1) {
+            html += '<h2>Domains:</h2>'
+                    + '<div class="info_description markdown"><ul>'
+                    + req.params._ls.map(function(domain) {
+                        return '<li><a href="' + encodeURIComponent(domain)
+                            + '/v1/?doc">' + domain + '</a></li>';
+                    }).join('\n')
+                    + '</ul></div>';
+        } else {
+            html += '<h2>APIs:</h2>'
+                    + '<div class="info_description markdown"><ul>'
+                    + req.params._ls.filter(function(item) {
+                            return item !== 'sys';
+                        })
+                        .map(function(api) {
+                        return '<li><a href="' + encodeURIComponent(api)
+                            + '/?doc">' + api + '</a></li>';
+                    }).join('\n')
+                    + '</ul>';
+        }
+        html += "<h3>JSON listing</h3><p>To retrieve a regular JSON listing, you can either "
+            + "omit the <code>Accept</code> header, or send one that does not contain "
+            + "<code>text/html</code>.</p></div>";
+
+        return swaggerUI(restbase, req)
+        .then(function(res) {
+            res.body = res.body
+                .replace(/window\.swaggerUi\.load/,'')
+                .replace(/<div id="swagger-ui-container" class="swagger-ui-wrap">/, html);
+            return res;
+        });
     } else {
         // Plain listing
         return P.resolve({


### PR DESCRIPTION
Requests with a non-canonical title (example: 'foobar' vs. 'Foobar') can
currently cause key_rev_value content to be stored using both the
non-canonical version ('foobar') and the canonical version ('Foobar'). This is
bad for performance and consistency.

This patch avoids this by comparing the normalized title retrieved from
page_revisions with the (slightly pre-normalized) request title. If the two
differ, the request is retried against storage before (potentially) creating
the content.