### PR TITLE
Expose RESTBase monitoring examples in Swagger spec

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -41,6 +41,7 @@ templates:
         - user:read
     x-subspecs:
       - mediawiki/v1/content
+      - mediawiki_v1_graphoid
       - test
 
   wmf-sys-1.0.0: &wp/sys/1.0.0
@@ -99,6 +100,17 @@ templates:
               # For local testing, use:
               # parsoidHost: http://localhost:8000
 
+      /{module:graphoid}:
+        x-modules:
+          - name: simple_service
+            version: 1.0.0
+            type: file
+            options:
+              paths:
+                /v1/png/{title}/{revision}/{graph_id}:
+                  get:
+                    backend_request:
+                      uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
 
       /{module:action}:
         x-modules:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -110,7 +110,7 @@ templates:
                 /v1/png/{title}/{revision}/{graph_id}:
                   get:
                     backend_request:
-                      uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
+                      uri: http://graphoid.wikimedia.org/en.wikipedia.org/v1/png/{title}/{revision}/{graph_id}
 
       /{module:action}:
         x-modules:
@@ -157,6 +157,7 @@ spec: &spec
   title: "The RESTBase root"
   # Some more general RESTBase info
   paths:
+    /{domain:en.wikipedia.org}: *wp/default/1.0.0
     # test domain
     /{domain:en.wikipedia.test.local}: *wp/default/1.0.0
 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -157,7 +157,6 @@ spec: &spec
   title: "The RESTBase root"
   # Some more general RESTBase info
   paths:
-    /{domain:en.wikipedia.org}: *wp/default/1.0.0
     # test domain
     /{domain:en.wikipedia.test.local}: *wp/default/1.0.0
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -154,6 +154,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
             specRoot = Object.assign({}, subSpec);
             specRoot.paths = {};
             specRoot.definitions = {};
+            specRoot['x-default-params'] = {};
             specRoot.basePath = specRootBasePath + prefixPath;
             prefixPath = '';
             // XXX: The basePath is incorrect when shared between domains. Set
@@ -265,12 +266,16 @@ Router.prototype._handleSwaggerSpec = function (rootNode, spec, operations, spec
         specRoot = spec;
         if (!spec.paths) { spec.paths = {}; }
         if (!spec.definitions) { spec.definitions = {}; }
+        if (!spec['x-default-params']) {spec['x-default-params'] = {}; }
         if (!spec.basePath) { spec.basePath  = prefixPath || ''; }
         prefixPath = '';
     }
     if (spec.definitions) {
         // Merge definitions
         Object.assign(specRoot.definitions, spec.definitions);
+    }
+    if (spec['x-default-params']) {
+        Object.assign(specRoot['x-default-params'], spec['x-default-params']);
     }
     var self = this;
     function handlePaths (paths) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -266,7 +266,7 @@ Router.prototype._handleSwaggerSpec = function (rootNode, spec, operations, spec
         specRoot = spec;
         if (!spec.paths) { spec.paths = {}; }
         if (!spec.definitions) { spec.definitions = {}; }
-        if (!spec['x-default-params']) {spec['x-default-params'] = {}; }
+        if (!spec['x-default-params']) { spec['x-default-params'] = {}; }
         if (!spec.basePath) { spec.basePath  = prefixPath || ''; }
         prefixPath = '';
     }

