### PR TITLE
Pass previous / current revision's content to Parsoid

### DIFF
--- a/mods/parsoid.yaml
+++ b/mods/parsoid.yaml
@@ -12,6 +12,9 @@ paths:
     get:
       summary: Retrieve a JSON bundle containing html and data-parsoid
       operationId: getPageBundle
+    post:
+      summary: Retrieve a JSON bundle containing html and data-parsoid
+      operationId: getPageBundle
   
   /wikitext/{title}/:
     get:

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -13,6 +13,7 @@ var fs     = require('fs');
 
 var revA = '45451075';
 var revB = '623616192';
+var revC = '645915794';
 var title = 'LCX';
 var pageUrl = server.config.bucketURL;
 
@@ -102,14 +103,15 @@ describe('on-demand generation of html and data-parsoid', function() {
         });
     });
 
-    it('should pass (stored) data-parsoid revision B to Parsoid for cache-control:no-cache',
+    it('should pass (stored) revision B content to Parsoid for template update',
     function () {
         // Start watching for new log entries
         var slice = server.config.logStream.slice();
         return preq.get({
             uri: pageUrl + '/data-parsoid/' + title + '/' + revB,
             headers: {
-                'cache-control': 'no-cache'
+                'cache-control': 'no-cache',
+				'x-restbase-mode': 'templates'
             },
         })
         .then(function (res) {
@@ -120,7 +122,89 @@ describe('on-demand generation of html and data-parsoid', function() {
             assert.deepEqual(typeof res.body, 'object');
             assert.localRequests(slice, false);
             assert.remoteRequests(slice, true);
+			var parsoidRequest = assert.findParsoidRequest(slice);
+			assert.deepEqual(parsoidRequest.method, 'post');
+			var prBody = parsoidRequest.body;
+			assert.deepEqual(prBody.update, 'templates');
+			assert.deepEqual(prBody.original.revid, revB);
+			if (!prBody.original.html.body) {
+				throw new Error('Missing original html body in parsoid request');
+			}
+			if (!prBody.original['data-parsoid'].body) {
+				throw new Error('Missing original html body in parsoid request');
+			}
         });
     });
+
+    it('should pass (stored) revision B content to Parsoid for image update',
+    function () {
+        // Start watching for new log entries
+        var slice = server.config.logStream.slice();
+        return preq.get({
+            uri: pageUrl + '/html/' + title + '/' + revB,
+            headers: {
+                'cache-control': 'no-cache',
+				'x-restbase-mode': 'images'
+            },
+        })
+        .then(function (res) {
+            // Stop watching for new log entries
+            slice.halt();
+            assert.contentType(res,
+              'text/html;profile=mediawiki.org/specs/html/1.0.0');
+            if (!/<html/.test(res.body)) {
+				throw new Error("Expected html content!");
+			}
+            assert.localRequests(slice, false);
+            assert.remoteRequests(slice, true);
+			var parsoidRequest = assert.findParsoidRequest(slice);
+			assert.deepEqual(parsoidRequest.method, 'post');
+			var prBody = parsoidRequest.body;
+			assert.deepEqual(prBody.update, 'images');
+			assert.deepEqual(prBody.original.revid, revB);
+			if (!prBody.original.html.body) {
+				throw new Error('Missing original html body in parsoid request');
+			}
+			if (!prBody.original['data-parsoid'].body) {
+				throw new Error('Missing original html body in parsoid request');
+			}
+        });
+    });
+
+    it('should pass (stored) revision B content to Parsoid for edit update',
+    function () {
+        // Start watching for new log entries
+        var slice = server.config.logStream.slice();
+        return preq.get({
+            uri: pageUrl + '/html/' + title + '/' + revC,
+            headers: {
+                'cache-control': 'no-cache',
+				'x-restbase-parentrevision': revB
+            },
+        })
+        .then(function (res) {
+            // Stop watching for new log entries
+            slice.halt();
+            assert.contentType(res,
+              'text/html;profile=mediawiki.org/specs/html/1.0.0');
+            if (!/<html/.test(res.body)) {
+				throw new Error("Expected html content!");
+			}
+            assert.localRequests(slice, false);
+            assert.remoteRequests(slice, true);
+			var parsoidRequest = assert.findParsoidRequest(slice);
+			assert.deepEqual(parsoidRequest.method, 'post');
+			var prBody = parsoidRequest.body;
+			assert.deepEqual(prBody.update, undefined);
+			assert.deepEqual(prBody.previous.revid, revB);
+			if (!prBody.previous.html.body) {
+				throw new Error('Missing original html body in parsoid request');
+			}
+			if (!prBody.previous['data-parsoid'].body) {
+				throw new Error('Missing original html body in parsoid request');
+			}
+        });
+    });
+
 
 });

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -111,7 +111,7 @@ describe('on-demand generation of html and data-parsoid', function() {
             uri: pageUrl + '/data-parsoid/' + title + '/' + revB,
             headers: {
                 'cache-control': 'no-cache',
-				'x-restbase-mode': 'templates'
+                'x-restbase-mode': 'templates'
             },
         })
         .then(function (res) {
@@ -122,17 +122,17 @@ describe('on-demand generation of html and data-parsoid', function() {
             assert.deepEqual(typeof res.body, 'object');
             assert.localRequests(slice, false);
             assert.remoteRequests(slice, true);
-			var parsoidRequest = assert.findParsoidRequest(slice);
-			assert.deepEqual(parsoidRequest.method, 'post');
-			var prBody = parsoidRequest.body;
-			assert.deepEqual(prBody.update, 'templates');
-			assert.deepEqual(prBody.original.revid, revB);
-			if (!prBody.original.html.body) {
-				throw new Error('Missing original html body in parsoid request');
-			}
-			if (!prBody.original['data-parsoid'].body) {
-				throw new Error('Missing original html body in parsoid request');
-			}
+            var parsoidRequest = assert.findParsoidRequest(slice);
+            assert.deepEqual(parsoidRequest.method, 'post');
+            var prBody = parsoidRequest.body;
+            assert.deepEqual(prBody.update, 'templates');
+            assert.deepEqual(prBody.original.revid, revB);
+            if (!prBody.original.html.body) {
+                throw new Error('Missing original html body in parsoid request');
+            }
+            if (!prBody.original['data-parsoid'].body) {
+                throw new Error('Missing original html body in parsoid request');
+            }
         });
     });
 
@@ -144,7 +144,7 @@ describe('on-demand generation of html and data-parsoid', function() {
             uri: pageUrl + '/html/' + title + '/' + revB,
             headers: {
                 'cache-control': 'no-cache',
-				'x-restbase-mode': 'images'
+                'x-restbase-mode': 'images'
             },
         })
         .then(function (res) {
@@ -153,21 +153,21 @@ describe('on-demand generation of html and data-parsoid', function() {
             assert.contentType(res,
               'text/html;profile=mediawiki.org/specs/html/1.0.0');
             if (!/<html/.test(res.body)) {
-				throw new Error("Expected html content!");
-			}
+                throw new Error("Expected html content!");
+            }
             assert.localRequests(slice, false);
             assert.remoteRequests(slice, true);
-			var parsoidRequest = assert.findParsoidRequest(slice);
-			assert.deepEqual(parsoidRequest.method, 'post');
-			var prBody = parsoidRequest.body;
-			assert.deepEqual(prBody.update, 'images');
-			assert.deepEqual(prBody.original.revid, revB);
-			if (!prBody.original.html.body) {
-				throw new Error('Missing original html body in parsoid request');
-			}
-			if (!prBody.original['data-parsoid'].body) {
-				throw new Error('Missing original html body in parsoid request');
-			}
+            var parsoidRequest = assert.findParsoidRequest(slice);
+            assert.deepEqual(parsoidRequest.method, 'post');
+            var prBody = parsoidRequest.body;
+            assert.deepEqual(prBody.update, 'images');
+            assert.deepEqual(prBody.original.revid, revB);
+            if (!prBody.original.html.body) {
+                throw new Error('Missing original html body in parsoid request');
+            }
+            if (!prBody.original['data-parsoid'].body) {
+                throw new Error('Missing original html body in parsoid request');
+            }
         });
     });
 
