### PR TITLE
Delete handling added (T100031)

### DIFF
--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -103,15 +103,25 @@ PRS.prototype._checkRevReturn = function(res) {
     // https://phabricator.wikimedia.org/T76165#1030962
     if (item && Array.isArray(item.restrictions) && item.restrictions.length > 0) {
         // there are some restrictions, deny access to the revision
-        throw new rbUtil.HTTPError({
-            status: 403,
-            body: {
-                type: 'access_denied#revision',
-                title: 'Access to resource denied',
-                description: 'Access is restricted for revision ' + item.rev,
-                restrictions: item.restrictions
-            }
-        });
+        if (item.restrictions.indexOf('page_deleted') >= 0) {
+            throw new rbUtil.HTTPError({
+                status: 404,
+                body: {
+                    type: 'not_found#page_revisions',
+                    description: 'Page was deleted'
+                }
+            });
+        } else {
+            throw new rbUtil.HTTPError({
+                status: 403,
+                body: {
+                    type: 'access_denied#revision',
+                    title: 'Access to resource denied',
+                    description: 'Access is restricted for revision ' + item.rev,
+                    restrictions: item.restrictions
+                }
+            });
+        }
     }
     return true;
 };
@@ -292,8 +302,46 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
             }
             return self.fetchAndStoreMWRevision(restbase, req);
         });
-    } else if (!rp.revision) {
-        revisionRequest = self.fetchAndStoreMWRevision(restbase, req);
+    } else if (!rp.revision || rp.revision === 'latest') {
+        revisionRequest = self.fetchAndStoreMWRevision(restbase, req)
+            .catch(function (e) {
+                if (e.status !== 404) {
+                    throw e;
+                }
+                // In case 404 is returned by MW api, the page is deleted
+                return self.listTitleRevisions(restbase, req)
+                    .then(function (res) {
+                        if (res.body.items && res.body.items.length > 0 ) {
+                            var revReq = {
+                                uri: new URI([rp.domain, 'sys', 'page_revisions', 'rev', res.body.items[0]]),
+                                params: {
+                                    api: 'sys',
+                                    domain: rp.domain,
+                                    module: 'page_revisions',
+                                    revision: res.body.items[0]
+                                }
+                            };
+                            return self.getRevision(restbase, revReq);
+                        } else {
+                            throw e;
+                        }
+                    })
+                    .then(function(result) {
+                        result = result.body.items[0];
+                        result.tid = uuid.now().toString();
+                        result.restrictions = result.restrictions || [];
+                        result.restrictions.push('page_deleted');
+                        return restbase.put({
+                            uri: self.tableURI(rp.domain),
+                            body: {
+                                table: self.tableName,
+                                attributes: result
+                            }
+                        }).then(function () {
+                            throw e;
+                        });
+                    });
+            });
     } else {
         throw new Error("Invalid revision: " + rp.revision);
     }

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -66,21 +66,13 @@ PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
         return res;
     }
 
-    if(!rp.revision && !req.query.sections) {
-        // we are dealing with the latest revision,
-        // so no need to check it, as the latest
-        // revision can never be supressed
-        return promise.then(ensureCharsetInContentType);
-    }
     var reqs = {
         content: promise,
     };
 
-    if (rp.revision) {
-        // Bundle the promise together with a call to getRevisionInfo(). A
-        // failure in getRevisionInfo will abort the entire request.
-        reqs.revisionInfo = this.getRevisionInfo(restbase, req);
-    }
+    // Bundle the promise together with a call to getRevisionInfo(). A
+    // failure in getRevisionInfo will abort the entire request.
+    reqs.revisionInfo = this.getRevisionInfo(restbase, req);
 
     // If the format is HTML and sections were requested, also request section
     // offsets

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "mocha-jshint": "^2.2.3",
     "mocha-lcov-reporter": "^0.0.2",
     "swagger-test": "0.2.0",
-    "url-template": "^2.0.6"
+    "url-template": "^2.0.6",
+    "nock": "^2.6.0"
   }
 }

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -99,6 +99,44 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/{title}/
 
