### PR TITLE
Replaced node-uuid with pure js uuid library (T94098)

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -9,7 +9,7 @@ var P = require('bluebird');
 var util = require('util');
 var url = require('url');
 var Busboy = require('busboy');
-var uuid = require('cassandra-uuid');
+var uuid = require('cassandra-uuid').TimeUuid;
 
 var rbUtil = {};
 
@@ -108,7 +108,7 @@ rbUtil.tidFromDate = function tidFromDate(date) {
         throw new Error('Invalid date');
     }
     // Create a new, deterministic timestamp
-    return uuid.TimeUuid.fromDate(date,
+    return uuid.fromDate(date,
         0,
         new Buffer([0x01, 0x23, 0x45, 0x67, 0x89, 0xab]),
         new Buffer([0x12, 0x34])).toString();
@@ -118,14 +118,14 @@ rbUtil.tidFromDate = function tidFromDate(date) {
  * Check if a string is a valid timeuuid
  */
 rbUtil.isTimeUUID = function (s) {
-    return uuid.TimeUuid.test(s);
+    return uuid.test(s);
 };
 
 /**
  * Generates a new request ID
  */
 rbUtil.generateRequestId = function() {
-    return uuid.Uuid.random().toRawString();
+    return uuid.now().toString();
 };
 
 /*

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -9,7 +9,7 @@ var P = require('bluebird');
 var util = require('util');
 var url = require('url');
 var Busboy = require('busboy');
-var uuid = require('node-uuid');
+var uuid = require('cassandra-uuid');
 
 var rbUtil = {};
 
@@ -108,31 +108,24 @@ rbUtil.tidFromDate = function tidFromDate(date) {
         throw new Error('Invalid date');
     }
     // Create a new, deterministic timestamp
-    return uuid.v1({
-        node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
-        clockseq: 0x1234,
-        msecs: +date,
-        nsecs: 0
-    });
+    return uuid.TimeUuid.fromDate(date,
+        0,
+        new Buffer([0x01, 0x23, 0x45, 0x67, 0x89, 0xab]),
+        new Buffer([0x12, 0x34])).toString();
 };
 
-var uuidRe = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 /**
  * Check if a string is a valid timeuuid
  */
 rbUtil.isTimeUUID = function (s) {
-    return uuidRe.test(s);
+    return uuid.TimeUuid.test(s);
 };
-
-
-var reqIdBuf = new Buffer(16);
 
 /**
  * Generates a new request ID
  */
 rbUtil.generateRequestId = function() {
-    uuid.v4(null, reqIdBuf);
-    return reqIdBuf.toString('hex');
+    return uuid.Uuid.random().toRawString();
 };
 
 /*

--- a/mods/key_rev_value.js
+++ b/mods/key_rev_value.js
@@ -5,7 +5,7 @@
  */
 
 var P = require('bluebird');
-var uuid = require('node-uuid');
+var uuid = require('cassandra-uuid').TimeUuid;
 var rbUtil = require('../lib/rbUtil');
 var URI = require('swagger-router').URI;
 
@@ -252,7 +252,7 @@ KRVBucket.prototype.listRevisions = function(restbase, req) {
 KRVBucket.prototype.putRevision = function(restbase, req) {
     var rp = req.params;
     var rev = parseRevision(rp.revision);
-    var tid = rp.tid && coerceTid(rp.tid) || uuid.v1();
+    var tid = rp.tid && coerceTid(rp.tid) || uuid.now().toString();
     if (req.headers['last-modified']) {
         // XXX: require elevated rights for passing in the revision time
         tid = rbUtil.tidFromDate(req.headers['last-modified']);

--- a/mods/key_value.js
+++ b/mods/key_value.js
@@ -5,7 +5,7 @@
  */
 
 var P = require('bluebird');
-var uuid = require('node-uuid');
+var uuid = require('cassandra-uuid').TimeUuid;
 var rbUtil = require('../lib/rbUtil');
 var URI = require('swagger-router').URI;
 
@@ -234,7 +234,7 @@ KVBucket.prototype.listRevisions = function(restbase, req) {
 KVBucket.prototype.putRevision = function(restbase, req) {
     // TODO: support other formats! See cassandra backend getRevision impl.
     var rp = req.params;
-    var tid = uuid.v1();
+    var tid = uuid.now().toString();
 
     var storeReq = {
         uri: new URI([rp.domain,'sys','table',rp.bucket,'']),

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -13,7 +13,7 @@
 
 var rbUtil = require('../lib/rbUtil.js');
 var URI = require('swagger-router').URI;
-var uuid = require('node-uuid');
+var uuid = require('cassandra-uuid').TimeUuid;
 
 // TODO: move to module
 var fs = require('fs');
@@ -219,7 +219,7 @@ PRS.prototype.fetchAndStoreMWRevision = function (restbase, req) {
                     title: rbUtil.normalizeTitle(dataResp.title),
                     page_id: parseInt(dataResp.pageid),
                     rev: parseInt(apiRev.revid),
-                    tid: uuid.v1(),
+                    tid: uuid.now().toString(),
                     namespace: parseInt(dataResp.ns),
                     user_id: apiRev.userid,
                     user_text: apiRev.user,

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -6,7 +6,7 @@
 
 var P = require('bluebird');
 var URI = require('swagger-router').URI;
-var uuid   = require('node-uuid');
+var uuid   = require('cassandra-uuid').TimeUuid;
 var rbUtil = require('../lib/rbUtil');
 
 // TODO: move tests & spec to separate npm module!
@@ -256,7 +256,7 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
     return parsoidReq
     .then(function(res) {
         var htmlBody = res.body.html.body;
-        var tid = uuid.v1();
+        var tid = uuid.now().toString();
         // Also make sure we have a meta tag for the tid in our output
         if (!/<meta property="mw:TimeUuid" [^>]+>/.test(htmlBody)) {
             res.body.html.body = htmlBody
@@ -335,7 +335,7 @@ PSP.getFormat = function (format, restbase, req) {
                     try {
                         var jobTime = Date.parse(req.headers['if-unmodified-since']);
                         var revInfo = rbUtil.parseETag(res.headers.etag);
-                        if (revInfo && uuid.v1time(uuid.parse(revInfo.tid)) >= jobTime) {
+                        if (revInfo && uuid.fromString(revInfo.tid).getDate() >= jobTime) {
                             // Already up to date, nothing to do.
                             return {
                                 status: 412,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "busboy": "^0.2.9",
     "js-yaml": "^3.3.1",
     "jsonwebtoken": "^5.0.1",
-    "node-uuid": "git+https://github.com/gwicke/node-uuid#master",
+    "cassandra-uuid": "^0.0.2",
     "preq": "^0.4.3",
     "restbase-mod-table-cassandra": "^0.6.6",
     "service-runner": "^0.2.0",


### PR DESCRIPTION
This replaces a node-uuid lib with a new cassandra-uuid lib, that's basically a copy-paste from a cassandra driver. New lib doesn't have any binary dependencies, all test pass. New lib is hosted [here] (https://github.com/Pchelolo/uuid) No API changes were made comparing to the original cassandra-driver implementation, bc it would be easier as we use cassandra's lib in other places.

The only concern is rbUtil.generateRequestId - in the previous implementation it returned uuid as a hex number without any '-' symbols. I've supposed something might possibly depend on this so left this behavior unchanged.