### PR TITLE
Fix transparent revision retrieval without explicit revision id

### DIFF
--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -352,6 +352,12 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
                         }
                     });
                 }
+            })
+            .catch(function(e) {
+                if (e.status !== 404) {
+                    throw e;
+                }
+                return self.fetchAndStoreMWRevision(restbase, req);
             });
         }
     } else {
@@ -405,7 +411,7 @@ PRS.prototype.listTitleRevisions = function(restbase, req) {
         });
         if (res.body.next) {
             res.body._links = {
-                next: { "href": "?page="+restbase.encodeToken(res.body.next) } 
+                next: { "href": "?page="+restbase.encodeToken(res.body.next) }
             };
         }
         res.body.items = items;
@@ -440,7 +446,7 @@ PRS.prototype.listRevisions = function(restbase, req) {
         });
         var next={};
         if (res.body.next) {
-            next = { 
+            next = {
                 next: { "href": "?page="+restbase.encodeToken(res.body.next) }
             };
         }

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -24,10 +24,25 @@ describe('item requests', function() {
             assert.deepEqual(res.headers['access-control-allow-headers'], 'accept, content-type');
         });
     });
+    it('should transparently create a new HTML revision for Main_Page', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/html/Main_Page',
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            return preq.get({
+                uri: server.config.bucketURL + '/html/Main_Page/'
+            });
+        })
+        .then(function(res) {
+            if (res.body.items.length !== 1) {
+                throw new Error('Expected a single revision for Main_Page');
+            }
+        });
+    });
     it('should transparently create a new HTML revision with id 624484477', function() {
         return preq.get({
             uri: server.config.bucketURL + '/html/Foobar/624484477',
-            body: 'Hello there'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);


### PR DESCRIPTION
The page deletion fix broke the transparent retrieval of revision metadata
if no explicit revision id was supplied. This patch restores that
functionality by catching a 404 from the internal storage request and calling fetchAndStoreMWRevision.

Change-Id: I3ad0cdf193497141caf9200db685d98ba8674cb0