### PR TITLE
Add security headers

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -24,13 +24,31 @@ function handleResponse (opts, req, resp, response) {
             response.headers = {};
         }
 
+        var rh = response.headers;
+
         // Set up CORS
-        response.headers['Access-Control-Allow-Origin'] = '*';
-        response.headers['Access-Control-Allow-Methods'] = 'GET';
-        response.headers['Access-Control-Allow-Headers'] = 'accept, content-type';
+        rh['Access-Control-Allow-Origin'] = '*';
+        rh['Access-Control-Allow-Methods'] = 'GET';
+        rh['Access-Control-Allow-Headers'] = 'accept, content-type';
+
+        // Set up security headers
+        // https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+        rh['X-Content-Type-Options'] = 'nosniff';
+        rh['X-Frame-Options'] = 'SAMEORIGIN';
+
+        if (!/^application\/json/.test(rh['content-type'])) {
+            rh['X-XSS-Protection'] = '1; mode=block';
+            rh['Content-Security-Policy'] =
+                "default-src 'none'; media-src *; img-src *; style-src *; frame-ancestors 'self'";
+            // For IE 10 & 11
+            rh['X-Content-Security-Policy'] = rh['Content-Security-Policy'];
+            // For Chrome <= v25 (seems to be <1% traffic; should we still
+            // care?)
+            rh['X-WebKit-CSP'] = rh['Content-Security-Policy'];
+        }
 
         // propagate the request id header
-        response.headers['X-Request-Id'] = opts.reqId;
+        rh['X-Request-Id'] = opts.reqId;
 
         var logLevel = 'trace/request';
         if (response.status >= 500) {


### PR DESCRIPTION
In modern browsers these headers help to avoid some of the most common
client-side security issues even if we missed something in our HTML and SVG
sanitization code.

Bug: https://phabricator.wikimedia.org/T95443