### PR TITLE
Bump service-runner version to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "preq": "~0.3.6",
     "request": "^2.44.0",
     "restbase-mod-table-cassandra": "^0.5.3",
-    "service-runner": "^0.1.4",
+    "service-runner": "^0.1.6",
     "swagger-router": "^0.0.4",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "url-template": "2.0.4",


### PR DESCRIPTION
Bumping the version as it contains the switch from TXStatsD to statsite.

Bug: [T94053](https://phabricator.wikimedia.org/T94053)