### PR TITLE
debian: misc fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,21 @@
+restbase (0.1.6+nmu1) UNRELEASED; urgency=medium
+
+  * Non-maintainer upload.
+
+  [debian/control]
+  * Dependencies are now on their own lines
+  * Build depends on git, nodejs-legacy
+  * Depends on nodejs-legacy (/usr/bin/node symlink)
+  * Bump Debian standard from 3.9.4 to 3.9.6
+  * Bump debhelper to >= 9 to match debian/compat
+
+  [debian/restbase.install]
+  * Remove shell brace expansion, not a supported feature
+
+ -- Antoine Musso <hashar@free.fr>  Thu, 12 Mar 2015 15:26:39 +0100
+
 restbase (0.1.6) UNRELEASED; urgency=medium
 
-  * Initial version 
+  * Initial version
 
  -- Gabriel Wicke <gwicke@wikimedia.org>  Mon, 06 Oct 2014 13:18:39 -0700

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,11 @@ Source: restbase
 Section: web
 Priority: optional
 Maintainer: Gabriel Wicke <gwicke@wikimedia.org>
-Build-Depends: debhelper (>= 8.0.0), npm
-Standards-Version: 3.9.4
+Build-Depends: debhelper (>= 9),
+ git,
+ nodejs-legacy,
+ npm
+Standards-Version: 3.9.6
 Homepage: https://github.com/gwicke/restbase
 Vcs-Git: https://github.com/gwicke/restbase.git
 #Vcs-Browser: http://git.debian.org/?p=collab-maint/restbase.git;a=summary
@@ -11,7 +14,13 @@ Vcs-Git: https://github.com/gwicke/restbase.git
 Package: restbase
 # we only package amd64 for now
 Architecture: amd64
-Depends: nodejs (>=0.10.0), cassandra (>=2.0.10), logrotate, adduser, ${shlibs:Depends}, ${misc:Depends}
+Depends: adduser,
+ cassandra (>=2.0.10),
+ nodejs (>=0.10.0),
+ nodejs-legacy,
+ logrotate,
+ ${shlibs:Depends},
+ ${misc:Depends}
 Enhances: mediawiki
 Description: REST storage service and backend orchestration layer
  Distributed storage with REST interface and a flexible backend orchestration layer. See https://github.com/gwicke/restbase.

--- a/debian/restbase.install
+++ b/debian/restbase.install
@@ -2,9 +2,15 @@
 debian/settings.yaml /etc/restbase/
 
 # everything
-{lib/,node_modules/,test/,package.json,server.js} usr/lib/restbase/
+lib/          usr/lib/restbase/
+node_modules/ usr/lib/restbase/
+test/         usr/lib/restbase/
+package.json  usr/lib/restbase/
+server.js     usr/lib/restbase/
 
-{README.md,LICENSE,doc/} usr/share/doc/restbase
+README.md  usr/share/doc/restbase
+LICENSE    usr/share/doc/restbase
+doc/       usr/share/doc/restbase
 
 # include all git stuff
 # TODO: do this only in a restbase-dev package?


### PR DESCRIPTION
* Non-maintainer upload.

[debian/control]
* Dependencies are now on their own lines
* Build depends on git, nodejs-legacy
* Depends on nodejs-legacy (/usr/bin/node symlink)
* Bump Debian standard from 3.9.4 to 3.9.6
* Bump debhelper to >= 9 to match debian/compat

[debian/restbase.install]
* Remove shell brace expansion, not a supported feature

Change-Id: I5de659cf1fa65bf39dd68b0497bc371306981472