### PR TITLE
Use the PHP API for revision and title listings

### DIFF
--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -122,28 +122,32 @@ PRS.prototype._checkRevReturn = function(res) {
 PRS.prototype.listTitles = function(restbase, req, options) {
     var rp = req.params;
     var listReq = {
-        uri: this.tableURI(rp.domain),
+        uri: new URI([rp.domain,'sys','action','query']),
+        method: 'post',
         body: {
-            table: this.tableName,
-            proj: ['title','rev'],
-            //distinct: true,
-            limit: 1000
+            generator: 'allpages',
+            gaplimit: 500,
+            prop: 'revisions',
+            format: 'json',
+            // gapcontinue: rp.next
         }
     };
 
     return restbase.get(listReq)
     .then(function(res) {
-        // Hacky distinct implementation as workaround
+        var pages = res.body.items;
         var items = [];
-        var lastTitle;
-        res.body.items.forEach(function(row) {
-            if (row.title !== lastTitle) {
-                items.push(row.title);
-                lastTitle = row.title;
-            }
+        Object.keys(pages).forEach(function(pageId) {
+            var article = pages[pageId];
+            items.push(article.title);
         });
-        res.body.items = items;
-        return res;
+
+        return {
+            status: 200,
+            body: {
+                items: items
+            }
+        };
     });
 };
 
@@ -321,28 +325,31 @@ PRS.prototype.listTitleRevisions = function(restbase, req) {
 PRS.prototype.listRevisions = function(restbase, req) {
     var rp = req.params;
     var listReq = {
-        uri: this.tableURI(rp.domain),
+        uri: new URI([rp.domain,'sys','action','query']),
+        method: 'post',
         body: {
-            table: this.tableName,
-            index: 'by_rev',
-            proj: ['rev','tid'],
-            //distinct: true,
-            limit: 1000
+            generator: 'allpages',
+            gaplimit: 500,
+            prop: 'revisions',
+            format: 'json',
+            // gapcontinue: rp.next
         }
     };
     return restbase.get(listReq)
     .then(function(res) {
-        // Hacky distinct implementation as workaround
+        var pages = res.body.items;
         var items = [];
-        var lastRev;
-        res.body.items.forEach(function(row) {
-            if (row.rev !== lastRev) {
-                items.push(row.rev);
-                lastRev = row.rev;
-            }
+        Object.keys(pages).forEach(function(pageId) {
+            var article = pages[pageId];
+            items.push(article.revisions[0].revid);
         });
-        res.body.items = items;
-        return res;
+
+        return {
+            status: 200,
+            body: {
+                items: items
+            }
+        };
     });
 };
 

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -109,7 +109,12 @@ describe('item requests', function() {
        .then(function(res) {
            assert.deepEqual(res.status, 200);
            assert.contentType(res, 'application/json');
-           assert.deepEqual(res.body.items, ['Foobar']);
+           if (!res.body.items || !res.body.items.length) {
+               throw new Error("Empty listing result!");
+           }
+           if (!/^!/.test(res.body.items[0])) {
+               throw new Error("Expected the first titles to start with !");
+           }
        });
     });
 

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -95,14 +95,12 @@ describe('revision requests', function() {
        .then(function(res) {
            assert.deepEqual(res.status, 200);
 			assert.contentType(res, 'application/json');
-			// at least the revisions from this test file
-			// should be present in storage
-			assert.deepEqual(res.body.items.some(function(revId) {
-				return revId === revOk;
-			}), true);
-			assert.deepEqual(res.body.items.some(function(revId) {
-				return revId === revDeleted;
-			}), true);
+            if (!res.body.items || !res.body.items.length) {
+                throw new Error("No revisions returned!");
+            }
+            if (typeof res.body.items[0] !== 'number') {
+                throw new Error("Expected a numeric revision id!");
+            }
        });
     });
 


### PR DESCRIPTION
We ran into issues with Cassandra's native secondary indexes. Large (>64k
IIRC) non-index column values caused inserts to fail with an index on one of
the partition keys. We only used them for fairly hacky listings anyway, so
decided to drop them in restbase-mod-table-cassandra recently (see https://github.com/wikimedia/restbase-mod-table-cassandra/pull/89).

This patch switches the existing listing to use the PHP API instead. This
gives us time to implement this more cleanly in both the interface & the
backend while still allowing users to discover titles for testing & providing
a glimpse of the direction we are heading in.