### PR TITLE
MobileApps service endpoints

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -125,6 +125,10 @@ templates:
                   get:
                     backend_request:
                       uri: http://appservice.wmflabs.org/{domain}/v1/mobile/app/page/html/{title}
+                /v1/lite/{title}:
+                  get:
+                    backend_request:
+                      uri: http://appservice.wmflabs.org/{domain}/v1/mobile/app/page/lite/{title}
 
       /{module:page_save}:
         x-modules:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -42,6 +42,7 @@ templates:
     x-subspecs:
       - mediawiki/v1/content
       - mediawiki_v1_graphoid
+      - mediawiki/v1/mobileapps
     # - mediawiki/v1/revision-scoring
 
   wmf-sys-1.0.0: &wp/sys/1.0.0
@@ -112,6 +113,18 @@ templates:
                   get:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
+
+      /{module:mobileapps}:
+        x-modules:
+          - name: simple_service
+            version: 1.0.0
+            type: file
+            options:
+              paths:
+                /v1/std/html/{title}:
+                  get:
+                    backend_request:
+                      uri: http://appservice.wmflabs.org/{domain}/v1/mobile/app/page/html/{title}
 
       /{module:page_save}:
         x-modules:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -42,6 +42,7 @@ templates:
     x-subspecs:
       - mediawiki/v1/content
       - mediawiki_v1_graphoid
+      - mediawiki/v1/mobileapps
       - test
 
   wmf-sys-1.0.0: &wp/sys/1.0.0
@@ -111,6 +112,18 @@ templates:
                   get:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/en.wikipedia.org/v1/png/{title}/{revision}/{graph_id}
+
+      /{module:mobileapps}:
+        x-modules:
+          - name: simple_service
+            version: 1.0.0
+            type: file
+            options:
+              paths:
+                /v1/std/html/{title}:
+                  get:
+                    backend_request:
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/mobile/app/page/html/{title}
 
       /{module:action}:
         x-modules:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -124,6 +124,10 @@ templates:
                   get:
                     backend_request:
                       uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/mobile/app/page/html/{title}
+                /v1/lite/{title}:
+                  get:
+                    backend_request:
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/mobile/app/page/lite/{title}
 
       /{module:action}:
         x-modules:

--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -44,3 +44,48 @@ paths:
             status: 200
             headers:
               content-type: /text\/html/
+            body: /body/
+  /{module:page}/mobile-json-lite/{title}:
+    get:
+      tags:
+        - Page content
+        - Mobile
+      description: >
+        Retrieve the *lite* version of the latest HTML for a page title optimised for viewing with
+        native mobile applications.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
+      produces:
+        - application/json
+      parameters:
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The JSON comprising the HTML and various page attributes for the given page title.
+        '404':
+          description: Unknown page title
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/mobileapps/v1/lite/{title}
+      x-monitor: true
+      x-amples:
+        - title: Get MobileApps Lite Main Page
+          request:
+            params:
+              title: Main_Page
+          response:
+            status: 200
+            headers:
+              content-type: /application\/json/
+            body:
+              revision: /.+/
+              displaytitle: /.+/

--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -1,0 +1,46 @@
+# MobileApps page-manipulation service
+
+swagger: 2.0
+
+paths:
+  /{module:page}/mobile-html-full/{title}:
+    get:
+      tags:
+        - Page content
+        - Mobile
+      description: >
+        Retrieve the latest HTML for a page title optimised for viewing with
+        native mobile applications.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
+      produces:
+        - text/html
+      parameters:
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The HTML for the given page title.
+        '404':
+          description: Unknown page title
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/mobileapps/v1/std/html/{title}
+      x-monitor: true
+      x-amples:
+        - title: Get MobileApps Main Page
+          request:
+            params:
+              title: Main_Page
+          response:
+            status: 200
+            headers:
+              content-type: /text\/html/

--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -76,16 +76,16 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/mobileapps/v1/lite/{title}
-      x-monitor: true
-      x-amples:
-        - title: Get MobileApps Lite Main Page
-          request:
-            params:
-              title: Main_Page
-          response:
-            status: 200
-            headers:
-              content-type: /application\/json/
-            body:
-              revision: /.+/
-              displaytitle: /.+/
+      x-monitor: false
+#      x-amples:
+#        - title: Get MobileApps Lite Main Page
+#          request:
+#            params:
+#              title: Main_Page
+#          response:
+#            status: 200
+#            headers:
+#              content-type: /application\/json/
+#            body:
+#              revision: /.+/
+#              displaytitle: /.+/


### PR DESCRIPTION
This PR adds the MobileApps service public endpoints and its back-end service. Only two routes are added, currently reflecting the existing ones in the service:

- `/{domain}/v1/page/mobile-html-full/{title}` for the *standard* version
- `/{domain}/v1/page/mobile-json-lite/{title}` for the *lite* version

Things to note:

- There is no `{/revision}` component at the moment, due to the usage of MW *mobileview* API which [does not permit selecting a particular revision](https://phabricator.wikimedia.org/T106143#1460715).
- The public endpoints are based on [T103811](https://phabricator.wikimedia.org/T103811) and as such can be subject to change.
- Before deploying this, the MobileApps service must be deployed and we need to have the config part in ops/puppet in place.
- Because the service will not have a public DNS record, we are using the labs instance in the repo config(s).

Bug: [T102130](https://phabricator.wikimedia.org/T102130)