### PR TITLE
Provide full version in etag headers

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -177,4 +177,26 @@ rbUtil.httpErrors = {
 };
 
 
+// Create an etag value of the form
+// "<revision>/<tid>"
+rbUtil.makeETag = function(rev, tid) {
+    return '"' + rev + '/' + tid + '"';
+};
+
+// Parse an etag value of the form
+// "<revision>/<tid>"
+// @param {string} etag
+// @return {object} with params rev / tid
+rbUtil.parseETag = function(etag) {
+    var bits = /^"?([^"\/]+)(?:\/([^"\/]+))"?$/.exec(etag);
+    if (bits) {
+        return {
+            rev: bits[1],
+            tid: bits[2],
+        };
+    } else {
+        return null;
+    }
+};
+
 module.exports = rbUtil;

--- a/mods/key_rev_value.js
+++ b/mods/key_rev_value.js
@@ -125,7 +125,7 @@ function returnRevision(req) {
         if (dbResult.body && dbResult.body.items && dbResult.body.items.length) {
             var row = dbResult.body.items[0];
             var headers = {
-                etag: row.tid,
+                etag: rbUtil.makeETag(row.rev, row.tid),
                 'content-type': row['content-type']
             };
             return {
@@ -268,7 +268,7 @@ KRVBucket.prototype.putRevision = function(restbase, req) {
             return {
                 status: 201,
                 headers: {
-                    etag: rp.revision
+                    etag: rbUtil.makeETag(rp.revision, tid),
                 },
                 body: {
                     message: "Created.",

--- a/mods/key_value.js
+++ b/mods/key_value.js
@@ -123,7 +123,7 @@ function returnRevision(req) {
         if (dbResult.body && dbResult.body.items && dbResult.body.items.length) {
             var row = dbResult.body.items[0];
             var headers = {
-                etag: row.tid,
+                etag: rbUtil.makeETag(row.rev, row.tid),
                 'content-type': row['content-type']
             };
             return {
@@ -255,7 +255,7 @@ KVBucket.prototype.putRevision = function(restbase, req) {
             return {
                 status: 201,
                 headers: {
-                    etag: tid
+                    etag: rbUtil.makeETag(rp.revision, tid)
                 },
                 body: {
                     message: "Created.",

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -286,7 +286,8 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
         if (!res.headers) {
             res.headers = {};
         }
-        res.headers.etag = res.body.items[0].tid;
+        var info = res.body.items[0];
+        res.headers.etag = rbUtil.makeETag(info.rev, info.tid);
         return res;
     });
     // TODO: handle other revision formats (tid)


### PR DESCRIPTION
Clients like the Content Translation service need a generic way to figure out
the revision they received when using end points that aren't revision-based.
Parsoid provided a private header (x-content-revision) for this so far, but in
RB it is preferable to use standard headers instead. In HTTP, revision IDs are
normally provided in the ETag header. We already passed the timeuuid in the
ETag header, but left out the revision so far.

This patch changes the format of our ETag header to include the revision in
addition to the tid, separated by a slash:

ETag: "123456/c4e494da-ee8f-11e4-83a1-8b80de1cde5f"

This provides content-independent version information that's reasonably simple
to parse. Quotes are required by the ETag spec (to do with the w/ prefix for
weak identifiers), sorry about that.

Bug: T97393