### PR TITLE
Paging support

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -158,6 +158,7 @@ services:
     conf: 
       port: 7231
       spec: *spec
+      saltKey: secret
 
 logging:
   name: restbase

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -158,7 +158,8 @@ services:
     conf: 
       port: 7231
       spec: *spec
-      saltKey: secret
+      salt: secret
+      default_page_size: 250
 
 logging:
   name: restbase

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -150,7 +150,8 @@ services:
     conf: 
       port: 7231
       spec: *spec
-      saltKey: secret
+      salt: secret
+      default_page_size: 1
 
 logging:
   name: restbase

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -150,6 +150,7 @@ services:
     conf: 
       port: 7231
       spec: *spec
+      saltKey: secret
 
 logging:
   name: restbase

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -51,11 +51,18 @@ function RESTBase (options, req) {
         this._recursionDepth = 0;
 
         options.maxDepth = options.maxDepth || 10;
+
+        if (!options.conf.salt || typeof options.conf.salt !== 'string') {
+            throw new Error("Missing or invalid `salt` option in RESTBase config. "
+                    + "Expected a string.");
+        }
+
         // Private state, shared with child instances
         this._priv = {
             options: options,
             router: options.router
         };
+
         this.rb_config = options.conf;
     }
 
@@ -80,35 +87,6 @@ RESTBase.prototype.makeChild = function(req) {
     // that we can provide nice error reporting and tracing.
     child._req = req;
     return child;
-};
-
-// Create a json web token
-// @param {string} token
-// @return {string} JWT signed token
-RESTBase.prototype.encodeToken = function(token) {
-    var newToken = jwt.sign({next:token},
-                        this._priv.options.conf.salt &&
-                        this._priv.options.conf.salt.toString());
-    return newToken;
-};
-
-// Decode signed token and decode the orignal token
-// @param {string} JWT token
-// @return {string} original token
-RESTBase.prototype.decodeToken = function(token) {
-    try {
-        var next = jwt.verify(token, this._priv.options.conf.salt.toString());
-        return next.next;
-    } catch(e) {
-        console.log(e);
-        throw new HTTPError({
-            status: 400,
-            body: {
-                type: 'invalid_paging_token',
-                title: 'Invalid paging token'
-            }
-        });
-    }
 };
 
 // A default listing handler for URIs that end in / and don't have any
@@ -378,5 +356,35 @@ methods.forEach(function(method) {
         return this._request(makeRequest(uri, req, method));
     };
 });
+
+
+// Utility methods that need access to restbase state.
+
+// Create a json web token
+// @param {string} token
+// @return {string} JWT signed token
+RESTBase.prototype.encodeToken = function(token) {
+    var newToken = jwt.sign({next:token}, this._priv.options.conf.salt);
+    return newToken;
+};
+
+// Decode signed token and decode the orignal token
+// @param {string} JWT token
+// @return {string} original token
+RESTBase.prototype.decodeToken = function(token) {
+    try {
+        var next = jwt.verify(token, this._priv.options.conf.salt);
+        return next.next;
+    } catch(e) {
+        console.log(e);
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'invalid_paging_token',
+                title: 'Invalid paging token'
+            }
+        });
+    }
+};
 
 module.exports = RESTBase;

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -4,6 +4,7 @@
  * RESTBase request dispatcher and general shared per-request state namespace
  */
 
+var jwt = require('json-web-token');
 var P = require('bluebird');
 var rbUtil = require('./rbUtil');
 var HTTPError = rbUtil.HTTPError;
@@ -79,6 +80,24 @@ RESTBase.prototype.makeChild = function(req) {
     return child;
 };
 
