### PR TITLE
Attach a x-request-id header to each incoming request

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -141,24 +141,6 @@ rbUtil.generateRequestId = function() {
     return reqIdBuf.toString('hex');
 };
 
-/**
- * Checks for the existence of the x-request-id header and
- * sets it in case it is not present
- *
- * @param {Request} the request object
- * @return {String} the obtained or generated request ID
- */
-rbUtil.requestId = function(req) {
-    if(!req) {
-        return rbUtil.generateRequestId();
-    }
-    req.headers = req.headers || {};
-    if(!req.headers['x-request-id']) {
-        req.headers['x-request-id'] = rbUtil.generateRequestId();
-    }
-    return req.headers['x-request-id'];
-};
-
 /*
  * Error instance wrapping HTTP error responses
  *

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -141,6 +141,24 @@ rbUtil.generateRequestId = function() {
     return reqIdBuf.toString('hex');
 };
 
+/**
+ * Checks for the existence of the x-request-id header and
+ * sets it in case it is not present
+ *
+ * @param {Request} the request object
+ * @return {String} the obtained or generated request ID
+ */
+rbUtil.requestId = function(req) {
+    if(!req) {
+        return rbUtil.generateRequestId();
+    }
+    req.headers = req.headers || {};
+    if(!req.headers['x-request-id']) {
+        req.headers['x-request-id'] = rbUtil.generateRequestId();
+    }
+    return req.headers['x-request-id'];
+};
+
 /*
  * Error instance wrapping HTTP error responses
  *

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -131,14 +131,14 @@ rbUtil.isTimeUUID = function (s) {
 };
 
 
-var buf = new Buffer(16);
+var reqIdBuf = new Buffer(16);
 
 /**
  * Generates a new request ID
  */
 rbUtil.generateRequestId = function() {
-    uuid.v4(null, buf);
-    return buf.toString('hex');
+    uuid.v4(null, reqIdBuf);
+    return reqIdBuf.toString('hex');
 };
 
 /*

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -130,6 +130,17 @@ rbUtil.isTimeUUID = function (s) {
     return uuidRe.test(s);
 };
 
+
+var buf = new Buffer(16);
+
+/**
+ * Generates a new request ID
+ */
+rbUtil.generateRequestId = function() {
+    uuid.v4(null, buf);
+    return buf.toString('hex');
+};
+
 /*
  * Error instance wrapping HTTP error responses
  *

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -34,7 +34,6 @@ function RESTBase (options, req) {
         this.metrics = par.metrics;
         this._recursionDepth = par._recursionDepth + 1;
         this._priv = par._priv;
-        this._isMain = false;
         this._reqId = par._reqId;
     } else {
         // Brand new instance
@@ -45,7 +44,6 @@ function RESTBase (options, req) {
         this._parent = null;
         this._req = null;
         this._recursionDepth = 0;
-        this._isMain = true;
 
         options.maxDepth = options.maxDepth || 10;
         // Private state, shared with child instances
@@ -64,7 +62,7 @@ function RESTBase (options, req) {
 // the request header, if defined
 RESTBase.prototype.setRequestId = function(req) {
 
-    if (this._isMain) {
+    if (!this._parent) {
         if (req && !(req.headers && req.headers['x-request-id'])) {
             rbUtil.requestId(req);
         }

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -49,9 +49,22 @@ function RESTBase (options, req) {
         this._priv = {
             options: options,
             router: options.router,
+            reqId: req ? req.headers && req.headers['x-request-id'] || rbUtil.generateRequestId() : null
         };
-
     }
+
+    if (req) {
+        req.headers = req.headers || {};
+        if (req.headers['x-request-id']) {
+            // the request has got the request id header set, use that
+            this._priv.reqId = req.headers['x-request-id'];
+        } else if (!this._priv.reqId) {
+            // no request id set, generate it
+            this._priv.reqId = rbUtil.generateRequestId();
+        }
+        req.headers['x-request-id'] = this._priv.reqId;
+    }
+
 }
 
 // Make a child instance
@@ -180,9 +193,6 @@ RESTBase.prototype.request = function (req) {
 // Internal request handler
 RESTBase.prototype._request = function (req) {
     var self = this;
-
-    req.headers = req.headers || {};
-    req.headers['x-request-id'] = req.headers['x-request-id'] || rbUtil.generateRequestId();
 
     // Special handling for https? requests
     if (req.uri.constructor === String && /^https?:\/\//.test(req.uri)) {

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -32,13 +32,14 @@ function RESTBase (options, req) {
         var par = this._parent = options;
         this.log = par.log;
         this.metrics = par.metrics;
+        this.reqId = req && req.headers && req.headers['x-request-id'] || req && req.reqId || par.reqId || rbUtil.generateRequestId();
         this._recursionDepth = par._recursionDepth + 1;
         this._priv = par._priv;
-        this._reqId = par._reqId;
     } else {
         // Brand new instance
         this.log = options.log; // logging method
         this.metrics = options.metrics;
+        this.reqId = null;
 
         // Private
         this._parent = null;
@@ -53,33 +54,17 @@ function RESTBase (options, req) {
         };
     }
 
-    // set the request id, if appropriate
-    this.setRequestId(req);
-
 }
 
 // sets the request id for this instance and adds it to
 // the request header, if defined
 RESTBase.prototype.setRequestId = function(req) {
 
-    if (!this._parent) {
-        if (req && !(req.headers && req.headers['x-request-id'])) {
-            rbUtil.requestId(req);
-        }
+    req.headers = req.headers || {};
+    if(req.headers['x-request-id']) {
         return;
     }
-
-    if (req) {
-        req.headers = req.headers || {};
-        if (req.headers['x-request-id']) {
-            // the request has got the request id header set, use that
-            this._reqId = req.headers['x-request-id'];
-        } else if (!this._reqId) {
-            // no request id set, generate it
-            this._reqId = rbUtil.generateRequestId();
-        }
-        req.headers['x-request-id'] = this._reqId;
-    }
+    req.headers['x-request-id'] = req.reqId || this.reqId;
 
 };
 
@@ -160,7 +145,8 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
 };
 
 // Special handling for external web requests
-RESTBase.prototype.defaultWebRequestHandler = function(restbase, req) {
+RESTBase.prototype.defaultWebRequestHandler = function(req) {
+    this.setRequestId(req);
     this.log('trace/webrequest', {
         req: req,
         request_id: req.headers['x-request-id']
@@ -211,12 +197,9 @@ RESTBase.prototype.request = function (req) {
 RESTBase.prototype._request = function (req) {
     var self = this;
 
-    // set the request id
-    this.setRequestId(req);
-
     // Special handling for https? requests
     if (req.uri.constructor === String && /^https?:\/\//.test(req.uri)) {
-        return this.defaultWebRequestHandler(this, req);
+        return this.defaultWebRequestHandler(req);
     }
 
     var priv = this._priv;
@@ -287,7 +270,7 @@ RESTBase.prototype._request = function (req) {
             self.log('trace', {
                 req: req,
                 res: res,
-                request_id: req.headers['x-request-id']
+                request_id: childRESTBase.reqId
             });
 
             if (!res) {

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -79,15 +79,13 @@ RESTBase.prototype.setRequestId = function(req) {
             this._reqId = rbUtil.generateRequestId();
         }
         req.headers['x-request-id'] = this._reqId;
-    } else if(!this._reqId) {
-        this._reqId = rbUtil.generateRequestId();
     }
 
 };
 
 // Make a child instance
 RESTBase.prototype.makeChild = function(req) {
-    var child = new RESTBase(this);
+    var child = new RESTBase(this, req);
     // Remember the request that led to this child instance at each level, so
     // that we can provide nice error reporting and tracing.
     child._req = req;

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -182,7 +182,7 @@ RESTBase.prototype._request = function (req) {
     var self = this;
 
     req.headers = req.headers || {};
-    req.headers['request-id'] = req.headers['request-id'] || rbUtil.generateRequestId();
+    req.headers['x-request-id'] = req.headers['x-request-id'] || rbUtil.generateRequestId();
 
     // Special handling for https? requests
     if (req.uri.constructor === String && /^https?:\/\//.test(req.uri)) {

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -34,6 +34,8 @@ function RESTBase (options, req) {
         this.metrics = par.metrics;
         this._recursionDepth = par._recursionDepth + 1;
         this._priv = par._priv;
+        this._isMain = false;
+        this._reqId = par._reqId;
     } else {
         // Brand new instance
         this.log = options.log; // logging method
@@ -43,29 +45,48 @@ function RESTBase (options, req) {
         this._parent = null;
         this._req = null;
         this._recursionDepth = 0;
+        this._isMain = true;
 
         options.maxDepth = options.maxDepth || 10;
         // Private state, shared with child instances
         this._priv = {
             options: options,
-            router: options.router,
-            reqId: req ? req.headers && req.headers['x-request-id'] || rbUtil.generateRequestId() : null
+            router: options.router
         };
+    }
+
+    // set the request id, if appropriate
+    this.setRequestId(req);
+
+}
+
+// sets the request id for this instance and adds it to
+// the request header, if defined
+RESTBase.prototype.setRequestId = function(req) {
+
+    if (this._isMain) {
+        if (req && !(req.headers && req.headers['x-request-id'])) {
+            req.headers = req.headers || {};
+            req.headers['x-request-id'] = rbUtil.generateRequestId();
+        }
+        return;
     }
 
     if (req) {
         req.headers = req.headers || {};
         if (req.headers['x-request-id']) {
             // the request has got the request id header set, use that
-            this._priv.reqId = req.headers['x-request-id'];
-        } else if (!this._priv.reqId) {
+            this._reqId = req.headers['x-request-id'];
+        } else if (!this._reqId) {
             // no request id set, generate it
-            this._priv.reqId = rbUtil.generateRequestId();
+            this._reqId = rbUtil.generateRequestId();
         }
-        req.headers['x-request-id'] = this._priv.reqId;
+        req.headers['x-request-id'] = this._reqId;
+    } else if(!this._reqId) {
+        this._reqId = rbUtil.generateRequestId();
     }
 
-}
+};
 
 // Make a child instance
 RESTBase.prototype.makeChild = function(req) {
@@ -193,6 +214,9 @@ RESTBase.prototype.request = function (req) {
 // Internal request handler
 RESTBase.prototype._request = function (req) {
     var self = this;
+
+    // set the request id
+    this.setRequestId(req);
 
     // Special handling for https? requests
     if (req.uri.constructor === String && /^https?:\/\//.test(req.uri)) {

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -167,7 +167,8 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
 // Special handling for external web requests
 RESTBase.prototype.defaultWebRequestHandler = function(restbase, req) {
     this.log('trace/webrequest', {
-        req: req
+        req: req,
+        request_id: req.headers['x-request-id']
     });
     // TODO: move this out & only enable it while testing!
     // Can really set up custom handlers for test.local in the config,
@@ -290,7 +291,8 @@ RESTBase.prototype._request = function (req) {
 
             self.log('trace', {
                 req: req,
-                res: res
+                res: res,
+                request_id: req.headers['x-request-id']
             });
 
             if (!res) {

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -181,6 +181,9 @@ RESTBase.prototype.request = function (req) {
 RESTBase.prototype._request = function (req) {
     var self = this;
 
+    req.headers = req.headers || {};
+    req.headers['request-id'] = req.headers['request-id'] || rbUtil.generateRequestId();
+
     // Special handling for https? requests
     if (req.uri.constructor === String && /^https?:\/\//.test(req.uri)) {
         return this.defaultWebRequestHandler(this, req);

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -66,8 +66,7 @@ RESTBase.prototype.setRequestId = function(req) {
 
     if (this._isMain) {
         if (req && !(req.headers && req.headers['x-request-id'])) {
-            req.headers = req.headers || {};
-            req.headers['x-request-id'] = rbUtil.generateRequestId();
+            rbUtil.requestId(req);
         }
         return;
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -42,8 +42,7 @@ function handleResponse (opts, req, resp, response) {
             message: response.message,
             req: req,
             res: response,
-            stack: response.stack,
-            request_id: req.headers['x-request-id']
+            stack: response.stack
         });
 
         var body;
@@ -124,7 +123,6 @@ function handleResponse (opts, req, resp, response) {
     } else {
         opts.log('error/request', {
             req: req,
-            request_id: req.headers['x-request-id'],
             msg: "No content returned"
         });
 
@@ -146,13 +144,17 @@ function handleResponse (opts, req, resp, response) {
 function handleRequest (opts, req, resp) {
     var newReq;
 
+    // set the request ID early on for external requests
+    rbUtil.requestId(req);
+
     var reqOpts = {
         conf: opts.conf,
         logger: opts.logger.child({
             req: {
                 method: req.method.toLowerCase(),
                 uri: req.url
-            }
+            },
+            request_id: req.headers['x-request-id']
         }),
         log: null,
         metrics: opts.metrics

--- a/lib/server.js
+++ b/lib/server.js
@@ -29,6 +29,9 @@ function handleResponse (opts, req, resp, response) {
         response.headers['Access-Control-Allow-Methods'] = 'GET';
         response.headers['Access-Control-Allow-Headers'] = 'accept, content-type';
 
+        // propagate the request id header
+        response.headers['X-Request-Id'] = req.headers['x-request-id'];
+
         var logLevel = 'trace/request';
         if (response.status >= 500) {
             logLevel = 'error/request';

--- a/lib/server.js
+++ b/lib/server.js
@@ -30,7 +30,7 @@ function handleResponse (opts, req, resp, response) {
         response.headers['Access-Control-Allow-Headers'] = 'accept, content-type';
 
         // propagate the request id header
-        response.headers['X-Request-Id'] = req.headers['x-request-id'];
+        response.headers['X-Request-Id'] = opts.reqId;
 
         var logLevel = 'trace/request';
         if (response.status >= 500) {
@@ -145,7 +145,7 @@ function handleRequest (opts, req, resp) {
     var newReq;
 
     // set the request ID early on for external requests
-    rbUtil.requestId(req);
+    var reqId = req && req.headers && req.headers['x-request-id'] || rbUtil.generateRequestId();
 
     var reqOpts = {
         conf: opts.conf,
@@ -154,9 +154,10 @@ function handleRequest (opts, req, resp) {
                 method: req.method.toLowerCase(),
                 uri: req.url
             },
-            request_id: req.headers['x-request-id']
+            request_id: reqId
         }),
         log: null,
+        reqId: reqId,
         metrics: opts.metrics
     };
     reqOpts.log = reqOpts.logger.log.bind(reqOpts.logger);
@@ -182,7 +183,8 @@ function handleRequest (opts, req, resp) {
             query: urlData.query,
             method: req.method.toLowerCase(),
             headers: req.headers,
-            body: body
+            body: body,
+            reqId: reqId
         };
 
         // Quick hack to set up general CORS
@@ -250,7 +252,6 @@ function main(options) {
     // Main app startup happens during async spec loading:
     return opts.router.loadSpec(conf.spec, childRestBase)
     .then(function(router) {
-        //console.log(JSON.stringify(router.tree, null, 2));
         var server = http.createServer(handleRequest.bind(null, opts));
         // Use a large listen queue
         // Also, echo 1024 | sudo tee /proc/sys/net/core/somaxconn

--- a/lib/server.js
+++ b/lib/server.js
@@ -42,7 +42,8 @@ function handleResponse (opts, req, resp, response) {
             message: response.message,
             req: req,
             res: response,
-            stack: response.stack
+            stack: response.stack,
+            request_id: req.headers['x-request-id']
         });
 
         var body;
@@ -123,6 +124,7 @@ function handleResponse (opts, req, resp, response) {
     } else {
         opts.log('error/request', {
             req: req,
+            request_id: req.headers['x-request-id'],
             msg: "No content returned"
         });
 

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -61,4 +61,27 @@ describe('router - misc', function() {
         });
     });
 
+    it('should log the request ID for a 404', function() {
+        var reqId = '9c54ff673d634b31bb28d60aae1cb43c';
+        var slice = server.config.logStream.slice();
+        return preq.get({
+            uri: server.config.bucketURL + '/foo-bucket/Foobar',
+            headers: {
+                'X-Request-Id': reqId
+            }
+        }).then(function(res) {
+            slice.halt();
+            throw new Error('Expected a 404, got ' + res.status);
+        }, function(err) {
+            slice.halt();
+            assert.deepEqual(err.headers['x-request-id'], reqId, 'Returned request ID does not match the sent one');
+            slice.get().forEach(function(line) {
+                var a = JSON.parse(line);
+                if(a.req || a.request_id) {
+                    assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
+                }
+            });
+        });
+    });
+
 });

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -8,10 +8,10 @@ var preq   = require('preq');
 var server = require('../../utils/server.js');
 
 describe('router - misc', function() {
+
     this.timeout(20000);
 
     before(function () { return server.start(); });
-
 
     it('should deny access to /{domain}/sys', function() {
         return preq.get({
@@ -20,5 +20,45 @@ describe('router - misc', function() {
             assert.deepEqual(err.status, 403);
         });
     });
-    
+
+    it('should set a request ID for each sub-request and return it', function() {
+        var slice = server.config.logStream.slice();
+        return preq.get({
+            uri: server.config.bucketURL + '/html/Foobar',
+            headers: {
+                'Cache-Control': 'no-cache'
+            }
+        }).then(function(res) {
+            slice.halt();
+            var reqId = res.headers['x-request-id'];
+            assert.notDeepEqual(reqId, undefined, 'Request ID not returned');
+            slice.get().forEach(function(line) {
+                var a = JSON.parse(line);
+                if(a.req || a.request_id) {
+                    assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
+                }
+            });
+        });
+    });
+
+    it('should honour the provided request ID', function() {
+        var reqId = 'b6c17ea83d634b31bb28d60aae1caaac';
+        var slice = server.config.logStream.slice();
+        return preq.get({
+            uri: server.config.bucketURL + '/html/Foobar',
+            headers: {
+                'X-Request-Id': reqId
+            }
+        }).then(function(res) {
+            slice.halt();
+            assert.deepEqual(res.headers['x-request-id'], reqId, 'Returned request ID does not match the sent one');
+            slice.get().forEach(function(line) {
+                var a = JSON.parse(line);
+                if(a.req || a.request_id) {
+                    assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
+                }
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
For each request to be handled, attach a `x-request-id` header and propagate it further to child requests. This allows us to track requests throughout the system, even when RESTBase acts only as a proxy to other back-end services.

Bug: [T89562](https://phabricator.wikimedia.org/T89562)