### PR TITLE
configure revision retention on parsoid.html/data-parsoid

### DIFF
--- a/mods/key_rev_value.js
+++ b/mods/key_rev_value.js
@@ -30,8 +30,9 @@ KRVBucket.prototype.getBucketInfo = function(restbase, req, options) {
 };
 
 KRVBucket.prototype.makeSchema = function (opts) {
-    opts.schemaVersion = 1;
-    return {
+    var schemaVersionMajor = 1;
+
+    var schema =  {
         options: {
             compression: [
                 {
@@ -57,8 +58,17 @@ KRVBucket.prototype.makeSchema = function (opts) {
             { attribute: 'key', type: 'hash' },
             { attribute: 'rev', type: 'range', order: 'desc' },
             { attribute: 'tid', type: 'range', order: 'desc' }
-        ]
+        ],
     };
+
+    if (opts.revisionRetentionPolicy) {
+        schema.revisionRetentionPolicy = opts.revisionRetentionPolicy;
+    }
+    if (opts.version) {
+        schema.version = schemaVersionMajor + opts.version;
+    }
+
+    return schema;
 };
 
 KRVBucket.prototype.createBucket = function(restbase, req) {

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -485,7 +485,13 @@ module.exports = function (options) {
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.html',
                 body: {
+                    revisionRetentionPolicy: {
+                        type: 'latest',
+                        count: 1,
+                        grace_ttl: 86400
+                    },
                     valueType: 'blob',
+                    version: 1,
                 }
             },
             {
@@ -497,7 +503,13 @@ module.exports = function (options) {
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.data-parsoid',
                 body: {
+                    revisionRetentionPolicy: {
+                        type: 'latest',
+                        count: 1,
+                        grace_ttl: 86400
+                    },
                     valueType: 'json',
+                    version: 1,
                 }
             },
             {


### PR DESCRIPTION
Parametizes `version` and `revisionRetentionPolicy` for key_rev_value clients.

Creates a schema version that is the sum of a key_rev_value schema major
version, and the client-supplied minor.  Only migrates schemas to this
scheme when clients explicitly pass a version.

Bug: T94524