+// Create a json web token
+// @param {string} token
+// @return {string} JWT signed token
+rbUtil.encodeToken = function(token) {
+    console.log(self._priv.options);
+    var newToken = jwt.sign(result.meta.pageState,
+                        self._priv.options.saltKey &&
+                        self._priv.options.saltKey.toString());
+    return newToken;
+}
+
+// Decode signed token and decode the orignal token
+// @param {string} JWT token
+// @return {string} original token
+rbUtil.decodeToken = function(token) {
+    console.log(self._priv.options);
+    return jwt.verify(token, self._priv.options.saltKey)
+}
 
 // A default listing handler for URIs that end in / and don't have any
 // handlers associated with it otherwise.

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -376,7 +376,6 @@ RESTBase.prototype.decodeToken = function(token) {
         var next = jwt.verify(token, this._priv.options.conf.salt);
         return next.next;
     } catch(e) {
-        console.log(e);
         throw new HTTPError({
             status: 400,
             body: {

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -4,7 +4,7 @@
  * RESTBase request dispatcher and general shared per-request state namespace
  */
 
-var jwt = require('json-web-token');
+var jwt = require('jsonwebtoken');
 var P = require('bluebird');
 var rbUtil = require('./rbUtil');
 var HTTPError = rbUtil.HTTPError;
@@ -38,6 +38,7 @@ function RESTBase (options, req) {
             rbUtil.generateRequestId();
         this._recursionDepth = par._recursionDepth + 1;
         this._priv = par._priv;
+        this.rb_config = this._priv.options.conf;
     } else {
         // Brand new instance
         this.log = options.log; // logging method
@@ -55,6 +56,7 @@ function RESTBase (options, req) {
             options: options,
             router: options.router
         };
+        this.rb_config = options.conf;
     }
 
 }
@@ -83,21 +85,31 @@ RESTBase.prototype.makeChild = function(req) {
 // Create a json web token
 // @param {string} token
 // @return {string} JWT signed token
-rbUtil.encodeToken = function(token) {
-    console.log(self._priv.options);
-    var newToken = jwt.sign(result.meta.pageState,
-                        self._priv.options.saltKey &&
-                        self._priv.options.saltKey.toString());
+RESTBase.prototype.encodeToken = function(token) {
+    var newToken = jwt.sign({next:token},
+                        this._priv.options.conf.salt &&
+                        this._priv.options.conf.salt.toString());
     return newToken;
-}
+};
 
 // Decode signed token and decode the orignal token
 // @param {string} JWT token
 // @return {string} original token
-rbUtil.decodeToken = function(token) {
-    console.log(self._priv.options);
-    return jwt.verify(token, self._priv.options.saltKey)
-}
+RESTBase.prototype.decodeToken = function(token) {
+    try {
+        var next = jwt.verify(token, this._priv.options.conf.salt.toString());
+        return next.next;
+    } catch(e) {
+        console.log(e);
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'invalid_paging_token',
+                title: 'Invalid paging token'
+            }
+        });
+    }
+};
 
 // A default listing handler for URIs that end in / and don't have any
 // handlers associated with it otherwise.

--- a/mods/page_revisions.yaml
+++ b/mods/page_revisions.yaml
@@ -5,7 +5,7 @@
       operationId: listTitles
       parameters:
         - name: page
-          in: Query
+          in: query
           description: The next page token
           type: string
           required: false
@@ -16,7 +16,7 @@
       operationId: listTitleRevisions
       parameters:
         - name: page
-          in: Query
+          in: query
           description: The next page token
           type: string
           required: false
@@ -45,7 +45,7 @@
       operationId: listRevisions
       parameters:
         - name: page
-          in: Query
+          in: query
           description: The next page token
           type: string
           required: false

--- a/mods/page_revisions.yaml
+++ b/mods/page_revisions.yaml
@@ -1,13 +1,25 @@
-paths:
+ paths:
   /page/:
     get:
       summary: List titles
       operationId: listTitles
+      parameters:
+        - name: page
+          in: Query
+          description: The next page token
+          type: string
+          required: false
 
   /page/{title}/:
     get:
       summary: List revisions for a title (page history)
       operationId: listTitleRevisions
+      parameters:
+        - name: page
+          in: Query
+          description: The next page token
+          type: string
+          required: false
 
   /page/{title}{/revision}:
     get:
@@ -31,6 +43,12 @@ paths:
     get:
       summary: List all revisions, ever
       operationId: listRevisions
+      parameters:
+        - name: page
+          in: Query
+          description: The next page token
+          type: string
+          required: false
 
   /rev/{revision}:
     get:

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -302,24 +302,22 @@ PSP.listRevisions = function (format, restbase, req) {
     var self = this;
     var rp = req.params;
     var revReq = {
-        uri: new URI([rp.domain, 'sys', 'key_rev_value', 'parsoid.' + format,
-                     normalizeTitle(rp.title), ''])
-        generator: 'allpages',
-        gaplimit: 500,
-        gapcontinue: ''
-    }
+        uri: new URI([rp.domain, 'sys', 'key_rev_value', 'parsoid.' + format, normalizeTitle(rp.title), '']),
+        body: {
+            gaplimit: restbase.rb_config.default_page_size,
+            gapcontinue: ''
+        }
+    };
 
-    if (req.next) {
-        listReq.gapcontinue = restbase.decodeToken(req.next);
+    if (req.query.page) {
+        revReq.body.gapcontinue = restbase.decodeToken(req.query.page);
     }
 
     return restbase.get(revReq)
         .then(function(res) {
             if (res.body.next) {
-                res.body.next = {
-                    _links: {
-                        next: { "href": "?next="+restbase.encodeToken(res.body.next.allpages.gapcontinue); } 
-                    }
+                res.body._links = {
+                    next: { "href": "?page="+restbase.encodeToken(res.body.next.allpages.gapcontinue) } 
                 };
             }
             return res;

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -304,20 +304,19 @@ PSP.listRevisions = function (format, restbase, req) {
     var revReq = {
         uri: new URI([rp.domain, 'sys', 'key_rev_value', 'parsoid.' + format, normalizeTitle(rp.title), '']),
         body: {
-            gaplimit: restbase.rb_config.default_page_size,
-            gapcontinue: ''
+            limit: restbase.rb_config.default_page_size,
         }
     };
 
     if (req.query.page) {
-        revReq.body.gapcontinue = restbase.decodeToken(req.query.page);
+        revReq.body.next = restbase.decodeToken(req.query.page);
     }
 
     return restbase.get(revReq)
         .then(function(res) {
             if (res.body.next) {
                 res.body._links = {
-                    next: { "href": "?page="+restbase.encodeToken(res.body.next.allpages.gapcontinue) } 
+                    next: { "href": "?page="+restbase.encodeToken(res.body.next.allpages.gapcontinue) }
                 };
             }
             return res;

--- a/mods/parsoid.yaml
+++ b/mods/parsoid.yaml
@@ -20,6 +20,12 @@ paths:
     get:
       summary: List Wikitext revisions.
       operationId: listWikitextRevisions
+      parameters:
+        - name: page
+          in: Query
+          description: The next page token
+          type: string
+          required: false
 
   /wikitext/{title}{/revision}{/tid}:
     get:
@@ -30,6 +36,12 @@ paths:
     get:
       summary: List HTML revisions.
       operationId: listHtmlRevisions
+      parameters:
+        - name: page
+          in: Query
+          description: The next page token
+          type: string
+          required: false
 
   /html/{title}{/revision}{/tid}:
     get:
@@ -40,6 +52,12 @@ paths:
     get:
       summary: List data-parsoid revisions.
       operationId: listDataParsoidRevisions
+      parameters:
+        - name: page
+          in: Query
+          description: The next page token
+          type: string
+          required: false
 
   /data-parsoid/{title}{/revision}{/tid}:
     get:

--- a/mods/parsoid.yaml
+++ b/mods/parsoid.yaml
@@ -15,7 +15,7 @@ paths:
     post:
       summary: Retrieve a JSON bundle containing html and data-parsoid
       operationId: getPageBundle
-  
+
   /wikitext/{title}/:
     get:
       summary: List Wikitext revisions.
@@ -25,7 +25,7 @@ paths:
     get:
       summary: Retrieve the wikitext for a title and revision.
       operationId: getWikitext
-  
+
   /html/{title}/:
     get:
       summary: List HTML revisions.
@@ -35,7 +35,7 @@ paths:
     get:
       summary: Retrieve the HTML for title and revision.
       operationId: getHtml
-  
+
   /data-parsoid/{title}/:
     get:
       summary: List data-parsoid revisions.
@@ -45,7 +45,7 @@ paths:
     get:
       summary: Retrieve the data-parsoid JSON for title & revision.
       operationId: getDataParsoid
-  
+
   /transform/html/to/html{/title}{/revision}:
     post:
       summary: Update HTML, while optionally passing in title & revision.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "preq": "^0.4.3",
     "restbase-mod-table-cassandra": "^0.6.6",
     "service-runner": "^0.2.0",
+    "jsonwebtoken": "3.0.0",
     "swagger-router": "^0.1.0",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master"
   },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "js-yaml": "^3.3.1",
     "node-uuid": "git+https://github.com/gwicke/node-uuid#master",
     "preq": "^0.4.3",
+    "jsonwebtoken": "5.0.0",
     "restbase-mod-table-cassandra": "^0.6.6",
     "service-runner": "^0.2.0",
     "jsonwebtoken": "3.0.0",

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -428,7 +428,7 @@ paths:
         - application/json
       parameters:
         - name: page
-          in: Query
+          in: query
           description: The next page token
           type: string
           required: false

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -44,6 +44,12 @@ paths:
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
       produces:
         - application/json
+      parameters:
+        - name: page
+          in: query
+          description: The next page token
+          type: string
+          required: false
       responses:
         '200':
           description: The queriable list of page titles
@@ -76,6 +82,11 @@ paths:
           description: The page title.
           type: string
           required: true
+        - name: page
+          in: query
+          description: The next page token
+          type: string
+          required: false
       responses:
         '200':
           description: The queriable list of page revisions.
@@ -99,6 +110,12 @@ paths:
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       produces:
         - application/json
+      parameters:
+        - name: page
+          in: query
+          description: The next page token
+          type: string
+          required: false
       responses:
         '200':
           description: The queriable list of page titles
@@ -171,6 +188,11 @@ paths:
           description: The page title
           type: string
           required: true
+        - name: page
+          in: query
+          description: The next page token
+          type: string
+          required: false
       responses:
         '200':
           description: The list of revisions
@@ -254,6 +276,12 @@ paths:
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
+      parameters:
+        - name: page
+          in: query
+          description: The next page token
+          type: string
+          required: false
       responses:
         '200':
           description: The queriable list of page titles
@@ -317,6 +345,11 @@ paths:
           description: The page title
           type: string
           required: true
+        - name: page
+          in: query
+          description: The next page token
+          type: string
+          required: false
       responses:
         '200':
           description: The list of revisions
@@ -393,6 +426,12 @@ paths:
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
       produces:
         - application/json
+      parameters:
+        - name: page
+          in: Query
+          description: The next page token
+          type: string
+          required: false
       responses:
         '200':
           description: The queriable sub-items

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -6,7 +6,7 @@
 var assert = require('../../utils/assert.js');
 var preq   = require('preq');
 var server = require('../../utils/server.js');
-
+var pagingToken = '';
 
 describe('revision requests', function() {
 
@@ -106,7 +106,7 @@ describe('revision requests', function() {
     it('should list stored revisions', function() {
        return preq.get({ uri: server.config.bucketURL + '/revision/' })
        .then(function(res) {
-           assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.status, 200);
 			assert.contentType(res, 'application/json');
             if (!res.body.items || !res.body.items.length) {
                 throw new Error("No revisions returned!");
@@ -114,7 +114,22 @@ describe('revision requests', function() {
             if (typeof res.body.items[0] !== 'number') {
                 throw new Error("Expected a numeric revision id!");
             }
+            pagingToken = res.body._links.next.href;
        });
+    });
+
+    it('should list next set of stored revisions using pagination', function() {
+       return preq.get({ uri: server.config.bucketURL + '/revision/' + pagingToken })
+       .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.contentType(res, 'application/json');
+            if (!res.body.items || !res.body.items.length) {
+                throw new Error("No revisions returned!");
+            }
+            if (typeof res.body.items[0] !== 'number') {
+                throw new Error("Expected a numeric revision id!");
+            }
+       })
     });
 
 });


### PR DESCRIPTION
Note: For deployment, we'll have to add a secret `salt` parameter in the config, which is used to encrypt page state.