### PR TITLE
explicity assign schema version

### DIFF
--- a/mods/key_rev_value.js
+++ b/mods/key_rev_value.js
@@ -57,7 +57,8 @@ KRVBucket.prototype.makeSchema = function (opts) {
             { attribute: 'key', type: 'hash' },
             { attribute: 'rev', type: 'range', order: 'desc' },
             { attribute: 'tid', type: 'range', order: 'desc' }
-        ]
+        ],
+        version: 1
     };
 };
 

--- a/mods/key_value.js
+++ b/mods/key_value.js
@@ -52,7 +52,8 @@ KVBucket.prototype.makeSchema = function (opts) {
                 { attribute: 'key', type: 'hash' },
                 { attribute: 'latestTid', type: 'static' },
                 { attribute: 'tid', type: 'range', order: 'desc' }
-            ]
+            ],
+            version: 1
         };
     } else {
         throw new Error('Bucket type ' + opts.type + ' not yet implemented');

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -86,7 +86,8 @@ PRS.prototype.getTableSchema = function () {
                 { attribute: 'rev', type: 'range', order: 'desc' },
                 { attribute: 'tid', type: 'range', order: 'desc' }
             ]
-        }
+        },
+        version: 1
     };
 };
 


### PR DESCRIPTION
This should be a non-normative change for existing installations as
historically, an undefined version defaulted to 1.

This is made necessary by https://github.com/wikimedia/restbase-mod-table-cassandra/pull/95.

Bug: T96612