### PR TITLE
Switch to the new MW API continuation mode

### DIFF
--- a/mods/action.js
+++ b/mods/action.js
@@ -130,7 +130,7 @@ function buildQueryResponse(res) {
     // XXX: Clean this up!
     res.body = {
         items: newBody,
-        next: res.body["query-continue"]
+        next: res.body["continue"]
     };
     return res;
 }
@@ -155,8 +155,8 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     body.action = defBody.action;
     body.format = body.format || defBody.format || 'json';
     body.formatversion = body.formatversion || defBody.formatversion || 1;
-    if (defBody.rawcontinue && !body.hasOwnProperty('continue')) {
-        body.rawcontinue = defBody.rawcontinue;
+    if (!body.hasOwnProperty('continue')) {
+        body.continue = '';
     }
     req.method = 'post';
     return restbase[req.method](req).then(cont);
@@ -165,8 +165,7 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
 ActionService.prototype.query = function(restbase, req) {
     return this._doRequest(restbase, req, {
         action: 'query',
-        format: 'json',
-        rawcontinue: 1
+        format: 'json'
     }, buildQueryResponse);
 };
 

--- a/mods/key_rev_value.js
+++ b/mods/key_rev_value.js
@@ -234,7 +234,7 @@ KRVBucket.prototype.listRevisions = function(restbase, req) {
     }
     return restbase.get(storeRequest)
     .then(function(res) {
-        var result = {
+        return {
             status: 200,
             headers: {
                 'content-type': 'application/json'
@@ -242,13 +242,10 @@ KRVBucket.prototype.listRevisions = function(restbase, req) {
             body: {
                 items: res.body.items.map(function(row) {
                     return { revision: row.rev, tid: row.tid };
-                })
+                }),
+                next: res.body.next
             }
         };
-        if (res.body.next) {
-            result.next = res.body.next;
-        }
-        return result;
     });
 };
 

--- a/mods/key_rev_value.js
+++ b/mods/key_rev_value.js
@@ -226,7 +226,7 @@ KRVBucket.prototype.listRevisions = function(restbase, req) {
                 key: req.params.key
             },
             proj: ['rev', 'tid'],
-            limit: 1000
+            limit: (req.body && req.body.limit) ? req.body.limit : restbase.rb_config.default_page_size
         }
     };
     if (rp.revision) {
@@ -234,7 +234,7 @@ KRVBucket.prototype.listRevisions = function(restbase, req) {
     }
     return restbase.get(storeRequest)
     .then(function(res) {
-        return {
+        var result = {
             status: 200,
             headers: {
                 'content-type': 'application/json'
@@ -245,6 +245,10 @@ KRVBucket.prototype.listRevisions = function(restbase, req) {
                 })
             }
         };
+        if (res.body.next) {
+            result.next = res.body.next;
+        }
+        return result;
     });
 };
 

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -136,13 +136,12 @@ PRS.prototype.listTitles = function(restbase, req, options) {
             generator: 'allpages',
             gaplimit: restbase.rb_config.default_page_size,
             prop: 'revisions',
-            format: 'json',
-            gapcontinue: ''
+            format: 'json'
         }
     };
 
     if (req.query.page) {
-        listReq.body.gapcontinue = restbase.decodeToken(req.query.page);
+        Object.assign(listReq.body, restbase.decodeToken(req.query.page));
     }
 
     return restbase.get(listReq)
@@ -158,7 +157,7 @@ PRS.prototype.listTitles = function(restbase, req, options) {
         var next = {};
         if (res.body.next) {
             next = {
-                next: { "href": "?page="+restbase.encodeToken(res.body.next.allpages.gapcontinue) } 
+                next: { "href": "?page="+restbase.encodeToken(res.body.next) }
             };
         }
 
@@ -425,12 +424,11 @@ PRS.prototype.listRevisions = function(restbase, req) {
             generator: 'allpages',
             gaplimit: restbase.rb_config.default_page_size,
             prop: 'revisions',
-            format: 'json',
-            gapcontinue: ''
+            format: 'json'
         }
     };
     if (req.query.page) {
-        listReq.body.gapcontinue = restbase.decodeToken(req.query.page);
+        Object.assign(listReq.body, restbase.decodeToken(req.query.page));
     }
     return restbase.get(listReq)
     .then(function(res) {
@@ -443,7 +441,7 @@ PRS.prototype.listRevisions = function(restbase, req) {
         var next={};
         if (res.body.next) {
             next = { 
-                next: { "href": "?page="+restbase.encodeToken(res.body.next.allpages.gapcontinue) } 
+                next: { "href": "?page="+restbase.encodeToken(res.body.next) }
             };
         }
 

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -372,7 +372,7 @@ PSP.listRevisions = function (format, restbase, req) {
     .then(function(res) {
         if (res.body.next) {
             res.body._links = {
-                next: { "href": "?page="+restbase.encodeToken(res.body.next.allpages.gapcontinue) }
+                next: { "href": "?page="+restbase.encodeToken(res.body.next) }
             };
         }
         return res;


### PR DESCRIPTION
Switch to the new MW API continue. Action module doesn't set rawcontinue any more,
but sets a continue parameter instead. All paces using MW API continuation were updated.
Places where we make a request to storage are not updated.

Docs says we need to provide everything returned in the previous continue field to the new request, so `Object.assign()` is used.

Also parsoid provided paging info to rev_key_values, but it was not honoured. 

Bug: https://phabricator.wikimedia.org/T104703