--- a/mods/simple_service.js
+++ b/mods/simple_service.js
@@ -55,9 +55,6 @@ SimpleService.prototype.processSpec = function(spec) {
                 }
 
                 function backendRequest() {
-                    if (req.params.domain === 'en.wikipedia.test.local') {
-                        req.params.domain = 'en.wikipedia.org';
-                    }
                     var beReq = {
                         uri: backendUriTemplate.toString({
                             params: req.params

--- a/mods/simple_service.js
+++ b/mods/simple_service.js
@@ -55,6 +55,9 @@ SimpleService.prototype.processSpec = function(spec) {
                 }
 
                 function backendRequest() {
+                    if (req.params.domain === 'en.wikipedia.test.local') {
+                        req.params.domain = 'en.wikipedia.org';
+                    }
                     var beReq = {
                         uri: backendUriTemplate.toString({
                             params: req.params

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -96,12 +96,27 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/{title}
       x-amples:
-        - title: Should get a latest revision of a page by title
+        - title: Get rev of by title from MW
           request:
             params:
               title: Foobar
             headers:
               cache-control: no-cache
+          response:
+            status: 200
+            headers:
+              etag: /.+/
+              content-type: application/json
+            body:
+              items:
+                - title: 'Foobar'
+                  rev: /\d+/
+                  tid: /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+                  comment: /.*/
+        - title: Get rev by title from storage
+          request:
+            params:
+              title: Foobar
           response:
             status: 200
             headers:
@@ -222,7 +237,17 @@ paths:
         # See also http://tools.ietf.org/html/rfc7231#section-7.1.2
         uri: /{domain}/sys/parsoid/html/{title}
       x-amples:
-        - title: Should get a latest html of a page by title
+        - title: Get html by title from Parsoid
+          request:
+            params:
+              title: Foobar
+          response:
+            status: 200
+            headers:
+              etag: /.+/
+              content-type: /^text/html;\s?profile=mediawiki.org/specs/html/\d\.\d\.\d.*/
+            body: /^<!DOCTYPE html>.*/
+        - title: Get html by title from storage
           request:
             params:
               title: Foobar
@@ -232,7 +257,7 @@ paths:
             status: 200
             headers:
               etag: /.+/
-              content-type: text/html
+              content-type: /^text/html;\s?profile=mediawiki.org/specs/html/\d\.\d\.\d.*/
             body: /^<!DOCTYPE html>.*/
 #    post:
 #      tags:
@@ -455,12 +480,10 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}
       x-amples:
-        - title: Should get a latest data-parsoid of a page by title
+        - title: Get data-parsoid by title
           request:
             params:
               title: Foobar
-            headers:
-              cache-control: no-cache
           response:
             status: 200
             headers:
@@ -627,7 +650,7 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/page_revisions/rev/{revision}
       x-amples:
-        - title: Should get a revision
+        - title: Get rev by ID
           request:
             params:
               revision: 642497713
@@ -804,7 +827,7 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/wikitext/to/html{/title}{/revision}
       x-amples:
-        - title: Should transform wikitext to html
+        - title: Transform wikitext to html
           request:
             params:
               title: Foobar
@@ -816,7 +839,7 @@ paths:
           response:
             status: 200
             headers:
-              content-type: text/html
+              content-type: /^text/html;\s?profile=mediawiki.org/specs/html/\d\.\d\.\d.*/
             body: /^<h2.*> Heading <\/h2>$/
 
   /{module:transform}/html/to/html{/title}{/revision}:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -34,6 +34,7 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+      x-monitor: false
 
   /{module:page}/title/:
     get:
@@ -62,6 +63,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/
+      x-monitor: false
 
   /{module:page}/title/{title}:
     get:
@@ -95,6 +97,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/{title}
+      x-monitor: true
       x-amples:
         - title: Get rev of by title from MW
           request:
@@ -164,6 +167,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/{title}/
+      x-monitor: false
 
   /{module:page}/html/:
     get:
@@ -193,6 +197,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/
+      x-monitor: false
 
   /{module:page}/html/{title}:
     get:
@@ -236,11 +241,14 @@ paths:
         # work in current Chrome and Firefox.
         # See also http://tools.ietf.org/html/rfc7231#section-7.1.2
         uri: /{domain}/sys/parsoid/html/{title}
+      x-monitor: true
       x-amples:
         - title: Get html by title from Parsoid
           request:
             params:
               title: Foobar
+            headers:
+              cache-control: no-cache
           response:
             status: 200
             headers:
@@ -251,8 +259,6 @@ paths:
           request:
             params:
               title: Foobar
-            headers:
-              cache-control: no-cache
           response:
             status: 200
             headers:
@@ -356,7 +362,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/html/{title}/
-
+      x-monitor: false
 
   /{module:page}/html/{title}/{revision}{/tid}:
     get:
@@ -416,6 +422,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/html/{title}/{revision}{/tid}
+      x-monitor: false
 
   /{module:page}/data-parsoid/:
     get:
@@ -447,6 +454,7 @@ paths:
         # Fixme: only list pages that have at least one revision with content
         # model 'wikitext'
         uri: /{domain}/sys/page_revisions/page/
+      x-monitor: false
 
   /{module:page}/data-parsoid/{title}:
     get:
@@ -479,6 +487,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}
+      x-monitor: true
       x-amples:
         - title: Get data-parsoid by title
           request:
@@ -531,6 +540,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}/
+      x-monitor: false
 
   /{module:page}/data-parsoid/{title}/{revision}{/tid}:
     get:
@@ -581,6 +591,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}/{revision}{/tid}
+      x-monitor: false
 
   /{module:page}/revision/:
     get:
@@ -609,6 +620,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/rev/
+      x-monitor: false
 
   /{module:page}/revision/{revision}:
     get:
@@ -649,6 +661,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/rev/{revision}
+      x-monitor: true
       x-amples:
         - title: Get rev by ID
           request:
@@ -775,6 +788,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/html/to/wikitext{/title}{/revision}
+      x-monitor: false
 
   /{module:transform}/wikitext/to/html{/title}{/revision}:
     post:
@@ -826,13 +840,12 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/wikitext/to/html{/title}{/revision}
+      x-monitor: true
       x-amples:
         - title: Transform wikitext to html
           request:
             params:
               title: Foobar
-            headers:
-              cache-control: no-cache
             body:
               wikitext: == Heading ==
               bodyOnly: true
@@ -892,6 +905,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/html/to/html{/title}{/revision}
+      x-monitor: false
 
   /{module:transform}/sections/to/wikitext/{title}/{revision}:
     post:
@@ -942,6 +956,7 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/sections/to/wikitext/{title}/{revision}
+      x-monitor: false
 
 definitions:
   # A https://tools.ietf.org/html/draft-nottingham-http-problem

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -107,7 +107,12 @@ paths:
             headers:
               etag: /.+/
               content-type: application/json
-
+            body:
+              items:
+                - title: 'Foobar'
+                  rev: /\d+/
+                  tid: /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+                  comment: /.*/
 
   /{module:page}/title/{title}/:
     get:
@@ -228,6 +233,7 @@ paths:
             headers:
               etag: /.+/
               content-type: text/html
+            body: /^<!DOCTYPE html>.*/
 #    post:
 #      tags:
 #        - Page content
@@ -460,6 +466,10 @@ paths:
             headers:
               etag: /.+/
               content-type: application/json
+            body:
+              counter: /\d+/
+              ids: /.*/
+              sectionOffsets: /.*/
 
   /{module:page}/data-parsoid/{title}/:
     get:
@@ -626,6 +636,12 @@ paths:
             headers:
               etag: /.+/
               content-type: application/json
+            body:
+              items:
+                - title: 'Foobar'
+                  rev: /\d+/
+                  tid: /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+                  comment: /.*/
 #  /{module:page}/wikitext/{title}:
 #    post:
 #      tags:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -253,7 +253,7 @@ paths:
             status: 200
             headers:
               etag: /.+/
-              content-type: /^text/html;\s?profile=mediawiki.org/specs/html/\d\.\d\.\d.*/
+              content-type: /^text\/html.+/
             body: /^<!DOCTYPE html>.*/
         - title: Get html by title from storage
           request:
@@ -263,7 +263,7 @@ paths:
             status: 200
             headers:
               etag: /.+/
-              content-type: /^text/html;\s?profile=mediawiki.org/specs/html/\d\.\d\.\d.*/
+              content-type: /^text\/html.+/
             body: /^<!DOCTYPE html>.*/
 #    post:
 #      tags:
@@ -852,7 +852,7 @@ paths:
           response:
             status: 200
             headers:
-              content-type: /^text/html;\s?profile=mediawiki.org/specs/html/\d\.\d\.\d.*/
+              content-type: /^text\/html.+/
             body: /^<h2.*> Heading <\/h2>$/
 
   /{module:transform}/html/to/html{/title}{/revision}:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -11,7 +11,8 @@ info:
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0
-
+x-default-params:
+  domain: en.wikipedia.org
 paths:
 
   /{module:page}/:
@@ -94,6 +95,19 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/{title}
+      x-amples:
+        - title: Should get a latest revision of a page by title
+          request:
+            params:
+              title: Foobar
+            headers:
+              cache-control: no-cache
+          response:
+            status: 200
+            headers:
+              etag: /.+/
+              content-type: application/json
+
 
   /{module:page}/title/{title}/:
     get:
@@ -202,6 +216,18 @@ paths:
         # work in current Chrome and Firefox.
         # See also http://tools.ietf.org/html/rfc7231#section-7.1.2
         uri: /{domain}/sys/parsoid/html/{title}
+      x-amples:
+        - title: Should get a latest html of a page by title
+          request:
+            params:
+              title: Foobar
+            headers:
+              cache-control: no-cache
+          response:
+            status: 200
+            headers:
+              etag: /.+/
+              content-type: text/html
 #    post:
 #      tags:
 #        - Page content
@@ -422,6 +448,18 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}
+      x-amples:
+        - title: Should get a latest data-parsoid of a page by title
+          request:
+            params:
+              title: Foobar
+            headers:
+              cache-control: no-cache
+          response:
+            status: 200
+            headers:
+              etag: /.+/
+              content-type: application/json
 
   /{module:page}/data-parsoid/{title}/:
     get:
@@ -578,7 +616,16 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/rev/{revision}
-
+      x-amples:
+        - title: Should get a revision
+          request:
+            params:
+              revision: 642497713
+          response:
+            status: 200
+            headers:
+              etag: /.+/
+              content-type: application/json
 #  /{module:page}/wikitext/{title}:
 #    post:
 #      tags:
@@ -740,6 +787,21 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/wikitext/to/html{/title}{/revision}
+      x-amples:
+        - title: Should transform wikitext to html
+          request:
+            params:
+              title: Foobar
+            headers:
+              cache-control: no-cache
+            body:
+              wikitext: == Heading ==
+              bodyOnly: true
+          response:
+            status: 200
+            headers:
+              content-type: text/html
+            body: /^<h2.*> Heading <\/h2>$/
 
   /{module:transform}/html/to/html{/title}{/revision}:
     post:

--- a/specs/mediawiki_v1_graphoid.yaml
+++ b/specs/mediawiki_v1_graphoid.yaml
@@ -52,7 +52,7 @@ paths:
         uri: /{domain}/sys/graphoid/v1/png/{title}/{revision}/{graph_id}
 
       x-amples:
-        - title: Should get a graph from graphoid
+        - title: Get a graph from Graphoid
           request:
             params:
               title: User:Pchelolo/Graph

--- a/specs/mediawiki_v1_graphoid.yaml
+++ b/specs/mediawiki_v1_graphoid.yaml
@@ -51,6 +51,7 @@ paths:
       x-backend-request:
         uri: /{domain}/sys/graphoid/v1/png/{title}/{revision}/{graph_id}
 
+      x-monitor: true
       x-amples:
         - title: Get a graph from Graphoid
           request:

--- a/specs/mediawiki_v1_graphoid.yaml
+++ b/specs/mediawiki_v1_graphoid.yaml
@@ -50,3 +50,15 @@ paths:
 
       x-backend-request:
         uri: /{domain}/sys/graphoid/v1/png/{title}/{revision}/{graph_id}
+
+      x-amples:
+        - title: Should get a graph from graphoid
+          request:
+            params:
+              title: User:Pchelolo/Graph
+              revision: 670213569
+              graph_id: 1533aaad45c733dcc7e07614b54cbae4119a6747.png
+          response:
+            status: 200
+            headers:
+              content-type: image/png

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -7,6 +7,7 @@ paths:
     get:
       x-backend-request:
         uri: /{domain}/sys/testservice/test/{title}{/revision}
+      x-monitor: false
 
   /{module:page}/wikitext/{title}:
     post:
@@ -71,4 +72,5 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_save/wikitext/{title}
+      x-monitor: false
 

--- a/test/features/specification/monitoring.js
+++ b/test/features/specification/monitoring.js
@@ -1,0 +1,136 @@
+'use strict';
+
+var preq   = require('preq');
+var assert = require('../../utils/assert.js');
+var server = require('../../utils/server.js');
+var URI    = require('swagger-router').URI;
+
+function constructTestCase(title, path, method, request, response) {
+    return {
+        title: title,
+        request: {
+            uri: server.config.baseURL + '/' + (path[0] === '/' ? path.substr(1) : path),
+            method: method,
+            headers: request.headers || {},
+            query: request.query,
+            body: request.body,
+            followRedirect: false
+        },
+        response: {
+            status: response.status || 200,
+            headers: response.headers || {},
+            body: response.body
+        }
+    };
+}
+
+function constructTests(paths, defParams) {
+    var ret = [];
+    Object.keys(paths).forEach(function(pathStr) {
+        Object.keys(paths[pathStr]).filter(function(method) {
+            return !!paths[pathStr][method]['x-amples'];
+        })
+        .forEach(function(method) {
+            var p = paths[pathStr][method];
+            var uri = new URI(pathStr, {}, true);
+            p['x-amples'].forEach(function(ex) {
+                ex.request = ex.request || {};
+                ret.push(constructTestCase(
+                    ex.title,
+                    uri.toString({params: Object.assign({}, defParams, ex.request.params || {})}),
+                    method,
+                    ex.request,
+                    ex.response || {},
+                    defParams
+                ));
+            });
+        });
+    });
+    return ret;
+}
+
+
+function cmp(result, expected, errMsg) {
+    expected = expected || '';
+    result = result || '';
+    if(expected.length > 1 && expected[0] === '/' && expected[expected.length - 1] === '/') {
+        if((new RegExp(expected.slice(1, -1))).test(result)) {
+            return true;
+        }
+    } else if(expected.length === 0 && result.length === 0) {
+        return true;
+    } else if(result === expected || result.indexOf(expected) === 0) {
+        return true;
+    }
+    assert.deepEqual(result, expected, errMsg);
+    return true;
+}
+
+
+function validateTestResponse(testCase, res) {
+    var expRes = testCase.response;
+    assert.deepEqual(res.status, expRes.status);
+    Object.keys(expRes.headers).forEach(function(key) {
+        var val = expRes.headers[key];
+        assert.deepEqual(res.headers.hasOwnProperty(key), true, 'Header ' + key + ' not found in response!');
+        cmp(res.headers[key], val, key + ' header mismatch!');
+    });
+    // check the body
+    if(!expRes.body) {
+        return true;
+    }
+    res.body = res.body || '';
+    if(Buffer.isBuffer(res.body)) { res.body = res.body.toString(); }
+    if(expRes.body.constructor !== res.body.constructor) {
+        if(expRes.body.constructor === String) {
+            res.body = JSON.stringify(res.body);
+        } else {
+            res.body = JSON.parse(res.body);
+        }
+    }
+    if(expRes.body.constructor === Object) {
+        Object.keys(expRes.body).forEach(function(key) {
+            var val = expRes.body[key];
+            assert.deepEqual(res.body.hasOwnProperty(key), true, 'Body field ' + key + ' not found in response!');
+            cmp(res.body[key], val, key + ' body field mismatch!');
+        });
+    } else {
+        cmp(res.body, expRes.body, 'Body mismatch!');
+    }
+
+    return true;
+
+}
+
+describe('Monitoring endpoints', function() {
+    this.timeout(20000);
+
+    var spec;
+    before(function () {
+        return server.start();
+    });
+
+    it('should get the spec', function() {
+        return preq.get(server.config.baseURL + '/?spec')
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.contentType(res, 'application/json');
+            assert.notDeepEqual(res.body, undefined, 'No body received!');
+            return res.body;
+        }).then(function(spec) {
+            describe('monitoring routes', function() {
+                constructTests(spec.paths, spec['x-default-params'] || {}).forEach(function(testCase) {
+                    it(testCase.title, function() {
+                        return preq(testCase.request)
+                        .then(function(res) {
+                            validateTestResponse(testCase, res);
+                        }, function(err) {
+                            validateTestResponse(testCase, err);
+                        });
+                    });
+                });
+            });
+        });
+    });
+});
+

--- a/test/features/specification/monitoring.js
+++ b/test/features/specification/monitoring.js
@@ -75,7 +75,6 @@ function validateTestResponse(testCase, res) {
         assert.deepEqual(res.headers.hasOwnProperty(key), true, 'Header ' + key + ' not found in response!');
         cmp(res.headers[key], val, key + ' header mismatch!');
     });
