### PR TITLE
Allow overlapping spec paths if methods are different.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -236,6 +236,11 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
                 specRoot.paths[prefixPath][methodName] = method;
             }
 
+            if (node.value.methods[methodName]) {
+                throw new Error('Trying to re-define existing method '
+                    + node.value.path + ':' + methodName);
+            }
+
             var backendRequest = method && method['x-backend-request'];
             if (backendRequest) {
                 // Set up a templated backend request handler
@@ -309,26 +314,24 @@ Router.prototype._handleSwaggerSpec = function (rootNode, spec, operations, spec
                 // specs are overlapping. We don't allow this for now to keep
                 // specs easy to read & understand.
                 subtree = branchNode.getChild(segment, {});
-                if (subtree) {
-                    throw new Error('Trying to re-define existing subtree ' + pathPattern);
-                }
+                if (!subtree) {
+                    // Build a new subtree
+                    subtree = new Node();
+                    // Set up our specific value object
+                    subtree.value = value;
+                    value.path = specRoot.basePath + subPrefixPath;
+                    value.methods = {};
+                    // XXX: Set ACLs and other value properties for path
+                    // subtree.value.acls = ...;
 
-                // Build a new subtree
-                subtree = new Node();
-                // Set up our specific value object
-                subtree.value = value;
-                value.path = specRoot.basePath + subPrefixPath;
-                value.methods = {};
-                // XXX: Set ACLs and other value properties for path
-                // subtree.value.acls = ...;
-
-                if (segment.modifier === '+') {
-                    // Set up a recursive match and end the traversal
-                    subtree.setChild(segment, subtree);
-                } else if (segment.modifier === '/') {
-                    // Since this path segment is optional, the parent node
-                    // has the same value.
-                    branchNode.value = value;
+                    if (segment.modifier === '+') {
+                        // Set up a recursive match and end the traversal
+                        subtree.setChild(segment, subtree);
+                    } else if (segment.modifier === '/') {
+                        // Since this path segment is optional, the parent node
+                        // has the same value.
+                        branchNode.value = value;
+                    }
                 }
 
                 // Assign the node before building the tree, so that sharing


### PR DESCRIPTION
In case paths are overlapping in a spec we throw an error indicating
that, but in case methods are not overlapping it's incorrect.