### PR TITLE
Minor improvements to test suite and If-Unmodified-Since support.

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -274,9 +274,9 @@ PSP.getFormat = function (format, restbase, req) {
         return contentReq.then(function(res) {
                 if (req.headers['if-unmodified-since']) {
                     try {
-                        var jobTime = new Date(req.headers['if-unmodified-since']);
+                        var jobTime = Date.parse(req.headers['if-unmodified-since']);
                         var revInfo = rbUtil.parseETag(res.headers.etag);
-                        if (revInfo && uuid.v1time(revInfo.tid) >= jobTime) {
+                        if (revInfo && uuid.v1time(uuid.parse(revInfo.tid)) >= jobTime) {
                             // Already up to date, nothing to do.
                             return {
                                 status: 412,

--- a/test/features/pagecontent/rerendering.js
+++ b/test/features/pagecontent/rerendering.js
@@ -111,7 +111,7 @@ describe('page re-rendering', function () {
             uri: server.config.bucketURL + dynamic1,
             headers: {
                 'cache-control': 'no-cache',
-                'if-unmodified-since': 'Wed Dec 11 2013 16:00:00 GMT-0800',
+                'if-unmodified-since': 'Wed, 11 Dec 2013 16:00:00 GMT',
             }
         })
         .then(function() {


### PR DESCRIPTION
Use `Date.parse` instead of `new Date` to avoid an unnecessary
object creation and a potentially confusing implicit conversion
from Date to nuber in the inequality test.

Use an explicit `uuid.parse` so that
https://github.com/gwicke/node-uuid/commit/ed652bb0953fad686d5eb3c65ed5911e2fc43604
isn't strictly necessary (since it hasn't yet been merged upstream).

Use a proper RFC822 date string in the rerendering test.

Use --no-timeouts to ensure the test suite passes even on developers'
slow laptops.

Change-Id: I2fa23a05e49297f3378ee48c45217646e0bda46f