### PR TITLE
Added endpoint to translate sections to wikitext (T94890).

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -461,22 +461,25 @@ PSP.transformRevision = function (restbase, req, from, to) {
             original: original
         };
         if (from === 'sections') {
-            try {
-                var sections = JSON.parse(req.body.sections);
-                body2.html = {
-                    body: replaceSections(original, sections)
-                };
-                from = 'html';
-            } catch(e) {
-                // Catch JSON parsing exception and return 400
-                throw new rbUtil.HTTPError({
-                    status: 400,
-                    body: {
-                        type: 'invalid_request',
-                        description: 'Invalid JSON provided in the request'
-                    }
-                });
+            var sections = req.body.sections;
+            if (req.body.sections.constructor !== Object) {
+                try {
+                     sections = JSON.parse(req.body.sections.toString());
+                } catch (e) {
+                    // Catch JSON parsing exception and return 400
+                    throw new rbUtil.HTTPError({
+                        status: 400,
+                        body: {
+                            type: 'invalid_request',
+                            description: 'Invalid JSON provided in the request'
+                        }
+                    });
+                }
             }
+            body2.html = {
+                body: replaceSections(original, sections)
+            };
+            from = 'html';
         } else {
             body2[from] = req.body[from];
         }

--- a/mods/parsoid.yaml
+++ b/mods/parsoid.yaml
@@ -78,3 +78,8 @@ paths:
     post:
       summary: Transform wikitext to HTML.
       operationId: transformWikitextToHtml
+
+  /transform/sections/to/wikitext{/title}{/revision}:
+    post:
+      summary: Transform sections to wikitext.
+      operationId: transformSectionsToWikitext

--- a/mods/parsoid.yaml
+++ b/mods/parsoid.yaml
@@ -79,7 +79,7 @@ paths:
       summary: Transform wikitext to HTML.
       operationId: transformWikitextToHtml
 
-  /transform/sections/to/wikitext{/title}{/revision}:
+  /transform/sections/to/wikitext/{title}/{revision}:
     post:
       summary: Transform sections to wikitext.
       operationId: transformSectionsToWikitext

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -760,6 +760,52 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/html/to/html{/title}{/revision}
 
+  /{module:transform}/sections/to/wikitext/{title}/{revision}:
+    post:
+      tags:
+        - Transforms
+      description: >
+        Transform sections representation to wikitext
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      consumes:
+        - multipart/form-data
+      produces:
+        - text/html; profile=mediawiki.org/specs/html/1.0.0
+      parameters:
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: The page revision
+          type: integer
+          required: true
+        - name: sections
+          in: formData
+          description: Sections to transform
+          type: string
+          required: true
+      responses:
+        '200':
+          schema: 'https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec'
+        '403':
+          description: access to the specific revision is restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '404':
+          description: Unknown page title or revision
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/parsoid/transform/sections/to/wikitext/{title}/{revision}
+
 definitions:
   # A https://tools.ietf.org/html/draft-nottingham-http-problem
   problem:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -791,6 +791,10 @@ paths:
       responses:
         '200':
           schema: 'https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec'
+        '400':
+          description: Illegal JSON provided or section id does not exist
+          schema:
+            $ref: '#/definitions/problem'
         '403':
           description: access to the specific revision is restricted
           schema:

--- a/test/features/errors/invalid_request.js
+++ b/test/features/errors/invalid_request.js
@@ -38,4 +38,46 @@ describe('400 handling', function() {
             assert.contentType(e, 'application/problem+json');
         });
     });
