### PR TITLE
Page save module

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -113,6 +113,11 @@ templates:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
 
+      /{module:page_save}:
+        x-modules:
+          - name: page_save
+            type: file
+
 #      /{module:revscore}:
 #        title: Simple revscore service wrapper
 #        x-modules:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -126,6 +126,11 @@ templates:
                         uri: /{domain}/sys/key_value/testservice.test/{key}
 
 
+      /{module:page_save}:
+        x-modules:
+          - name: page_save
+            type: file
+
   wp-default-1.0.0: &wp/default/1.0.0
     x-subspecs:
       - paths:

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -157,25 +157,6 @@ util.inherits(HTTPError, Error);
 
 rbUtil.HTTPError = HTTPError;
 
-rbUtil.httpErrors = {
-    notFound: function(description) {
-        return new HTTPError({
-            status: 404,
-            type: 'notfound',
-            title: 'Not found',
-            description: description
-        });
-    },
-    server: function(description) {
-        return new HTTPError({
-            status: 500,
-            type: 'server',
-            title: 'Server error',
-            description: description
-        });
-    }
-};
-
 
 // Create an etag value of the form
 // "<revision>/<tid>"

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -180,11 +180,18 @@ rbUtil.parseETag = function(etag) {
     }
 };
 
+
+/***
+ * MediaWiki-specific functions
+ * TODO: Move them out in a separate file
+ ***/
+
 // Store titles as MediaWiki db keys
 // @param {string} title
 // @return {string} normalised title
 rbUtil.normalizeTitle = function(title) {
     return title.replace(/ /g, '_');
 };
+
 
 module.exports = rbUtil;

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -199,4 +199,11 @@ rbUtil.parseETag = function(etag) {
     }
 };
 
+// Store titles as MediaWiki db keys
+// @param {string} title
+// @return {string} normalised title
+rbUtil.normalizeTitle = function(title) {
+    return title.replace(/ /g, '_');
+};
+
 module.exports = rbUtil;