+  /{module:page}/title/{title}/{revision}:
+      get:
+        tags:
+          - Page content
+        description: >
+          Get a specific revision for a title.
+          In case 'latest' string is provided as a revision, the latest revision is returned
+          Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        produces:
+          - application/json
+        parameters:
+          - name: title
+            in: path
+            description: The page title.
+            type: string
+            required: true
+          - name: revision
+            in: path
+            description: The revision id or a 'latest' string
+            type: string
+            required: true
+          - name: page
+            in: query
+            description: The next page token
+            type: string
+            required: false
+        responses:
+          '200':
+            description: The revision's properties
+            schema:
+              $ref: '#/definitions/revision'
+          default:
+            description: Error
+            schema:
+              $ref: '#/definitions/problem'
+        x-backend-request:
+          uri: /{domain}/sys/page_revisions/page/{title}/{revision}
+
   /{module:page}/html/:
     get:
       tags:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -67,7 +67,9 @@ paths:
       tags:
         - Page content
       description: >
-        Returns the latest revision of the title
+        Returns the latest revision for the title. By default returns the latest revision
+        stored in RESTBase, but if Cache-Control header is set to no-cache, MediaWiki API
+        is queried for the latest revision.
 
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       produces:
@@ -80,9 +82,9 @@ paths:
           required: true
       responses:
         '200':
-          description: The queriable list of page revisions.
+          description: The latest revision for the title
           schema:
-            $ref: '#/definitions/listing'
+            $ref: '#/definitions/revision'
         '404':
           description: Unknown page title or no revisions found
           schema:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -67,9 +67,8 @@ paths:
       tags:
         - Page content
       description: >
-        Returns the latest revision for the title. By default returns the latest revision
-        stored in RESTBase, but if Cache-Control header is set to no-cache, MediaWiki API
-        is queried for the latest revision.
+        Returns the latest revision ID for the title present in storage.
+        Supply the Cache-Control: no-cache header to obtain the latest available revision ID
 
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       produces:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -62,12 +62,43 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/
 
+  /{module:page}/title/{title}:
+    get:
+      tags:
+        - Page content
+      description: >
+        Returns the latest revision of the title
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json
+      parameters:
+        - name: title
+          in: path
+          description: The page title.
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The queriable list of page revisions.
+          schema:
+            $ref: '#/definitions/listing'
+        '404':
+          description: Unknown page title or no revisions found
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/page_revisions/page/{title}
 
   /{module:page}/title/{title}/:
     get:
       tags:
         - Page content
-      description: > 
+      description: >
         List revisions for a title. Currently this lists all revisions that
         ever used this title and are stored in RESTBase, but eventually it
         should probably return the linear history (across renames) of the page
@@ -98,44 +129,6 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/{title}/
-
-  /{module:page}/title/{title}/{revision}:
-      get:
-        tags:
-          - Page content
-        description: >
-          Get a specific revision for a title.
-          In case 'latest' string is provided as a revision, the latest revision is returned
-          Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-        produces:
-          - application/json
-        parameters:
-          - name: title
-            in: path
-            description: The page title.
-            type: string
-            required: true
-          - name: revision
-            in: path
-            description: The revision id or a 'latest' string
-            type: string
-            required: true
-          - name: page
-            in: query
-            description: The next page token
-            type: string
-            required: false
-        responses:
-          '200':
-            description: The revision's properties
-            schema:
-              $ref: '#/definitions/revision'
-          default:
-            description: Error
-            schema:
-              $ref: '#/definitions/problem'
-        x-backend-request:
-          uri: /{domain}/sys/page_revisions/page/{title}/{revision}
 
   /{module:page}/html/:
     get:

--- a/test/features/errors/notfound.js
+++ b/test/features/errors/notfound.js
@@ -7,10 +7,8 @@ var assert = require('../../utils/assert.js');
 var preq   = require('preq');
 var server = require('../../utils/server.js');
 var nock = require('nock');
