### PR TITLE
Follow-up on request IDs

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -32,7 +32,9 @@ function RESTBase (options, req) {
         var par = this._parent = options;
         this.log = par.log;
         this.metrics = par.metrics;
-        this.reqId = req && req.headers && req.headers['x-request-id'] || req && req.reqId || par.reqId || rbUtil.generateRequestId();
+        this.reqId = par.reqId ||
+            req && req.headers && req.headers['x-request-id'] ||
+            rbUtil.generateRequestId();
         this._recursionDepth = par._recursionDepth + 1;
         this._priv = par._priv;
     } else {
@@ -64,7 +66,7 @@ RESTBase.prototype.setRequestId = function(req) {
     if(req.headers['x-request-id']) {
         return;
     }
-    req.headers['x-request-id'] = req.reqId || this.reqId;
+    req.headers['x-request-id'] = this.reqId;
 
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -145,7 +145,8 @@ function handleRequest (opts, req, resp) {
     var newReq;
 
     // set the request ID early on for external requests
-    var reqId = req && req.headers && req.headers['x-request-id'] || rbUtil.generateRequestId();
+    req.headers = req.headers || {};
+    req.headers['x-request-id'] = req.headers['x-request-id'] || rbUtil.generateRequestId();
 
     var reqOpts = {
         conf: opts.conf,
@@ -154,10 +155,10 @@ function handleRequest (opts, req, resp) {
                 method: req.method.toLowerCase(),
                 uri: req.url
             },
-            request_id: reqId
+            request_id: req.headers['x-request-id']
         }),
         log: null,
-        reqId: reqId,
+        reqId: req.headers['x-request-id'],
         metrics: opts.metrics
     };
     reqOpts.log = reqOpts.logger.log.bind(reqOpts.logger);
@@ -183,8 +184,7 @@ function handleRequest (opts, req, resp) {
             query: urlData.query,
             method: req.method.toLowerCase(),
             headers: req.headers,
-            body: body,
-            reqId: reqId
+            body: body
         };
 
         // Quick hack to set up general CORS


### PR DESCRIPTION
- set the incoming request's `x-request-id` header and use it to simplify req ID retrieval logic
- minor style fix