### PR TITLE
don't wrap preq HTTPError exceptions

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -189,7 +189,7 @@ function handleRequest (opts, req, resp) {
         return handleResponse(reqOpts, newReq, resp, result);
     })
     .catch (function(e) {
-        if (e && !(e instanceof rbUtil.HTTPError)) {
+        if (e && e.name !== 'HTTPError') {
             var stack = e.stack;
             e = new rbUtil.HTTPError({
                 status: 500,


### PR DESCRIPTION
preq's HTTPErrors can be treated identically to rbUtil.HTTPErrors, and
wrapping the former in the latter is causing us to lose valuable error context.

See: https://phabricator.wikimedia.org/T92356