### PR TITLE
Minor fix: Parse the body to JSON only if it's defined

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -218,7 +218,7 @@ function handleRequest (opts, req, resp) {
     // Then process the request
     .then(function(body) {
 
-        if (/^application\/json/i.test(req.headers['content-type'])) {
+        if (req.body && /^application\/json/i.test(req.headers['content-type'])) {
             try {
                 body = JSON.parse(req.body.toString());
             } catch (e) {


### PR DESCRIPTION
When the application/json header is received from a client, the request's body is parsed to JSON. However, this should be done only if the body contains a string to be parsed.