### PR TITLE
Fix reference to req.uri

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -92,7 +92,7 @@ function handleResponse (opts, req, resp, response) {
                 }
             }
             if (response.status >= 400) {
-                if (!body.uri) { body.uri = req.url; }
+                if (!body.uri) { body.uri = req.uri; }
                 if (!body.method) { body.method = req.method; }
             }
             if (!body.type) {


### PR DESCRIPTION
We are working on an internal request here, so use req.uri instead of req.url.