### PR TITLE
Fix basePath when the Parsoid domain is the same as the request domain.

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -101,7 +101,7 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
 
         if (req.params.domain === req.headers.host.replace(/:[0-9]+$/,'')) {
             // This is a host-based request. Set an appropriate base path.
-            spec.basePath = spec['x-host-basePath'] || '';
+            spec.basePath = spec['x-host-basePath'] || spec.basePath;
         }
 
         return P.resolve({


### PR DESCRIPTION
In testing, I saw this when the parsoid prefix was `localhost` and I
was accessing the swagger docs at http://localhost:7231/localhost/v1/?doc

Change-Id: I89d80d5d4718798a08ec8c9ffb670636a3d1d1c8