### PR TITLE
Added .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ coverage
 config.yaml
 node_modules
 npm-debug.log
+# WebStorm IDE files
+.idea/*


### PR DESCRIPTION
I'm using a WebStorm IDE for dev, and it creates some supporting files and places them to .idea folder within the project root. To avoid excluding IDE files from comment every time I've added this folder to .gitignore. No actual code changed.