### PR TITLE
content-security-policy headers breakage

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -43,8 +43,10 @@ function handleResponse (opts, req, resp, response) {
 
         if (!/^application\/json/.test(rh['content-type'])) {
             rh['X-XSS-Protection'] = '1; mode=block';
-            rh['Content-Security-Policy'] =
-                "default-src 'none'; media-src *; img-src *; style-src *; frame-ancestors 'self'";
+            if (!rh['Content-Security-Policy']) {
+                rh['Content-Security-Policy'] =
+                    "default-src 'none'; media-src *; img-src *; style-src *; frame-ancestors 'self'";
+            }
             // For IE 10 & 11
             rh['X-Content-Security-Policy'] = rh['Content-Security-Policy'];
             // For Chrome <= v25 (seems to be <1% traffic; should we still

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -37,6 +37,7 @@ function staticServe (restbase, req) {
             status: 200,
             headers: {
                 'content-type': contentType,
+                'Content-Security-Policy': "default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self';"
             },
             body: body
         });


### PR DESCRIPTION
The recent addition of restrictive default CSP headers rendered the online
HTML documentation inoperative.  This changeset:

* does not assign the defaults if the header has already been set
* sets a specialized CSP header in ?doc responses

The ?doc response header here is:
```
default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self';
```
`script-src` and `style-src` both use `unsafe-inline` because the docs use inline javascript and css.  `connect-src` is needed for fetching the spec.

See: https://phabricator.wikimedia.org/T97185