### PR TITLE
Don't use timeouts since test suite has unpredictable network timing

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 --recursive
+--no-timeouts


### PR DESCRIPTION
Use --no-timeouts to ensure the test suite passes even on developers' slow laptops.