-    // check the body
     if(!expRes.body) {
         return true;
     }
@@ -97,12 +96,10 @@ function validateTestResponse(testCase, res) {
     } else {
         cmp(res.body, expRes.body, 'Body mismatch!');
     }
-
     return true;
-
 }
 
-describe('Monitoring endpoints', function() {
+describe('Monitoring tests', function() {
     this.timeout(20000);
 
     var spec;
@@ -117,14 +114,16 @@ describe('Monitoring endpoints', function() {
             assert.contentType(res, 'application/json');
             assert.notDeepEqual(res.body, undefined, 'No body received!');
             return res.body;
-        }).then(function(spec) {
-            describe('monitoring routes', function() {
+        })
+        .then(function(spec) {
+            describe('Monitoring endpoints', function() {
                 constructTests(spec.paths, spec['x-default-params'] || {}).forEach(function(testCase) {
                     it(testCase.title, function() {
                         return preq(testCase.request)
                         .then(function(res) {
                             validateTestResponse(testCase, res);
-                        }, function(err) {
+                        })
+                        .catch(function(err) {
                             validateTestResponse(testCase, err);
                         });
                     });


### PR DESCRIPTION
Added x-amples to several endpoints to allow enabling monitoring.
Covered endpoints:
- /page/title/{title}
- /page/html/{title}
- /page/data-parsoid/{title}
- /page/revision/{revision}
- /transform/wikitext/to/html{/title}{/revision}
- /page/graph/png/{title}/{revision}/{graph_id}

This gives fine coverage while not creating too much load.
Also a monitoring.js test was added which runs all tests based on x-amples. The test is mostly copy-pasted from https://github.com/wikimedia/service-template-node/pull/39 and in future this should be probably replaced by an actual library that would be used for monitoring. 

The actual body is checked only partially to make it independent from any changes that might happen to the page. More specific matching would be added when there's an actual monitoring lib in place.

Bug: https://phabricator.wikimedia.org/T104850