+
+    it('Should return 400 on invalid JSON sections', function() {
+        var pageWithSectionsTitle = 'User:Pchelolo',
+            pageWithSectionsRev = 669197670;
+        return preq.post({
+            uri: server.config.baseURL
+                + '/transform/sections/to/wikitext/'
+                + pageWithSectionsTitle
+                + '/' + pageWithSectionsRev,
+            body: {
+                sections: '{"mwAQ":"First section replaced" INVALID}'
+            }
+        })
+        .then(function() {
+            throw new Error("400 should be returned");
+        })
+        .catch(function(e) {
+            assert.deepEqual(e.status, 400);
+            assert.contentType(e, 'application/problem+json');
+        });
+    });
+
+    it('Should return 400 if non-existent section id provided', function() {
+        var pageWithSectionsTitle = 'User:Pchelolo',
+            pageWithSectionsRev = 669197670;
+        return preq.post({
+            uri: server.config.baseURL
+                + '/transform/sections/to/wikitext/'
+                + pageWithSectionsTitle
+                + '/' + pageWithSectionsRev,
+            body: {
+                sections: '{"INVALID":"First section replaced"}'
+            }
+        })
+        .then(function() {
+            throw new Error("400 should be returned");
+        })
+        .catch(function(e) {
+            assert.deepEqual(e.status, 400);
+            assert.contentType(e, 'application/problem+json');
+        });
+    });
 });

