### PR TITLE
Clean up node module dependencies

### DIFF
--- a/maintenance/generate-wikimedia-domain-config.js
+++ b/maintenance/generate-wikimedia-domain-config.js
@@ -9,7 +9,7 @@ var P = require('bluebird');
 
 var fs = require("fs"),
 	writeFile = P.promisify(fs.writeFile),
-	request = P.promisify(require('request')),
+	request = P.promisify(require('preq/node_modules/request')),
 	downloadUrl = "https://en.wikipedia.org/w/api.php?action=sitematrix&format=json",
 	filename = "sitematrix.json";
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "js-yaml": "^3.3.1",
     "node-uuid": "git+https://github.com/gwicke/node-uuid#master",
     "preq": "^0.4.3",
-    "restbase-mod-table-cassandra": "^0.6.5",
+    "restbase-mod-table-cassandra": "^0.6.6",
     "service-runner": "^0.2.0",
     "swagger-router": "^0.1.0",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master"

--- a/package.json
+++ b/package.json
@@ -32,29 +32,25 @@
   },
   "homepage": "https://github.com/wikimedia/restbase",
   "dependencies": {
-    "bluebird": "~2.2.2",
-    "bunyan": "~1.1.3",
-    "busboy": "~0.2.8",
-    "gelf-stream": "~0.2.4",
-    "js-yaml": "~3.2.2",
-    "node-txstatsd": "~0.1.5",
+    "bluebird": "^2.9.27",
+    "busboy": "^0.2.9",
+    "js-yaml": "^3.3.1",
     "node-uuid": "git+https://github.com/gwicke/node-uuid#master",
-    "preq": "^0.4.0",
-    "request": "^2.44.0",
+    "preq": "^0.4.3",
     "restbase-mod-table-cassandra": "^0.6.5",
-    "service-runner": "^0.1.10",
+    "service-runner": "^0.2.0",
     "swagger-router": "^0.1.0",
-    "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
-    "url-template": "2.0.4",
-    "yargs": "~1.3.0"
+    "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master"
   },
   "devDependencies": {
-    "mocha": "~1.x.x",
-    "mocha-jshint": "0.0.9",
-    "istanbul": "0.3.5",
-    "mocha-lcov-reporter": "0.0.1",
-    "coveralls": "2.11.2",
+    "bunyan": "^1.4.0",
+    "coveralls": "^2.11.2",
+    "heapdump": "^0.3.5",
+    "istanbul": "^0.3.15",
+    "mocha": "^2.2.5",
+    "mocha-jshint": "^2.2.3",
+    "mocha-lcov-reporter": "^0.0.2",
     "swagger-test": "0.2.0",
-    "heapdump": "^0.3.3"
+    "url-template": "^2.0.6"
   }
 }


### PR DESCRIPTION
- moved from `dependencies` to `devDependencies`:
  - bunyan
  - url-template
- removed unused modules:
  - gelf-stream
  - node-txstatsd
  - request
  - yargs
- updated module versions

Note: `maintenance/generate-wikimedia-domain-config.js` now requires
`preq/node_modules/request`