### PR TITLE
Improve RESTBase CSP headers: use 'self' instead of *, allow inline s…

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -57,19 +57,21 @@ rbUtil.wildcardSubdomain = function(domain) {
 /**
  * Constructs Content-Security-Policy header to send in response
  *
- * @param allowInline if true 'unsafe-inline' is added to style-src
+ * @param domain the domain to allow. If undefined, '*' is allowed
+ * @param options options containing the following fields:
+ *                - allowInline - if true 'unsafe-inline' is added to style-src
  * @returns {string} CSP header value
  */
-rbUtil.constructCSP = function(req, allowInline) {
+rbUtil.constructCSP = function(domain, options) {
     var styleSource;
-    if (req.params && req.params.domain) {
-        styleSource = this.wildcardSubdomain(req.params.domain);
+    if (domain) {
+        styleSource = this.wildcardSubdomain(domain);
         styleSource = 'http://' + styleSource + ' https://' + styleSource;
     } else {
         styleSource = '*';
     }
     return "default-src 'none'; media-src *; img-src *; style-src " + styleSource
-        + (allowInline ? " 'unsafe-inline'" : "") + "; frame-ancestors 'self'";
+        + (options && options.allowInline ? " 'unsafe-inline'" : "") + "; frame-ancestors 'self'";
 };
 
 // Parse a POST request into request.body with BusBoy

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -40,6 +40,38 @@ rbUtil.parseURL = function parseURL (uri) {
     }
 };
 
+/**
+ * Replaces subdomain with a wildcard
+ *
+ * @param domain a full domain name (e.g. en.wikipedia.org)
+ * @returns {string} wildcard version (e.g. *.wikipedia.org)
+ */
+rbUtil.wildcardSubdomain = function(domain) {
+    if ((domain.match(/\./g) || []).length >= 2) {
+        return '*.' + domain.replace(/^[^.]+\./, "");
+    } else {
+        return domain;
+    }
+};
+
+/**
+ * Constructs Content-Security-Policy header to send in response
+ *
+ * @param allowInline if true 'unsafe-inline' is added to style-src
+ * @returns {string} CSP header value
+ */
+rbUtil.constructCSP = function(req, allowInline) {
+    var styleSource;
+    if (req.params && req.params.domain) {
+        styleSource = this.wildcardSubdomain(req.params.domain);
+        styleSource = 'http://' + styleSource + ' https://' + styleSource;
+    } else {
+        styleSource = '*';
+    }
+    return "default-src 'none'; media-src *; img-src *; style-src " + styleSource
+        + (allowInline ? " 'unsafe-inline'" : "") + "; frame-ancestors 'self'";
+};
+
 // Parse a POST request into request.body with BusBoy
 // Drops file uploads on the floor without creating temporary files
 //

--- a/lib/server.js
+++ b/lib/server.js
@@ -44,7 +44,7 @@ function handleResponse (opts, req, resp, response) {
         if (!/^application\/json/.test(rh['content-type'])) {
             rh['X-XSS-Protection'] = '1; mode=block';
             if (!rh['Content-Security-Policy']) {
-                rh['Content-Security-Policy'] = rbUtil.constructCSP(req, false);
+                rh['Content-Security-Policy'] = rbUtil.constructCSP(req.params ? req.params.domain : undefined);
             }
             // For IE 10 & 11
             rh['X-Content-Security-Policy'] = rh['Content-Security-Policy'];

--- a/lib/server.js
+++ b/lib/server.js
@@ -44,8 +44,7 @@ function handleResponse (opts, req, resp, response) {
         if (!/^application\/json/.test(rh['content-type'])) {
             rh['X-XSS-Protection'] = '1; mode=block';
             if (!rh['Content-Security-Policy']) {
-                rh['Content-Security-Policy'] =
-                    "default-src 'none'; media-src *; img-src *; style-src *; frame-ancestors 'self'";
+                rh['Content-Security-Policy'] = rbUtil.constructCSP(req, false);
             }
             // For IE 10 & 11
             rh['X-Content-Security-Policy'] = rh['Content-Security-Policy'];

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -323,7 +323,7 @@ PSP.getFormat = function (format, restbase, req) {
             && rp.revision)
     {
         // Check content generation either way
-        return contentReq.then(function(res) {
+        contentReq = contentReq.then(function(res) {
                 if (req.headers['if-unmodified-since']) {
                     try {
                         var jobTime = Date.parse(req.headers['if-unmodified-since']);
@@ -345,13 +345,19 @@ PSP.getFormat = function (format, restbase, req) {
             generateContent);
     } else {
         // Only (possibly) generate content if there was an error
-        return contentReq
-        .then(function(res) {
+        contentReq = contentReq.then(function(res) {
             return self.wrapContentReq(restbase, req, P.resolve(res), format);
         },
         generateContent // No need to wrap generateContent
         );
     }
+    return contentReq
+    .then(function(res) {
+        if (res && res.headers && !/^application\/json/.test(res.headers['content-type'])) {
+            res.headers['Content-Security-Policy'] = rbUtil.constructCSP(req, true);
+        }
+        return res;
+    });
 };
 
 PSP.listRevisions = function (format, restbase, req) {

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -354,7 +354,7 @@ PSP.getFormat = function (format, restbase, req) {
     return contentReq
     .then(function(res) {
         if (res && res.headers && !/^application\/json/.test(res.headers['content-type'])) {
-            res.headers['Content-Security-Policy'] = rbUtil.constructCSP(req, true);
+            res.headers['Content-Security-Policy'] = rbUtil.constructCSP(rp.domain, { allowInline: true } );
         }
         return res;
     });

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -200,5 +200,14 @@ describe('on-demand generation of html and data-parsoid', function() {
         });
     });
 
-
+    it('should return correct Content-Security-Policy header', function () {
+        return preq.get({
+            uri: pageUrl + '/html/' + title
+        })
+        .then(function (res) {
+            assert.deepEqual(!!res.headers['content-security-policy'], true);
+            assert.deepEqual(res.headers['content-security-policy']
+                .indexOf("style-src http://*.wikipedia.test.local https://*.wikipedia.test.local 'unsafe-inline'") > 0, true);
+        });
+    });
 });


### PR DESCRIPTION
'self' doesn't work for localhost tests, so actual domains were added.
This should've been as easy as adding a domain name, but looks like Safari
doesn't support subdomains and lack of protocol, so for en.wikipedia.org
we actually need `http://*.wikipedia.org https://*.wikipedia.org`

Also 'unsafe-inline' attribute added for html that we've got from Parsoid and
therefor know it's sanitazed and safe.

Bug: https://phabricator.wikimedia.org/T104913