--- a/test/features/errors/invalid_request.js
+++ b/test/features/errors/invalid_request.js
@@ -40,15 +40,15 @@ describe('400 handling', function() {
     });
 
     it('Should return 400 on invalid JSON sections', function() {
-        var pageWithSectionsTitle = 'User:Pchelolo',
-            pageWithSectionsRev = 669197670;
+        var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
+        var pageWithSectionsRev = 669458404;
         return preq.post({
             uri: server.config.baseURL
                 + '/transform/sections/to/wikitext/'
                 + pageWithSectionsTitle
                 + '/' + pageWithSectionsRev,
             body: {
-                sections: '{"mwAQ":"First section replaced" INVALID}'
+                sections: '{"mwAg":"First section replaced" INVALID}'
             }
         })
         .then(function() {
@@ -61,8 +61,8 @@ describe('400 handling', function() {
     });
 
     it('Should return 400 if non-existent section id provided', function() {
-        var pageWithSectionsTitle = 'User:Pchelolo',
-            pageWithSectionsRev = 669197670;
+        var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
+        var pageWithSectionsRev = 669458404;
         return preq.post({
             uri: server.config.baseURL
                 + '/transform/sections/to/wikitext/'

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -143,8 +143,47 @@ describe('transform api', function() {
         });
     });
 
-});
+    it('sections2wt, replace', function() {
+        var pageWithSectionsTitle = 'User:Pchelolo',
+            pageWithSectionsRev = 669197670;
+        return preq.post({
+            uri: server.config.baseURL
+                + '/transform/sections/to/wikitext/'
+                + pageWithSectionsTitle
+                + '/' + pageWithSectionsRev,
+            body: {
+                sections: '{"mwAQ":"<h2>First section replaced</h2>",'
+                    + '"mwAg":"<h2>Second section replaced</h2>"}'
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.contentType(res, 'text/plain;profile=mediawiki.org/specs/wikitext/1.0.0');
+            assert.deepEqual(/== First section replaced ==/.test(res.body), true);
+            assert.deepEqual(/== Second section replaced ==/.test(res.body), true);
+        });
+    });
 
+    it('sections2wt, append', function() {
+        var pageWithSectionsTitle = 'User:Pchelolo',
+            pageWithSectionsRev = 669197670;
+        return preq.post({
+            uri: server.config.baseURL
+                + '/transform/sections/to/wikitext/'
+                + pageWithSectionsTitle
+                + '/' + pageWithSectionsRev,
+            body: {
+                sections: '{"mwAQ":"<h2>First section replaced</h2><h2>Appended section</h2>"}'
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.contentType(res, 'text/plain;profile=mediawiki.org/specs/wikitext/1.0.0');
+            assert.deepEqual(/== Appended section ==/.test(res.body), true);
+            assert.deepEqual(/== Second section ==/.test(res.body), true);
+        });
+    });
+});
 
 
 /* TODO: actually implement wikitext fetching

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -187,6 +187,33 @@ describe('transform api', function() {
             assert.deepEqual(/== Second Section ==/.test(res.body), true);
         });
     });
+
+    it('sections2wt, append, application/json', function() {
+        var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
+        var pageWithSectionsRev = 669458404;
+        return preq.post({
+            uri: server.config.baseURL
+                + '/transform/sections/to/wikitext/'
+                + pageWithSectionsTitle
+                + '/' + pageWithSectionsRev,
+            body: {
+                sections: {
+                    'mwAg':'<h2>First Section replaced</h2><h2>Appended Section</h2>'
+                }
+            },
+            headers: {
+                'content-type': 'application/json'
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.contentType(res, 'text/plain;profile=mediawiki.org/specs/wikitext/1.0.0');
+            assert.deepEqual(/== First Section ==/.test(res.body), false);
+            assert.deepEqual(/== First Section replaced ==/.test(res.body), true);
+            assert.deepEqual(/== Appended Section ==/.test(res.body), true);
+            assert.deepEqual(/== Second Section ==/.test(res.body), true);
+        });
+    });
 });
 
 

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -144,43 +144,47 @@ describe('transform api', function() {
     });
 
     it('sections2wt, replace', function() {
-        var pageWithSectionsTitle = 'User:Pchelolo',
-            pageWithSectionsRev = 669197670;
+        var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
+        var pageWithSectionsRev = 669458404;
         return preq.post({
             uri: server.config.baseURL
                 + '/transform/sections/to/wikitext/'
                 + pageWithSectionsTitle
                 + '/' + pageWithSectionsRev,
             body: {
-                sections: '{"mwAQ":"<h2>First section replaced</h2>",'
-                    + '"mwAg":"<h2>Second section replaced</h2>"}'
+                sections: '{"mwAg":"<h2>First Section replaced</h2>",'
+                    + '"mwAw":"<h2>Second Section replaced</h2>"}'
             }
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'text/plain;profile=mediawiki.org/specs/wikitext/1.0.0');
-            assert.deepEqual(/== First section replaced ==/.test(res.body), true);
-            assert.deepEqual(/== Second section replaced ==/.test(res.body), true);
+            assert.deepEqual(/== First Section ==/.test(res.body), false);
+            assert.deepEqual(/== Second Section ==/.test(res.body), false);
+            assert.deepEqual(/== First Section replaced ==/.test(res.body), true);
+            assert.deepEqual(/== Second Section replaced ==/.test(res.body), true);
         });
     });
 
     it('sections2wt, append', function() {
-        var pageWithSectionsTitle = 'User:Pchelolo',
-            pageWithSectionsRev = 669197670;
+        var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
+        var pageWithSectionsRev = 669458404;
         return preq.post({
             uri: server.config.baseURL
                 + '/transform/sections/to/wikitext/'
                 + pageWithSectionsTitle
                 + '/' + pageWithSectionsRev,
             body: {
-                sections: '{"mwAQ":"<h2>First section replaced</h2><h2>Appended section</h2>"}'
+                sections: '{"mwAg":"<h2>First Section replaced</h2><h2>Appended Section</h2>"}'
             }
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'text/plain;profile=mediawiki.org/specs/wikitext/1.0.0');
-            assert.deepEqual(/== Appended section ==/.test(res.body), true);
-            assert.deepEqual(/== Second section ==/.test(res.body), true);
+            assert.deepEqual(/== First Section ==/.test(res.body), false);
+            assert.deepEqual(/== First Section replaced ==/.test(res.body), true);
+            assert.deepEqual(/== Appended Section ==/.test(res.body), true);
+            assert.deepEqual(/== Second Section ==/.test(res.body), true);
         });
     });
 });


### PR DESCRIPTION
A new endpoint /transform/sections/to/wikitext/{title}/{revision}
was added. It takes the original revision from restbase, replaces
sections according to JSON, provided in a sections parameter, and
posts it to parsoid for html->wikitext translation.

A set of tests was added verifying the sections could be replaced
and added, and verifying errors on non-existent sections and invalid
JSON.

Bug: https://phabricator.wikimedia.org/T94890