### PR TITLE
Support rewriting the base path for host-based access & proxying

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -85,12 +85,19 @@ RESTBase.prototype.makeChild = function(req) {
 RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
     var rq = req.query;
     if (rq.spec !== undefined && value.specRoot) {
+        var spec = Object.assign({}, value.specRoot, {
+            // Set the base path dynamically
+            basePath: req.uri.toString().replace(/\/$/, '')
+        });
+
+        if (req.params.domain === req.headers.host.replace(/:[0-9]+$/,'')) {
+            // This is a host-based request. Set an appropriate base path.
+            spec.basePath = spec['x-host-basePath'] || '';
+        }
+
         return P.resolve({
             status: 200,
-            body: Object.assign({}, value.specRoot, {
-                // Set the base path dynamically
-                basePath: req.uri.toString().replace(/\/$/, '')
-            })
+            body: spec
         });
     } else if (rq.doc !== undefined) {
         // Return swagger UI & load spec from /?spec

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -46,4 +46,3 @@ function staticServe (restbase, req) {
 
 
 module.exports = staticServe;
-


### PR DESCRIPTION
We now expose the docs at /api/rest_v1/, so need the ability to set the right
base path for host-based and rewritten requests.