-var P = require('bluebird');
 
 describe('404 handling', function() {
-    var revPageDeleted = 668588412;
 
     this.timeout(20000);
 
@@ -71,94 +69,98 @@ describe('404 handling', function() {
         });
     });
     it('should return 404 on deleted revision', function() {
-        return preq.get({ uri: server.config.bucketURL + '/revision/' + revPageDeleted })
-            .then(function() {
-                throw new Error('404 should be returned')
-            })
-            .catch(function(e) {
-                assert.deepEqual(e.status, 404);
-                assert.contentType(e, 'application/problem+json');
-            })
+        return preq.get({
+            uri: server.config.bucketURL + '/revision/668588412'
+        })
+        .then(function() {
+            throw new Error('404 should be returned')
+        })
+        .catch(function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+        });
     });
     it('should set page_deleted on deleted page', function() {
         var apiURI = server.config
-            .conf.templates['wmf-sys-1.0.0']
-            .paths['/{module:action}']['x-modules'][0].options.apiURI;
+        .conf.templates['wmf-sys-1.0.0']
+        .paths['/{module:action}']['x-modules'][0].options.apiURI;
         var title = 'TestingTitle';
         var revision = 12345;
 
         nock.enableNetConnect();
         var api = nock(apiURI)
             // The first request should return a page so that we store it.
-            .post('')
-            .reply(200, {
-                'batchcomplete': '',
-                'query': {
-                    'pages': {
-                        '11089416': {
-                            'pageid': 11089416,
-                            'ns': 0,
-                            'title': title,
+        .post('')
+        .reply(200, {
+            'batchcomplete': '',
+            'query': {
+                'pages': {
+                    '11089416': {
+                        'pageid': 11089416,
+                        'ns': 0,
+                        'title': title,
+                        'contentmodel': 'wikitext',
+                        'pagelanguage': 'en',
+                        'touched': '2015-05-22T08:49:39Z',
+                        'lastrevid': 653508365,
+                        'length': 2941,
+                        'revisions': [{
+                            'revid': revision,
+                            'user': 'Chuck Norris',
+                            'userid': 3606755,
+                            'timestamp': '2015-03-25T20:29:50Z',
+                            'size': 2941,
+                            'sha1': 'c47571122e00f28402d2a1b75cff77a22e7bfecd',
                             'contentmodel': 'wikitext',
-                            'pagelanguage': 'en',
-                            'touched': '2015-05-22T08:49:39Z',
-                            'lastrevid': 653508365,
-                            'length': 2941,
-                            'revisions': [{
-                                'revid': revision,
-                                'user': 'Chuck Norris',
-                                'userid': 3606755,
-                                'timestamp': '2015-03-25T20:29:50Z',
-                                'size': 2941,
-                                'sha1': 'c47571122e00f28402d2a1b75cff77a22e7bfecd',
-                                'contentmodel': 'wikitext',
-                                'comment': 'Test',
-                                'tags': []
-                            }]
-                        }
+                            'comment': 'Test',
+                            'tags': []
+                        }]
                     }
                 }
-            })
-            // Other requests return nothing as if the page is deleted.
-            .post('')
-            .reply(200, {})
-            .post('')
-            .reply(200, {});
+            }
+        })
+        // Other requests return nothing as if the page is deleted.
+        .post('')
+        .reply(200, {})
+        .post('')
+        .reply(200, {});
         // Fetch the page
-        return preq.get({ uri: server.config.bucketURL + '/title/' + title + '/latest'})
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-                assert.deepEqual(res.body.items.length, 1);
-                assert.deepEqual(res.body.items[0].rev, revision);
-            })
-            // Now fetch info that it's deleted
-            .then(function() {
-                return preq.get({ uri: server.config.bucketURL + '/title/' + title + '/latest'});
-            })
-            .then(function() {
-                throw new Error('404 should have been returned for a deleted page');
-            })
-            .catch(function(e) {
-                assert.deepEqual(e.status, 404);
-                assert.contentType(e, 'application/problem+json');
-            })
-            // Getting it by revision id should also return 404
-            .then(function() {
-                return preq.get({ uri: server.config.bucketURL + '/revision/' + revision});
-            })
-            .then(function() {
-                throw new Error('404 should have been returned for a deleted page');
-            })
-            .catch(function(e) {
-                assert.deepEqual(e.status, 404);
-                assert.contentType(e, 'application/problem+json');
-            })
-            .then(function() {
-                api.done();
-            })
-            .finally(function() {
-                nock.cleanAll();
-                nock.restore();
-            });
+        return preq.get({
+            uri: server.config.bucketURL + '/title/' + title + '/latest'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, revision);
+        })
+        // Now fetch info that it's deleted
+        .then(function() {
+            return preq.get({uri: server.config.bucketURL + '/title/' + title + '/latest'});
+        })
+        .then(function() {
+            throw new Error('404 should have been returned for a deleted page');
+        })
+        .catch(function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+        })
+        // Getting it by revision id should also return 404
+        .then(function() {
+            return preq.get({uri: server.config.bucketURL + '/revision/' + revision});
+        })
+        .then(function() {
+            throw new Error('404 should have been returned for a deleted page');
+        })
+        .catch(function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+        })
+        .then(function() {
+            api.done();
+        })
+        .finally(function() {
+            nock.cleanAll();
+            nock.restore();
+        });
     })
 });

