### PR TITLE
Provide page id and revision timestamp in revision data end point

### DIFF
--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -198,7 +198,7 @@ PRS.prototype.fetchAndStoreMWRevision = function (restbase, req) {
         });
 
         //get the redirect property, it's inclusion means true
-        var redirect = typeof dataResp.redirect !== "undefined" ? true : false;
+        var redirect = dataResp.redirect !== undefined;
 
         return restbase.put({ // Save / update the revision entry
             uri: self.tableURI(rp.domain),

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -658,6 +658,9 @@ definitions:
         items:
           title:
             type: string
+          page_id:
+            type: integer
+            format: int32            
           rev:
             type: integer
             format: int32
@@ -689,4 +692,8 @@ definitions:
             format: int32
           user_text:
             type: string
+          timestamp:
+            type: timestamp
+          redirect:
+            type: boolean  
 

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -12,7 +12,7 @@ describe('revision requests', function() {
 
 	var revOk = 642497713;
 	var revDeleted = 645504917;
-    var revRedirect = 591082967;
+	var revRedirect = 591082967;
 
     this.timeout(20000);
 

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -12,6 +12,7 @@ describe('revision requests', function() {
 
 	var revOk = 642497713;
 	var revDeleted = 645504917;
+    var revRedirect = 591082967;
 
     this.timeout(20000);
 
@@ -24,6 +25,18 @@ describe('revision requests', function() {
             assert.deepEqual(res.body.items.length, 1);
             assert.deepEqual(res.body.items[0].rev, revOk);
             assert.deepEqual(res.body.items[0].title, 'Foobar');
+            assert.deepEqual(res.body.items[0].page_id, '11178');
+            assert.deepEqual(res.body.items[0].redirect, false);
+        });
+    });
+
+    it('should return redirect true when included', function() {
+        return preq.get({ uri: server.config.bucketURL + '/revision/' + revRedirect })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, revRedirect);
+            assert.deepEqual(res.body.items[0].redirect, true);
         });
     });
 


### PR DESCRIPTION
Relating to changes described in:
https://phabricator.wikimedia.org/T95364