### PR TITLE
Added data-parsoid check before sending parsoid request

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -445,12 +445,14 @@ PSP.transformRevision = function (restbase, req, from, to) {
     return this._getOriginalContent(restbase, req, rp.revision, tid)
     .then(function (original) {
         // Check if parsoid metadata is present as it's required by parsoid.
-        if (!original['data-parsoid'].body || !original['data-parsoid'].body.ids) {
+        if (!original['data-parsoid'].body
+                || original['data-parsoid'].body.constructor !== Object
+                || !original['data-parsoid'].body.ids) {
             throw new rbUtil.HTTPError({
                 status: 400,
                 body: {
                     type: 'invalid_request',
-                    description: "Couldn't find parsoid metadata for page " + req.body.title + ' ' + rp.revision
+                    description: 'The page/revision has no associated Parsoid data'
                 }
             });
         }

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -445,12 +445,12 @@ PSP.transformRevision = function (restbase, req, from, to) {
     return this._getOriginalContent(restbase, req, rp.revision, tid)
     .then(function (original) {
         // Check if parsoid metadata is present as it's required by parsoid.
-        if (!original || !original['data-parsoid'] || !original['data-parsoid'].body.ids) {
+        if (!original['data-parsoid'].body || !original['data-parsoid'].body.ids) {
             throw new rbUtil.HTTPError({
                 status: 400,
                 body: {
                     type: 'invalid_request',
-                    description: 'Couldn\'t find parsoid metadata for page ' + req.body.title + ' ' + rp.revision
+                    description: "Couldn't find parsoid metadata for page " + req.body.title + ' ' + rp.revision
                 }
             });
         }

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -444,6 +444,16 @@ PSP.transformRevision = function (restbase, req, from, to) {
 
     return this._getOriginalContent(restbase, req, rp.revision, tid)
     .then(function (original) {
+        // Check if parsoid metadata is present as it's required by parsoid.
+        if (!original || !original['data-parsoid'] || !original['data-parsoid'].body.ids) {
+            throw new rbUtil.HTTPError({
+                status: 400,
+                body: {
+                    type: 'invalid_request',
+                    description: 'Couldn\'t find parsoid metadata for page ' + req.body.title + ' ' + rp.revision
+                }
+            });
+        }
         var body2 = {
             original: original
         };


### PR DESCRIPTION
Added a check that parsed metadata was correctly retrieved from the storage before sending a request to parsed transformer [T102117] (https://phabricator.wikimedia.org/T102117).

Check on saving, mentioned in the issue was already fixed by @gwicke [around here] (https://github.com/wikimedia/restbase/commit/7a4bd137b093bf26cb41c914db953eb913727876#diff-22ea565322fb171e4b5370c6f9f46bcbR173)