--- a/test/features/errors/notfound.js
+++ b/test/features/errors/notfound.js
@@ -6,8 +6,12 @@
 var assert = require('../../utils/assert.js');
 var preq   = require('preq');
 var server = require('../../utils/server.js');
+var nock = require('nock');
+var P = require('bluebird');
 
 describe('404 handling', function() {
+    var revPageDeleted = 668588412;
+
     this.timeout(20000);
 
     before(function () { return server.start(); });
@@ -66,4 +70,95 @@ describe('404 handling', function() {
             assert.contentType(e, 'application/problem+json');
         });
     });
+    it('should return 404 on deleted revision', function() {
+        return preq.get({ uri: server.config.bucketURL + '/revision/' + revPageDeleted })
+            .then(function() {
+                throw new Error('404 should be returned')
+            })
+            .catch(function(e) {
+                assert.deepEqual(e.status, 404);
+                assert.contentType(e, 'application/problem+json');
+            })
+    });
+    it('should set page_deleted on deleted page', function() {
+        var apiURI = server.config
+            .conf.templates['wmf-sys-1.0.0']
+            .paths['/{module:action}']['x-modules'][0].options.apiURI;
+        var title = 'TestingTitle';
+        var revision = 12345;
+
+        nock.enableNetConnect();
+        var api = nock(apiURI)
+            // The first request should return a page so that we store it.
+            .post('')
+            .reply(200, {
+                'batchcomplete': '',
+                'query': {
+                    'pages': {
+                        '11089416': {
+                            'pageid': 11089416,
+                            'ns': 0,
+                            'title': title,
+                            'contentmodel': 'wikitext',
+                            'pagelanguage': 'en',
+                            'touched': '2015-05-22T08:49:39Z',
+                            'lastrevid': 653508365,
+                            'length': 2941,
+                            'revisions': [{
+                                'revid': revision,
+                                'user': 'Chuck Norris',
+                                'userid': 3606755,
+                                'timestamp': '2015-03-25T20:29:50Z',
+                                'size': 2941,
+                                'sha1': 'c47571122e00f28402d2a1b75cff77a22e7bfecd',
+                                'contentmodel': 'wikitext',
+                                'comment': 'Test',
+                                'tags': []
+                            }]
+                        }
+                    }
+                }
+            })
+            // Other requests return nothing as if the page is deleted.
+            .post('')
+            .reply(200, {})
+            .post('')
+            .reply(200, {});
+        // Fetch the page
+        return preq.get({ uri: server.config.bucketURL + '/title/' + title + '/latest'})
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body.items.length, 1);
+                assert.deepEqual(res.body.items[0].rev, revision);
+            })
+            // Now fetch info that it's deleted
+            .then(function() {
+                return preq.get({ uri: server.config.bucketURL + '/title/' + title + '/latest'});
+            })
+            .then(function() {
+                throw new Error('404 should have been returned for a deleted page');
+            })
+            .catch(function(e) {
+                assert.deepEqual(e.status, 404);
+                assert.contentType(e, 'application/problem+json');
+            })
+            // Getting it by revision id should also return 404
+            .then(function() {
+                return preq.get({ uri: server.config.bucketURL + '/revision/' + revision});
+            })
+            .then(function() {
+                throw new Error('404 should have been returned for a deleted page');
+            })
+            .catch(function(e) {
+                assert.deepEqual(e.status, 404);
+                assert.contentType(e, 'application/problem+json');
+            })
+            .then(function() {
+                api.done();
+            })
+            .finally(function() {
+                nock.cleanAll();
+                nock.restore();
+            });
+    })
 });

