### PR TITLE
Downgrade bluebird to 2.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/wikimedia/restbase",
   "dependencies": {
-    "bluebird": "^2.9.27",
+    "bluebird": "2.8.2",
     "busboy": "^0.2.9",
     "js-yaml": "^3.3.1",
     "jsonwebtoken": "^5.0.1",


### PR DESCRIPTION
The 2.9.x series have been a bit buggy, so stay with 2.8.2 for now.