@@ -179,7 +179,7 @@ describe('on-demand generation of html and data-parsoid', function() {
             uri: pageUrl + '/html/' + title + '/' + revC,
             headers: {
                 'cache-control': 'no-cache',
-				'x-restbase-parentrevision': revB
+                'x-restbase-parentrevision': revB
             },
         })
         .then(function (res) {
@@ -188,21 +188,21 @@ describe('on-demand generation of html and data-parsoid', function() {
             assert.contentType(res,
               'text/html;profile=mediawiki.org/specs/html/1.0.0');
             if (!/<html/.test(res.body)) {
-				throw new Error("Expected html content!");
-			}
+                throw new Error("Expected html content!");
+            }
             assert.localRequests(slice, false);
             assert.remoteRequests(slice, true);
-			var parsoidRequest = assert.findParsoidRequest(slice);
-			assert.deepEqual(parsoidRequest.method, 'post');
-			var prBody = parsoidRequest.body;
-			assert.deepEqual(prBody.update, undefined);
-			assert.deepEqual(prBody.previous.revid, revB);
-			if (!prBody.previous.html.body) {
-				throw new Error('Missing original html body in parsoid request');
-			}
-			if (!prBody.previous['data-parsoid'].body) {
-				throw new Error('Missing original html body in parsoid request');
-			}
+            var parsoidRequest = assert.findParsoidRequest(slice);
+            assert.deepEqual(parsoidRequest.method, 'post');
+            var prBody = parsoidRequest.body;
+            assert.deepEqual(prBody.update, undefined);
+            assert.deepEqual(prBody.previous.revid, revB);
+            if (!prBody.previous.html.body) {
+                throw new Error('Missing original html body in parsoid request');
+            }
+            if (!prBody.previous['data-parsoid'].body) {
+                throw new Error('Missing original html body in parsoid request');
+            }
         });
     });
 

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -48,6 +48,17 @@ function remoteRequests(slice, expected) {
     );
 }
 
+/**
+ * Finds the first request to parsoid
+ */
+function findParsoidRequest(slice) {
+    var logEntry = slice.get().find(function(line) {
+            var entry = JSON.parse(line);
+            return entry.req && /^http:\/\/parsoid/.test(entry.req.uri);
+    });
+    return JSON.parse(logEntry).req;
+}
+
 function isDeepEqual(result, expected, message) {
     try {
         if (typeof expected === 'string') {
@@ -123,4 +134,5 @@ module.exports.isSuperset     = isSuperset;
 module.exports.contentType    = contentType;
 module.exports.localRequests  = localRequests;
 module.exports.remoteRequests = remoteRequests;
+module.exports.findParsoidRequest = findParsoidRequest;
 


### PR DESCRIPTION
Parsoid implements several optimizations based on the reuse of existing HTML
content. For example, it reuses template expansions when only images need to
be updated, or vice versa. It also user a previous revision's template
expansions in the rendering of a successor revision.

This patch implements passing this information from RESTBase to Parsoid in a
JSON POST request.

Bug: https://phabricator.wikimedia.org/T92972