--- a/test/features/errors/notfound.js
+++ b/test/features/errors/notfound.js
@@ -82,8 +82,8 @@ describe('404 handling', function() {
     });
     it('should set page_deleted on deleted page', function() {
         var apiURI = server.config
-        .conf.templates['wmf-sys-1.0.0']
-        .paths['/{module:action}']['x-modules'][0].options.apiURI;
+            .conf.templates['wmf-sys-1.0.0']
+            .paths['/{module:action}']['x-modules'][0].options.apiURI;
         var title = 'TestingTitle';
         var revision = 12345;
 

--- a/test/features/errors/notfound.js
+++ b/test/features/errors/notfound.js
@@ -86,6 +86,7 @@ describe('404 handling', function() {
             .paths['/{module:action}']['x-modules'][0].options.apiURI;
         var title = 'TestingTitle';
         var revision = 12345;
+        var emptyResponse = {'batchcomplete':'','query':{'badrevids':{'12345' :{'revid':'12345'}}}};
 
         nock.enableNetConnect();
         var api = nock(apiURI)
@@ -121,12 +122,15 @@ describe('404 handling', function() {
         })
         // Other requests return nothing as if the page is deleted.
         .post('')
-        .reply(200, {})
+        .reply(200, emptyResponse)
         .post('')
-        .reply(200, {});
+        .reply(200, emptyResponse);
         // Fetch the page
         return preq.get({
-            uri: server.config.bucketURL + '/title/' + title + '/latest'
+            uri: server.config.bucketURL + '/title/' + title,
+            headers: {
+                'cache-control': 'no-cache'
+            }
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
@@ -135,7 +139,11 @@ describe('404 handling', function() {
         })
         // Now fetch info that it's deleted
         .then(function() {
-            return preq.get({uri: server.config.bucketURL + '/title/' + title + '/latest'});
+            return preq.get({
+                uri: server.config.bucketURL + '/title/' + title,
+                headers: {
+                    'cache-control': 'no-cache'
+                }});
         })
         .then(function() {
             throw new Error('404 should have been returned for a deleted page');

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -136,7 +136,10 @@ describe('revision requests', function() {
 
     it('should return latest revision for a page', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/title/' + pageName + '/latest'
+            uri: server.config.bucketURL + '/title/' + pageName,
+            headers: {
+                'cache-control': 'no-cache'
+            }
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -10,9 +10,9 @@ var pagingToken = '';
 
 describe('revision requests', function() {
 
-	var revOk = 642497713;
-	var revDeleted = 645504917;
-	var revRedirect = 591082967;
+    var revOk = 642497713;
+    var revDeleted = 645504917;
+    var revRedirect = 591082967;
     var pageName = 'User:GWicke%2fDate';
     var pageLastRev = 653530930;
 

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -6,6 +6,7 @@
 var assert = require('../../utils/assert.js');
 var preq   = require('preq');
 var server = require('../../utils/server.js');
+var P = require('bluebird');
 var pagingToken = '';
 
 describe('revision requests', function() {
@@ -13,6 +14,8 @@ describe('revision requests', function() {
 	var revOk = 642497713;
 	var revDeleted = 645504917;
 	var revRedirect = 591082967;
+    var pageName = 'User:GWicke%2fDate';
+    var pageLastRev = 653530930;
 
     this.timeout(20000);
 
@@ -132,5 +135,13 @@ describe('revision requests', function() {
         })
     });
 
+    it('should return latest revision for a page', function () {
+        return preq.get({uri: server.config.bucketURL + '/title/' + pageName + '/latest'})
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body.items.length, 1);
+                assert.deepEqual(res.body.items[0].rev, pageLastRev);
+            });
+    });
 });
 

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -6,7 +6,6 @@
 var assert = require('../../utils/assert.js');
 var preq   = require('preq');
 var server = require('../../utils/server.js');
-var P = require('bluebird');
 var pagingToken = '';
 
 describe('revision requests', function() {
@@ -135,13 +134,15 @@ describe('revision requests', function() {
         })
     });
 
-    it('should return latest revision for a page', function () {
-        return preq.get({uri: server.config.bucketURL + '/title/' + pageName + '/latest'})
-            .then(function (res) {
-                assert.deepEqual(res.status, 200);
-                assert.deepEqual(res.body.items.length, 1);
-                assert.deepEqual(res.body.items[0].rev, pageLastRev);
-            });
+    it('should return latest revision for a page', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/title/' + pageName + '/latest'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, pageLastRev);
+        });
     });
 });
 


### PR DESCRIPTION
This changeset handles handles page deleted notifications. When the page is removed, the /page/{title}/latest endpoint is called. This makes us try to fetch the latest revision from MediaWiki API by calling fetchAndStoreMWRevision. If page is deleted this returns 404, and so we know that we need to mark the latest known by restbase revision with 'page_deleted' restriction. This is done by getting latest revision stored in restbase, modifying it and saving with a new timestamp.

Also this changes removes an optimisation in parsoid code, because now the assumption that the latest revision can never be restricted is wrong.

The test mocks http requests to MediaWiki API and simulates the situation when the page was deleted.
Also it tests that the /page/{title}/latest endpoint works correctly and that we return 404 on a deleted page.

In order to work correctly this needs [updates] (https://gerrit.wikimedia.org/r/#/c/221597/) to RestbaseUpdateJob extension