### PR TITLE
Clean up tid requests

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -65,7 +65,7 @@ PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
         return res;
     }
 
-    if(!rp.revision && !req.query.sections || rbUtil.isTimeUUID(rp.revision)) {
+    if(!rp.revision && !req.query.sections) {
         // we are dealing with the latest revision,
         // so no need to check it, as the latest
         // revision can never be supressed


### PR DESCRIPTION
For consistency, require {/revision}{/tid}, rather than interpreting revision
as a tid if it looks like one. This already matches our documentation,
external behavior and tests, so it's really just an internal clean-up.