--- a/mods/action.js
+++ b/mods/action.js
@@ -119,25 +119,24 @@ function apiError(apiErr) {
 
 function buildQueryResponse(res) {
     if (res.status !== 200) {
-        throw rbUtil.httpErrors.server('Unexpected response status (' + res.status + ') from the PHP action API.');
+        throw apiError({info: 'Unexpected response status (' + res.status + ') from the PHP action API.'});
     } else if(!res.body || res.body.error) {
         throw apiError((res.body || {}).error);
     } else if (!res.body.query || !res.body.query.pages) {
-        throw rbUtil.httpErrors.server('Missing query pages from the PHP action API response.');
-    } else {
-        // Rewrite res.body
-        // XXX: Rethink!
-        var pages = res.body.query.pages;
-        var newBody = Object.keys(pages).map(function(key) {
-            return pages[key];
-        });
-        // XXX: Clean this up!
-        res.body = {
-            items: newBody,
-            next: res.body["query-continue"]
-        };
-        return res;
+        throw apiError({info: 'Missing query pages from the PHP action API response.'});
     }
+    // Rewrite res.body
+    // XXX: Rethink!
+    var pages = res.body.query.pages;
+    var newBody = Object.keys(pages).map(function(key) {
+        return pages[key];
+    });
+    // XXX: Clean this up!
+    res.body = {
+        items: newBody,
+        next: res.body["query-continue"]
+    };
+    return res;
 }
 
 function buildEditResponse(res) {
@@ -160,7 +159,7 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     body.formatversion = body.formatversion || defBody.formatversion || 1;
     req.method = 'post';
     return restbase[req.method](req).then(cont);
-}
+};
 
 ActionService.prototype.query = function(restbase, req) {
     return this._doRequest(restbase, req, {

--- a/mods/action.js
+++ b/mods/action.js
@@ -145,8 +145,7 @@ function buildEditResponse(res) {
     } else if (!res.body || res.body.error) {
         throw apiError((res.body || {}).error);
     }
-    res.body = undefined;
-    res.status = 201;
+    res.body = res.body.edit;
     return res;
 }
 

--- a/mods/action.js
+++ b/mods/action.js
@@ -19,6 +19,7 @@ var errDefs = {
     '500': { status: 500, type: 'server_error' },
     '501': { status: 501, type: 'not_supported' }
 };
+
 var errCodes = {
     /* 400 - bad request */
     'articleexists': errDefs['400'],
@@ -79,6 +80,7 @@ var errCodes = {
     /* 501 - not supported */
     'editnotsupported': errDefs['501']
 };
+
 function apiError(apiErr) {
     var ret;
     apiErr = apiErr || {};
@@ -98,6 +100,7 @@ function apiError(apiErr) {
     return new rbUtil.HTTPError(ret);
 }
 
+
 /**
  * Action module code
  */
@@ -106,8 +109,6 @@ function ActionService (options) {
 }
 
 ActionService.prototype.apiURI = function(domain) {
-    // Re-map test domain
-    if(domain === 'en.wikipedia.test.local') { domain = 'en.wikipedia.org'; }
     // TODO: use proper templating
     return this.apiURITemplate.replace(/\{domain\}/, domain);
 };

--- a/mods/action.js
+++ b/mods/action.js
@@ -106,6 +106,8 @@ function ActionService (options) {
 }
 
 ActionService.prototype.apiURI = function(domain) {
+    // Re-map test domain
+    if(domain === 'en.wikipedia.test.local') { domain = 'en.wikipedia.org'; }
     // TODO: use proper templating
     return this.apiURITemplate.replace(/\{domain\}/, domain);
 };

--- a/mods/action.js
+++ b/mods/action.js
@@ -6,6 +6,101 @@
 
 var rbUtil = require('../lib/rbUtil');
 
+/**
+ * Error translation
+ */
+var errDefs = {
+    '400': { status: 400, type: 'invalid_request' },
+    '401': { status: 401, type: 'unauthorized' },
+    '403': { status: 403, type: 'access_denied#edit' },
+    '409': { status: 409, type: 'conflict' },
+    '413': { status: 413, type: 'too_large' },
+    '429': { status: 429, type: 'rate_exceeded' },
+    '500': { status: 500, type: 'server_error' },
+    '501': { status: 501, type: 'not_supported' }
+};
+var errCodes = {
+    /* 400 - bad request */
+    'articleexists': errDefs['400'],
+    'badformat': errDefs['400'],
+    'badmd5': errDefs['400'],
+    'badtoken': errDefs['400'],
+    'invalidparammix': errDefs['400'],
+    'invalidsection': errDefs['400'],
+    'invalidtitle': errDefs['400'],
+    'invaliduser': errDefs['400'],
+    'missingparam': errDefs['400'],
+    'missingtitle': errDefs['400'],
+    'nosuchpageid': errDefs['400'],
+    'nosuchrcid': errDefs['400'],
+    'nosuchrevid': errDefs['400'],
+    'nosuchsection': errDefs['400'],
+    'nosuchuser': errDefs['400'],
+    'notext': errDefs['400'],
+    'notitle': errDefs['400'],
+    'pagecannotexist': errDefs['400'],
+    'revwrongpage': errDefs['400'],
+    /* 401 - unauthorised */
+    'cantcreate-anon': errDefs['401'],
+    'confirmemail': errDefs['401'],
+    'noedit-anon': errDefs['401'],
+    'noimageredirect-anon': errDefs['401'],
+    'protectedpage': errDefs['401'],
+    'readapidenied': errDefs['401'],
+    /* 403 - access denied */
+    'autoblocked': errDefs['403'],
+    'blocked': errDefs['403'],
+    'cantcreate': errDefs['403'],
+    'customcssjsprotected': errDefs['403'],
+    'customcssprotected': errDefs['403'],
+    'customjsprotected': errDefs['403'],
+    'emptynewsection': errDefs['403'],
+    'emptypage': errDefs['403'],
+    'filtered': errDefs['403'],
+    'hookaborted': errDefs['403'],
+    'noedit': errDefs['403'],
+    'noimageredirect': errDefs['403'],
+    'permissiondenied': errDefs['403'],
+    'protectednamespace': errDefs['403'],
+    'protectednamespace-interface': errDefs['403'],
+    'protectedtitle': errDefs['403'],
+    'readonly': errDefs['403'],
+    'unsupportednamespace': errDefs['403'],
+    'writeapidenied': errDefs['403'],
+    /* 409 - conflict */
+    'cascadeprotected': errDefs['409'],
+    'editconflict': errDefs['409'],
+    'pagedeleted': errDefs['409'],
+    'spamdetected': errDefs['409'],
+    /* 413 - body too large */
+    'contenttoobig': errDefs['413'],
+    /* 429 - rate limit exceeded */
+    'ratelimited': errDefs['429'],
+    /* 501 - not supported */
+    'editnotsupported': errDefs['501']
+};
+function apiError(apiErr) {
+    var ret;
+    apiErr = apiErr || {};
+    ret = {
+        message: 'MW API call error ' + apiErr.code,
+        status: errDefs['500'].status,
+        body: {
+            type: errDefs['500'].type,
+            title: apiErr.code || 'MW API Error',
+            description: apiErr.info || 'Unknown MW API error'
+        }
+    };
+    if(apiErr.code && errCodes.hasOwnProperty(apiErr.code)) {
+        ret.status = errCodes[apiErr.code].status;
+        ret.body.type = errCodes[apiErr.code].type;
+    }
+    return new rbUtil.HTTPError(ret);
+}
+
+/**
+ * Action module code
+ */
 function ActionService (options) {
     this.apiURITemplate = options.apiURI;
 }
@@ -14,108 +109,6 @@ ActionService.prototype.apiURI = function(domain) {
     // TODO: use proper templating
     return this.apiURITemplate.replace(/\{domain\}/, domain);
 };
-
-function apiError(apiErr) {
-    var ret;
-    apiErr = apiErr || {};
-    ret = {
-        status: 500,
-        body: {
-            type: 'server_error',
-            title: apiErr.code || 'MW API Error',
-            description: apiErr.info || 'Unknown MW API error'
-        }
-    };
-    if(!apiErr.code) {
-        return new rbUtil.HTTPError(ret);
-    }
-    switch(apiErr.code) {
-        /* 400 - bad request */
-        case 'articleexists':
-        case 'badformat':
-        case 'badmd5':
-        case 'badtoken':
-        case 'invalidparammix':
-        case 'invalidsection':
-        case 'invalidtitle':
-        case 'invaliduser':
-        case 'missingparam':
-        case 'missingtitle':
-        case 'nosuchpageid':
-        case 'nosuchrcid':
-        case 'nosuchrevid':
-        case 'nosuchsection':
-        case 'nosuchuser':
-        case 'notext':
-        case 'notitle':
-        case 'pagecannotexist':
-        case 'revwrongpage':
-            ret.status = 400;
-            ret.body.type = 'invalid_request';
-            break;
-        /* 401 - unauthorised */
-        case 'cantcreate-anon':
-        case 'confirmemail':
-        case 'noedit-anon':
-        case 'noimageredirect-anon':
-        case 'protectedpage':
-        case 'readapidenied':
-            ret.status = 401;
-            ret.body.type = 'unauthorized';
-            break;
-        /* 403 - access denied */
-        case 'autoblocked':
-        case 'blocked':
-        case 'cantcreate':
-        case 'customcssjsprotected':
-        case 'customcssprotected':
-        case 'customjsprotected':
-        case 'emptynewsection':
-        case 'emptypage':
-        case 'noedit':
-        case 'noimageredirect':
-        case 'permissiondenied':
-        case 'protectednamespace':
-        case 'protectednamespace-interface':
-        case 'protectedtitle':
-        case 'readonly':
-        case 'writeapidenied':
-            ret.status = 403;
-            ret.body.type = 'access_denied#edit';
-            break;
-        /* 409 - conflict */
-        case 'cascadeprotected':
-        case 'editconflict':
-        case 'pagedeleted':
-        case 'spamdetected':
-            ret.status = 409;
-            ret.body.type = 'conflict';
-            break;
-        /* 412 - precondition failed */
-        case 'filtered':
-        case 'hookaborted':
-        case 'unsupportednamespace':
-            ret.status = 412;
-            ret.body.type = 'precondition_fail';
-            break;
-        /* 413 - body too large */
-        case 'contenttoobig':
-            ret.status = 413;
-            ret.body.type = 'too_large';
-            break;
-        /* 429 - rate limit exceeded */
-        case 'ratelimited':
-            ret.status = 429;
-            ret.body.type = 'rate_exceeded';
-            break;
-        /* 501 - not supported */
-        case 'editnotsupported':
-            ret.status = 501;
-            ret.body.type = 'not_supported';
-            break;
-    }
-    return new rbUtil.HTTPError(ret);
-}
 
 function buildQueryResponse(res) {
     if (res.status !== 200) {

--- a/mods/action.js
+++ b/mods/action.js
@@ -139,6 +139,9 @@ function buildEditResponse(res) {
         throw apiError((res.body || {}).error);
     }
     res.body = res.body.edit;
+    if(res.body && !res.body.nochange) {
+        res.status = 201;
+    }
     return res;
 }
 

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -255,7 +255,7 @@ PRS.prototype.fetchAndStoreMWRevision = function (restbase, req) {
         // if a bad revision is supplied, the action module
         // returns a 500 with the 'Missing query pages' message
         // so catch that and turn it into a 404 in our case
-        if(e.status === 500 && /^Missing query pages/.test(e.description)) {
+        if(e.status === 500 && /^Missing query pages/.test(e.body.description)) {
             throw new rbUtil.HTTPError({
                 status: 404,
                 body: {

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -21,12 +21,6 @@ var yaml = require('js-yaml');
 var spec = yaml.safeLoad(fs.readFileSync(__dirname + '/page_revisions.yaml'));
 
 
-// Store titles as MediaWiki db keys
-function normalizeTitle (title) {
-    return title.replace(/ /g, '_');
-}
-
-
 // Title Revision Service
 function PRS (options) {
     this.options = options;
@@ -222,7 +216,7 @@ PRS.prototype.fetchAndStoreMWRevision = function (restbase, req) {
                     // FIXME: if a title has been given, check it
                     // matches the one returned by the MW API
                     // cf. https://phabricator.wikimedia.org/T87393
-                    title: normalizeTitle(dataResp.title),
+                    title: rbUtil.normalizeTitle(dataResp.title),
                     page_id: parseInt(dataResp.pageid),
                     rev: parseInt(apiRev.revid),
                     tid: uuid.v1(),
@@ -286,7 +280,7 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
             body: {
                 table: this.tableName,
                 attributes: {
-                    title: normalizeTitle(rp.title),
+                    title: rbUtil.normalizeTitle(rp.title),
                     rev: parseInt(rp.revision)
                 },
                 limit: 1
@@ -326,7 +320,7 @@ PRS.prototype.listTitleRevisions = function(restbase, req) {
     var revisionRequest = {
         table: this.tableName,
         attributes: {
-            title: normalizeTitle(rp.title)
+            title: rbUtil.normalizeTitle(rp.title)
         },
         proj: ['rev'],
         limit: restbase.rb_config.default_page_size

--- a/mods/page_save.js
+++ b/mods/page_save.js
@@ -102,9 +102,6 @@ PageSave.prototype.saveWikitext = function(restbase, req) {
             },
             body: body
         });
-    }).then(function(res) {
-        res.status = 201;
-        return res;
     });
 };
 

--- a/mods/page_save.js
+++ b/mods/page_save.js
@@ -1,0 +1,102 @@
+'use strict';
+
+
+/**
+ * page_save module
+ *
+ * Sends the wikitext of a page to the MW API for saving
+ */
+
+
+var P = require('bluebird');
+var URI = require('swagger-router').URI;
+var rbUtil = require('../lib/rbUtil');
+
+
+function PageSave(options) {
+    var self = this;
+    this.log = options.log || function() {};
+    this.spec = {
+        paths: {
+            '/wikitext/{title}{/revision}': {
+                post: {
+                    operationId: 'saveWikitext'
+                }
+            }
+        }
+    };
+    this.operations = {
+        saveWikitext: self.saveWikitext.bind(self)
+    };
+}
+
+PageSave.prototype._getRevInfo = function(restbase, req) {
+    var rp = req.params;
+    var path = [rp.domain,'sys','page_revisions','page',
+                         rbUtil.normalizeTitle(rp.title)];
+    if (!/^(?:[0-9]+)$/.test(rp.revision)) {
+        throw new Error("Invalid revision: " + rp.revision);
+    }
+    path.push(rp.revision);
+    return restbase.get({
+        uri: new URI(path)
+    })
+    .then(function(res) {
+        return res.body.items[0];
+    }).catch(function(err) {
+        if(err.status != 403) {
+            throw err;
+        }
+        // we are dealing with a restricted revision
+        // however, let MW deal with it as the user
+        // might have sufficient permissions to do an edit
+        return {title: rbUtil.normalizeTitle(rp.title)};
+    });
+};
+
+PageSave.prototype.saveWikitext = function(restbase, req) {
+    var rp = req.params;
+    var promise = P.resolve({
+        title: rbUtil.normalizeTitle(rp.title)
+    });
+    if(rp.revision) {
+        promise = this._getRevInfo(restbase, req);
+    }
+    return promise.then(function(revInfo) {
+        var body = {
+            action: 'edit',
+            format: 'json',
+            formatversion: 2,
+            title: revInfo.title,
+            text: req.body.text,
+            summary: req.body.summary || 'Change text to: ' + req.body.text.substr(0, 100),
+            minor: req.body.minor,
+            bot: req.body.bot,
+            token: req.body.token
+        };
+        // we need to add each info separately
+        // since the presence of an empty value
+        // might startle the MW API
+        if(revInfo.rev) { body.parentrevid = revInfo.rev; }
+        if(revInfo.timestamp) { body.basetimestamp = revInfo.timestamp; }
+        // FIXME: use the action module instead here!
+        return restbase.post({
+            uri: 'http://' + rp.domain + '/w/api.php',
+            headers: {
+                cookie: req.headers.cookie
+            },
+            body: body
+        });
+    });
+};
+
+
+
+module.exports = function(options) {
+    var ps = new PageSave(options || {});
+    return {
+        spec: ps.spec,
+        operations: ps.operations
+    };
+};
+

--- a/mods/page_save.js
+++ b/mods/page_save.js
@@ -54,9 +54,25 @@ PageSave.prototype._getRevInfo = function(restbase, req) {
     });
 };
 
+PageSave.prototype._checkParams = function(params) {
+    console.log("\n\nPARAMS: " + JSON.stringify(params, null, 2) + "\n\n");
+    if(!(params && params.text && params.text.trim() && params.token)) {
+        throw new rbUtil.HTTPError({
+            status: 400,
+            body: {
+                type: 'invalid_request',
+                title: 'Missing parameters',
+                description: 'The text and token parameters are required'
+            }
+        });
+    }
+};
+
 PageSave.prototype.saveWikitext = function(restbase, req) {
     var rp = req.params;
-    var promise = P.resolve({
+    var promise;
+    this._checkParams(req.body);
+    promise = P.resolve({
         title: rbUtil.normalizeTitle(rp.title)
     });
     if(rp.revision) {
@@ -70,8 +86,8 @@ PageSave.prototype.saveWikitext = function(restbase, req) {
             title: revInfo.title,
             text: req.body.text,
             summary: req.body.summary || 'Change text to: ' + req.body.text.substr(0, 100),
-            minor: req.body.minor,
-            bot: req.body.bot,
+            minor: req.body.minor || false,
+            bot: req.body.bot || false,
             token: req.body.token
         };
         // we need to add each info separately

--- a/mods/page_save.js
+++ b/mods/page_save.js
@@ -69,17 +69,15 @@ PageSave.prototype._checkParams = function(params) {
 
 PageSave.prototype.saveWikitext = function(restbase, req) {
     var rp = req.params;
-    var promise;
+    var title = rbUtil.normalizeTitle(rp.title);
+    var promise = P.resolve({});
     this._checkParams(req.body);
-    promise = P.resolve({
-        title: rbUtil.normalizeTitle(rp.title)
-    });
     if(rp.revision) {
         promise = this._getRevInfo(restbase, req);
     }
     return promise.then(function(revInfo) {
         var body = {
-            title: revInfo.title,
+            title: title,
             text: req.body.text,
             summary: req.body.summary || 'Change text to: ' + req.body.text.substr(0, 100),
             minor: req.body.minor || false,

--- a/mods/page_save.js
+++ b/mods/page_save.js
@@ -44,7 +44,7 @@ PageSave.prototype._getRevInfo = function(restbase, req) {
     .then(function(res) {
         return res.body.items[0];
     }).catch(function(err) {
-        if(err.status != 403) {
+        if(err.status !== 403) {
             throw err;
         }
         // we are dealing with a restricted revision

--- a/mods/page_save.js
+++ b/mods/page_save.js
@@ -55,13 +55,13 @@ PageSave.prototype._getRevInfo = function(restbase, req) {
 };
 
 PageSave.prototype._checkParams = function(params) {
-    if(!(params && params.text && params.text.trim() && params.token)) {
+    if(!(params && params.wikitext && params.wikitext.trim() && params.token)) {
         throw new rbUtil.HTTPError({
             status: 400,
             body: {
                 type: 'invalid_request',
                 title: 'Missing parameters',
-                description: 'The text and token parameters are required'
+                description: 'The wikitexttext and token parameters are required'
             }
         });
     }
@@ -78,8 +78,8 @@ PageSave.prototype.saveWikitext = function(restbase, req) {
     return promise.then(function(revInfo) {
         var body = {
             title: title,
-            text: req.body.text,
-            summary: req.body.summary || 'Change text to: ' + req.body.text.substr(0, 100),
+            text: req.body.wikitext,
+            summary: req.body.comment || 'Change text to: ' + req.body.wikitext.substr(0, 100),
             minor: req.body.minor || false,
             bot: req.body.bot || false,
             token: req.body.token

--- a/mods/page_save.js
+++ b/mods/page_save.js
@@ -104,6 +104,9 @@ PageSave.prototype.saveWikitext = function(restbase, req) {
             },
             body: body
         });
+    }).then(function(res) {
+        res.status = 201;
+        return res;
     });
 };
 

--- a/mods/simple_service.js
+++ b/mods/simple_service.js
@@ -6,11 +6,8 @@
 
 var P = require('bluebird');
 var URI = require('swagger-router').URI;
+var rbUtil = require('../lib/rbUtil');
 
-// Store titles as MediaWiki db keys
-function normalizeTitle (title) {
-    return title.replace(/ /g, '_');
-}
 
 function SimpleService(options) {
     options = options || {};
@@ -54,7 +51,7 @@ SimpleService.prototype.processSpec = function(spec) {
             operations[conf.operationId] = function(restbase, req) {
                 var rp = req.params;
                 if (rp.key) {
-                    rp.key = normalizeTitle(rp.key);
+                    rp.key = rbUtil.normalizeTitle(rp.key);
                 }
 
                 function backendRequest() {

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -506,7 +506,7 @@ paths:
           in: path
           description: The revision of the page the edit is based on.
           type: string
-        - name: text
+        - name: wikitext
           in: formData
           description: The wikitext source of the page to save
           type: string
@@ -516,7 +516,7 @@ paths:
           description: The CRSF edit token provided by the MW API
           type: string
           required: true
-        - name: summary
+        - name: comment
           in: formData
           description: The summary of the change
           type: string

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -484,7 +484,7 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/page_revisions/rev/{revision}
 
-  /{module:page}/wikitext/{title}{/revision}:
+  /{module:page}/wikitext/{title}:
     post:
       tags:
         - Page content
@@ -503,9 +503,10 @@ paths:
           type: string
           required: true
         - name: revision
-          in: path
+          in: formData
           description: The revision of the page the edit is based on.
           type: string
+          required: false
         - name: wikitext
           in: formData
           description: The wikitext source of the page to save

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -484,6 +484,68 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/page_revisions/rev/{revision}
 
+  /{module:page}/wikitext/{title}{/revision}:
+    post:
+      tags:
+        - Page content
+        - Save
+        - Wikitext
+      description: >
+        Save a new revision of a page
+
+        For new pages, the `revision` parameter should be left empty.
+        For editing existing pages, it should contain the revision ID
+        the edit is derived from.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      parameters:
+        - name: title
+          in: path
+          description: The page title.
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: The revision of the page the edit is based on.
+        - name: text
+          in: formData
+          description: The wikitext source of the page to save
+          type: string
+          required: true
+        - name: token
+          in: formData
+          description: The CRSF edit token provided by the MW API
+          type: string
+          required: true
+        - name: summary
+          in: formData
+          description: The summary of the change
+          type: string
+          required: false
+        - name: minor
+          in: formData
+          description: Whether this represents a minor change
+          type: boolean
+          required: false
+        - name: bot
+          in: formData
+          description: Whether the change is being made by a bot
+          type: boolean
+          required: false
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: A new revision of the page has been created
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/page_save/wikitext/{title}{/revision}
+
   /{module:transform}/html/to/wikitext{/title}{/revision}:
     post:
       tags:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -488,8 +488,6 @@ paths:
     post:
       tags:
         - Page content
-        - Save
-        - Wikitext
       description: >
         Save a new revision of a page
 
@@ -538,6 +536,8 @@ paths:
       produces:
         - application/json
       responses:
+        '200':
+          description: The existing revision of the page matches the sent text
         '201':
           description: A new revision of the page has been created
         default:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -507,6 +507,7 @@ paths:
         - name: revision
           in: path
           description: The revision of the page the edit is based on.
+          type: string
         - name: text
           in: formData
           description: The wikitext source of the page to save

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -170,69 +170,69 @@ paths:
         # work in current Chrome and Firefox.
         # See also http://tools.ietf.org/html/rfc7231#section-7.1.2
         uri: /{domain}/sys/parsoid/html/{title}
-    post:
-      tags:
-        - Page content
-      description: >
-        Save a new revision of a page given in HTML format
-
-        Note that the title must exist. See [the MediaWiki DOM
-        spec](https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec) for a
-        description of the MediaWiki-specific semantic markup needed by this API
-        end-point.
-
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
-      parameters:
-        - name: title
-          in: path
-          description: The page title.
-          type: string
-          required: true
-        - name: revision
-          in: formData
-          description: The revision of the page the edit is based on.
-          type: string
-          required: false
-        - name: html
-          in: formData
-          description: The HTML of the page to save
-          type: string
-          required: true
-        - name: token
-          in: formData
-          description: The CRSF edit token provided by the MW API
-          type: string
-          required: true
-        - name: comment
-          in: formData
-          description: The summary of the change
-          type: string
-          required: false
-        - name: minor
-          in: formData
-          description: Whether this represents a minor change
-          type: boolean
-          required: false
-        - name: bot
-          in: formData
-          description: Whether the change is being made by a bot
-          type: boolean
-          required: false
-      consumes:
-        - multipart/form-data
-      produces:
-        - application/json
-      responses:
-        '200':
-          description: The existing revision of the page matches the sent text
-        '201':
-          description: A new revision of the page has been created
-        default:
-          description: Error
-          schema:
-            $ref: '#/definitions/problem'
-      x-backend-request:
-        uri: /{domain}/sys/page_save/html/{title}
+#    post:
+#      tags:
+#        - Page content
+#      description: >
+#        Save a new revision of a page given in HTML format
+#
+#        Note that the title must exist. See [the MediaWiki DOM
+#        spec](https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec) for a
+#        description of the MediaWiki-specific semantic markup needed by this API
+#        end-point.
+#
+#        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+#      parameters:
+#        - name: title
+#          in: path
+#          description: The page title.
+#          type: string
+#          required: true
+#        - name: revision
+#          in: formData
+#          description: The revision of the page the edit is based on.
+#          type: string
+#          required: false
+#        - name: html
+#          in: formData
+#          description: The HTML of the page to save
+#          type: string
+#          required: true
+#        - name: token
+#          in: formData
+#          description: The CRSF edit token provided by the MW API
+#          type: string
+#          required: true
+#        - name: comment
+#          in: formData
+#          description: The summary of the change
+#          type: string
+#          required: false
+#        - name: minor
+#          in: formData
+#          description: Whether this represents a minor change
+#          type: boolean
+#          required: false
+#        - name: bot
+#          in: formData
+#          description: Whether the change is being made by a bot
+#          type: boolean
+#          required: false
+#      consumes:
+#        - multipart/form-data
+#      produces:
+#        - application/json
+#      responses:
+#        '200':
+#          description: The existing revision of the page matches the sent text
+#        '201':
+#          description: A new revision of the page has been created
+#        default:
+#          description: Error
+#          schema:
+#            $ref: '#/definitions/problem'
+#      x-backend-request:
+#        uri: /{domain}/sys/page_save/html/{title}
 
   /{module:page}/html/{title}/:
     get:
@@ -547,69 +547,69 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/page_revisions/rev/{revision}
 
-  /{module:page}/wikitext/{title}:
-    post:
-      tags:
-        - Page content
-      description: >
-        Save a new revision of a page
-
-        For new pages, the `revision` parameter should be left empty.
-        For editing existing pages, it should contain the revision ID
-        the edit is derived from.
-
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
-      parameters:
-        - name: title
-          in: path
-          description: The page title.
-          type: string
-          required: true
-        - name: revision
-          in: formData
-          description: The revision of the page the edit is based on.
-          type: string
-          required: false
-        - name: wikitext
-          in: formData
-          description: The wikitext source of the page to save
-          type: string
-          required: true
-        - name: token
-          in: formData
-          description: The CRSF edit token provided by the MW API
-          type: string
-          required: true
-        - name: comment
-          in: formData
-          description: The summary of the change
-          type: string
-          required: false
-        - name: minor
-          in: formData
-          description: Whether this represents a minor change
-          type: boolean
-          required: false
-        - name: bot
-          in: formData
-          description: Whether the change is being made by a bot
-          type: boolean
-          required: false
-      consumes:
-        - multipart/form-data
-      produces:
-        - application/json
-      responses:
-        '200':
-          description: The existing revision of the page matches the sent text
-        '201':
-          description: A new revision of the page has been created
-        default:
-          description: Error
-          schema:
-            $ref: '#/definitions/problem'
-      x-backend-request:
-        uri: /{domain}/sys/page_save/wikitext/{title}
+#  /{module:page}/wikitext/{title}:
+#    post:
+#      tags:
+#        - Page content
+#      description: >
+#        Save a new revision of a page
+#
+#        For new pages, the `revision` parameter should be left empty.
+#        For editing existing pages, it should contain the revision ID
+#        the edit is derived from.
+#
+#        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+#      parameters:
+#        - name: title
+#          in: path
+#          description: The page title.
+#          type: string
+#          required: true
+#        - name: revision
+#          in: formData
+#          description: The revision of the page the edit is based on.
+#          type: string
+#          required: false
+#        - name: wikitext
+#          in: formData
+#          description: The wikitext source of the page to save
+#          type: string
+#          required: true
+#        - name: token
+#          in: formData
+#          description: The CRSF edit token provided by the MW API
+#          type: string
+#          required: true
+#        - name: comment
+#          in: formData
+#          description: The summary of the change
+#          type: string
+#          required: false
+#        - name: minor
+#          in: formData
+#          description: Whether this represents a minor change
+#          type: boolean
+#          required: false
+#        - name: bot
+#          in: formData
+#          description: Whether the change is being made by a bot
+#          type: boolean
+#          required: false
+#      consumes:
+#        - multipart/form-data
+#      produces:
+#        - application/json
+#      responses:
+#        '200':
+#          description: The existing revision of the page matches the sent text
+#        '201':
+#          description: A new revision of the page has been created
+#        default:
+#          description: Error
+#          schema:
+#            $ref: '#/definitions/problem'
+#      x-backend-request:
+#        uri: /{domain}/sys/page_save/wikitext/{title}
 
   /{module:transform}/html/to/wikitext{/title}{/revision}:
     post:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -170,6 +170,69 @@ paths:
         # work in current Chrome and Firefox.
         # See also http://tools.ietf.org/html/rfc7231#section-7.1.2
         uri: /{domain}/sys/parsoid/html/{title}
+    post:
+      tags:
+        - Page content
+      description: >
+        Save a new revision of a page given in HTML format
+
+        Note that the title must exist. See [the MediaWiki DOM
+        spec](https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec) for a
+        description of the MediaWiki-specific semantic markup needed by this API
+        end-point.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      parameters:
+        - name: title
+          in: path
+          description: The page title.
+          type: string
+          required: true
+        - name: revision
+          in: formData
+          description: The revision of the page the edit is based on.
+          type: string
+          required: false
+        - name: html
+          in: formData
+          description: The HTML of the page to save
+          type: string
+          required: true
+        - name: token
+          in: formData
+          description: The CRSF edit token provided by the MW API
+          type: string
+          required: true
+        - name: comment
+          in: formData
+          description: The summary of the change
+          type: string
+          required: false
+        - name: minor
+          in: formData
+          description: Whether this represents a minor change
+          type: boolean
+          required: false
+        - name: bot
+          in: formData
+          description: Whether the change is being made by a bot
+          type: boolean
+          required: false
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: The existing revision of the page matches the sent text
+        '201':
+          description: A new revision of the page has been created
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/page_save/html/{title}
 
   /{module:page}/html/{title}/:
     get:
@@ -546,7 +609,7 @@ paths:
           schema:
             $ref: '#/definitions/problem'
       x-backend-request:
-        uri: /{domain}/sys/page_save/wikitext/{title}{/revision}
+        uri: /{domain}/sys/page_save/wikitext/{title}
 
   /{module:transform}/html/to/wikitext{/title}{/revision}:
     post:
@@ -578,6 +641,7 @@ paths:
           required: true
       responses:
         '200':
+          description: The transformed wikitext
           schema: 'text/plain'
         '403':
           description: Access to the specific revision is restricted

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -7,3 +7,68 @@ paths:
     get:
       x-backend-request:
         uri: /{domain}/sys/testservice/test/{title}{/revision}
+
+  /{module:page}/wikitext/{title}:
+    post:
+      tags:
+        - Page content
+      description: >
+        Save a new revision of a page
+
+        For new pages, the `revision` parameter should be left empty.
+        For editing existing pages, it should contain the revision ID
+        the edit is derived from.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      parameters:
+        - name: title
+          in: path
+          description: The page title.
+          type: string
+          required: true
+        - name: revision
+          in: formData
+          description: The revision of the page the edit is based on.
+          type: string
+          required: false
+        - name: wikitext
+          in: formData
+          description: The wikitext source of the page to save
+          type: string
+          required: true
+        - name: token
+          in: formData
+          description: The CRSF edit token provided by the MW API
+          type: string
+          required: true
+        - name: comment
+          in: formData
+          description: The summary of the change
+          type: string
+          required: false
+        - name: minor
+          in: formData
+          description: Whether this represents a minor change
+          type: boolean
+          required: false
+        - name: bot
+          in: formData
+          description: Whether the change is being made by a bot
+          type: boolean
+          required: false
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: The existing revision of the page matches the sent text
+        '201':
+          description: A new revision of the page has been created
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/page_save/wikitext/{title}
+

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -1,0 +1,120 @@
+'use strict';
+
+
+var assert = require('../../utils/assert.js');
+var preq   = require('preq');
+var server = require('../../utils/server.js');
+
+
+describe('page save api', function() {
+
+    var uri = server.config.bucketURL + '/wikitext/User:Mobrovac-WMF%2FRB_Save_Api_Test';
+    var token;
+    var saveText = "Welcome to the page which tests the RESTBase save API!\n\n" +
+        "== Date ==\nText generated on " + new Date().toUTCString() + "\n\n" +
+        "== Random ==\nHere's a random number: " + Math.floor(Math.random() * 32768);
+    var oldRev = 666464140;
+
+    this.timeout(20000);
+
+    before(function () {
+        return server.start().then(function() {
+            return preq.get({
+                uri: 'http://en.wikipedia.org/w/api.php',
+                query: {
+                    action: 'query',
+                    meta: 'tokens',
+                    format: 'json',
+                    formatversion: 2
+                }
+            });
+        }).then(function(res) {
+            token = res.body.query.tokens.csrftoken;
+        });
+    });
+
+    it('fail for missing content', function() {
+        return preq.post({
+            uri: uri,
+            body: {
+                text: ''
+            }
+        }).then(function(res) {
+            throw new Error('Expected an error, but got status: ' + res.status);
+        }, function(err) {
+            assert.deepEqual(err.status, 400);
+            assert.deepEqual(err.body.title, 'Missing parameters');
+        });
+    });
+
+    it('fail for missing token', function() {
+        return preq.post({
+            uri: uri,
+            body: {
+                text: 'abcd'
+            }
+        }).then(function(res) {
+            throw new Error('Expected an error, but got status: ' + res.status);
+        }, function(err) {
+            assert.deepEqual(err.status, 400);
+            assert.deepEqual(err.body.title, 'Missing parameters');
+        });
+    });
+
+    it('fail for bad token', function() {
+        return preq.post({
+            uri: uri,
+            body: {
+                text: 'abcd',
+                token: 'this_is_a_bad_token'
+            }
+        }).then(function(res) {
+            throw new Error('Expected an error, but got status: ' + res.status);
+        }, function(err) {
+            assert.deepEqual(err.status, 400);
+            assert.deepEqual(err.body.title, 'badtoken');
+        });
+    });
+
+    it('save page', function() {
+        return preq.post({
+            uri: uri,
+            body: {
+                text: saveText,
+                token: token
+            }
+        }).then(function(res) {
+            assert.deepEqual(res.status, 201);
+        });
+    });
+
+    it('no change', function() {
+        return preq.post({
+            uri: uri,
+            body: {
+                text: saveText,
+                token: token
+            }
+        }).then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.nochange, true);
+        });
+    });
+
+    it('detect conflict', function() {
+        return preq.post({
+            uri: uri + '/' + oldRev,
+            body: {
+                text: saveText + "\n\nExtra text",
+                token: token
+            }
+        }).then(function(res) {
+            throw new Error('Expected an error, but got status: ' + res.status);
+        }, function(err) {
+            assert.deepEqual(err.status, 409);
+            assert.deepEqual(err.body.title, 'editconflict');
+        });
+    });
+
+});
+

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -136,6 +136,8 @@ describe('page save api', function() {
         });
     });
 
+    /*
+     * TODO: Uncomment once POST /page/html/{title} is publicly available
     it('save HTML', function() {
         return preq.get({
             uri: htmlUri + '/' + lastRev
@@ -151,11 +153,9 @@ describe('page save api', function() {
             });
         }).then(function(res) {
             assert.deepEqual(res.status, 201);
-        }).catch(function(err) {
-            console.log(JSON.stringify(err.body, null, 2));
-            throw err;
         });
     });
+    */
 
 });
 

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -37,7 +37,7 @@ describe('page save api', function() {
         return preq.post({
             uri: uri,
             body: {
-                text: ''
+                wikitext: ''
             }
         }).then(function(res) {
             throw new Error('Expected an error, but got status: ' + res.status);
@@ -51,7 +51,7 @@ describe('page save api', function() {
         return preq.post({
             uri: uri,
             body: {
-                text: 'abcd'
+                wikitext: 'abcd'
             }
         }).then(function(res) {
             throw new Error('Expected an error, but got status: ' + res.status);
@@ -65,7 +65,7 @@ describe('page save api', function() {
         return preq.post({
             uri: uri,
             body: {
-                text: 'abcd',
+                wikitext: 'abcd',
                 token: 'this_is_a_bad_token'
             }
         }).then(function(res) {
@@ -80,7 +80,7 @@ describe('page save api', function() {
         return preq.post({
             uri: uri,
             body: {
-                text: saveText,
+                wikitext: saveText,
                 token: token
             }
         }).then(function(res) {
@@ -92,7 +92,7 @@ describe('page save api', function() {
         return preq.post({
             uri: uri,
             body: {
-                text: saveText,
+                wikitext: saveText,
                 token: token
             }
         }).then(function(res) {
@@ -105,7 +105,7 @@ describe('page save api', function() {
         return preq.post({
             uri: uri + '/' + oldRev,
             body: {
-                text: saveText + "\n\nExtra text",
+                wikitext: saveText + "\n\nExtra text",
                 token: token
             }
         }).then(function(res) {

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -76,6 +76,22 @@ describe('page save api', function() {
         });
     });
 
+    it('fail for bad revision', function() {
+        return preq.post({
+            uri: uri,
+            body: {
+                revision: '13r25fv31',
+                wikitext: 'abcd',
+                token: 'this_is_a_bad_token'
+            }
+        }).then(function(res) {
+            throw new Error('Expected an error, but got status: ' + res.status);
+        }, function(err) {
+            assert.deepEqual(err.status, 400);
+            assert.deepEqual(err.body.title, 'Bad revision');
+        });
+    });
+
     it('save page', function() {
         return preq.post({
             uri: uri,
@@ -103,8 +119,9 @@ describe('page save api', function() {
 
     it('detect conflict', function() {
         return preq.post({
-            uri: uri + '/' + oldRev,
+            uri: uri,
             body: {
+                revision: oldRev,
                 wikitext: saveText + "\n\nExtra text",
                 token: token
             }


### PR DESCRIPTION
This PR creates a new API end-point which allows users to save a page, in wikitext or HTML format.

Also:
- add the `/edit` endpoint to the action module
- add MW API to RB error translation
- small clean-ups

Bug: [T101501](https://phabricator.wikimedia.org/T101501)