### PR TITLE
Urgent fix: Allow JSON content in POST requests

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -218,9 +218,9 @@ function handleRequest (opts, req, resp) {
     // Then process the request
     .then(function(body) {
 
-        if (req.body && /^application\/json/i.test(req.headers['content-type'])) {
+        if (body && /^application\/json/i.test(req.headers['content-type'])) {
             try {
-                body = JSON.parse(req.body.toString());
+                body = JSON.parse(body.toString());
             } catch (e) {
                 reqOpts.log('error/request/json-parsing', e);
             }


### PR DESCRIPTION
After parsing a POST request's body, we attempt to parse its contents if the `application/json` content type is present. However, the code tries to parse `req.body`, which is undefined, since `rbUtil.parsePOST()` returns the body, but does not set the `req.body` field. This PR fixes the issue by correctly using the return value.