### PR TITLE
Added rawcontinue parameter to MediaWiki query requests,

### DIFF
--- a/mods/action.js
+++ b/mods/action.js
@@ -155,7 +155,7 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     body.action = defBody.action;
     body.format = body.format || defBody.format || 'json';
     body.formatversion = body.formatversion || defBody.formatversion || 1;
-    if (defBody.rawcontinue) {
+    if (defBody.rawcontinue && !body.continue) {
         body.rawcontinue = defBody.rawcontinue;
     }
     req.method = 'post';

--- a/mods/action.js
+++ b/mods/action.js
@@ -155,7 +155,7 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     body.action = defBody.action;
     body.format = body.format || defBody.format || 'json';
     body.formatversion = body.formatversion || defBody.formatversion || 1;
-    if (defBody.rawcontinue !== undefined) {
+    if (defBody.rawcontinue) {
         body.rawcontinue = defBody.rawcontinue;
     }
     req.method = 'post';
@@ -166,7 +166,7 @@ ActionService.prototype.query = function(restbase, req) {
     return this._doRequest(restbase, req, {
         action: 'query',
         format: 'json',
-        rawcontinue: ''
+        rawcontinue: 1
     }, buildQueryResponse);
 };
 

--- a/mods/action.js
+++ b/mods/action.js
@@ -155,7 +155,7 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     body.action = defBody.action;
     body.format = body.format || defBody.format || 'json';
     body.formatversion = body.formatversion || defBody.formatversion || 1;
-    if (defBody.rawcontinue && !body.continue) {
+    if (defBody.rawcontinue && !body.hasOwnProperty('continue')) {
         body.rawcontinue = defBody.rawcontinue;
     }
     req.method = 'post';

--- a/mods/action.js
+++ b/mods/action.js
@@ -155,6 +155,9 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     body.action = defBody.action;
     body.format = body.format || defBody.format || 'json';
     body.formatversion = body.formatversion || defBody.formatversion || 1;
+    if (defBody.rawcontinue !== undefined) {
+        body.rawcontinue = defBody.rawcontinue;
+    }
     req.method = 'post';
     return restbase[req.method](req).then(cont);
 };
@@ -162,7 +165,8 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
 ActionService.prototype.query = function(restbase, req) {
     return this._doRequest(restbase, req, {
         action: 'query',
-        format: 'json'
+        format: 'json',
+        rawcontinue: ''
     }, buildQueryResponse);
 };
 


### PR DESCRIPTION
MediaWiki API have deployed a breaking change in paging support, which breaks all restless listings.

(see https://lists.wikimedia.org/pipermail/wikitech-l/2015-June/081931.html)