### PR TITLE
Templates support

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -113,9 +113,6 @@ templates:
                   get:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
-                      headers:
-                        accept: '{accept}'
-                        accept-language: '{accept-language}'
                       body: '{$.request.body}'
 
       /{module:mobileapps}:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -113,6 +113,10 @@ templates:
                   get:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
+                      headers:
+                        accept: '{accept}'
+                        accept-language: '{accept-language}'
+                      body: '{$.request.body}'
 
       /{module:mobileapps}:
         x-modules:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -112,6 +112,10 @@ templates:
                   get:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/en.wikipedia.org/v1/png/{title}/{revision}/{graph_id}
+                      headers:
+                        accept: '{accept}'
+                        accept-language: '{accept-language}'
+                      body: '{$.request.body}'
 
       /{module:mobileapps}:
         x-modules:
@@ -147,6 +151,10 @@ templates:
                   get:
                     backend_request:
                       uri: http://en.wikipedia.org/wiki/{+key}
+                      headers:
+                        accept: '{accept}'
+                        accept-language: '{accept-language}'
+                      body: '{$.request.body}'
                     storage: 
                       no-cache_refresh: true
                       bucket_request: 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -112,9 +112,6 @@ templates:
                   get:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/en.wikipedia.org/v1/png/{title}/{revision}/{graph_id}
-                      headers:
-                        accept: '{accept}'
-                        accept-language: '{accept-language}'
                       body: '{$.request.body}'
 
       /{module:mobileapps}:

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -4,45 +4,55 @@ var URI = require('swagger-router').URI;
 var rbUtil = require('./rbUtil');
 var TAssembly = require('tassembly');
 
-function _setAtPath(obj, value, path) {
-    var i;
-    path = path.split('.');
-    for (i = 0; i < path.length - 1; i++) {
-        obj = obj[path[i]];
-    }
-    if (value !== undefined) {
-        obj[path[i]] = value;
-    } else {
-        delete obj[path[i]];
-    }
+function _setAtPathFun(path) {
+    var ref = path.split('.').map(function(elem) {
+        return '["' + elem + '"]';
+    }).join('');
+    var code =  'if (value !== undefined) {\n' +
+                '   obj' + ref + ' = value;\n' +
+                '} else {\n' +
+                '   delete obj' + ref +';\n' +
+                '}';
+    /* jslint evil: true */
+    return new Function('obj', 'value', code);
 }
 
 function _createTemplateResolvers(subspec, reqPart, path, resolvers) {
+    var resolveTemplate = function(templateSpec, templatePath) {
+        if (templateSpec instanceof Object) {
+            _createTemplateResolvers(templateSpec, reqPart, templatePath, resolvers);
+        } else if (/^\{[^}]+}$/.test(templateSpec)) {
+            var template = /^\{([^}]+)}$/.exec(templateSpec)[1];
+            if (template.indexOf('$.req') === 0) {
+                template = template.replace('$.req', 'm');
+            } else {
+                template = 'm.' + reqPart + '.' + template;
+            }
+            var getValue = TAssembly.compile([['raw', template]], {
+                errorHandler: function() { return undefined; },
+                identityCallback: true
+            });
+            var setValue = _setAtPathFun(templatePath);
+            resolvers.push(function(newReq, req) {
+                var value = getValue(req);
+                setValue(newReq, value);
+            });
+        }
+    };
+
     if (!resolvers) {
         resolvers = [];
     }
     if (!path) {
         path = reqPart;
     }
-    Object.keys(subspec).forEach(function(key) {
-        if (subspec[key] instanceof Object) {
-            _createTemplateResolvers(subspec[key], reqPart, path + '.' + key, resolvers);
-        } else if (/^\{[^}]+}$/.test(subspec[key])) {
-            var template = /^\{([^}]+)}$/.exec(subspec[key])[1];
-            if (template.indexOf('$.req') === 0) {
-                template.replace('$.req', 'm');
-            } else {
-                template = 'm.' + reqPart + '.' + template;
-            }
-            var compiled = TAssembly.compile([['raw', template]], {
-                cb: function(val) { return val; }
-            });
-            resolvers.push(function(newReq, req) {
-                var value = compiled(req);
-                _setAtPath(newReq, value, path + '.' + key);
-            });
-        }
-    });
+    if (subspec instanceof Object) {
+        Object.keys(subspec).forEach(function(key) {
+            resolveTemplate(subspec[key], path + '.' + key);
+        });
+    } else {
+        resolveTemplate(subspec, path);
+    }
     return resolvers;
 }
 
@@ -68,13 +78,13 @@ function Template(spec) {
 }
 
 Template.prototype.eval = function(req) {
-    var self = this;
-    var newReq = self.spec;
-    newReq.uri = self._evalUri(req);
-    if (self._evalMethod) {
-        newReq.method = self._evalMethod(req);
+    var newReq = this.spec;
+    newReq.uri = this._evalUri(req);
+    newReq.params = req.params;
+    if (this._evalMethod) {
+        newReq.method = this._evalMethod(req);
     }
-    self.resolvers.forEach(function(resolver) {
+    this.resolvers.forEach(function(resolver) {
         resolver(newReq, req);
     });
     return newReq;

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -1,0 +1,83 @@
+"use strict";
+
+var URI = require('swagger-router').URI;
+var rbUtil = require('./rbUtil');
+var TAssembly = require('tassembly');
+
+function _setAtPath(obj, value, path) {
+    var i;
+    path = path.split('.');
+    for (i = 0; i < path.length - 1; i++) {
+        obj = obj[path[i]];
+    }
+    if (value !== undefined) {
+        obj[path[i]] = value;
+    } else {
+        delete obj[path[i]];
+    }
+}
+
+function _createTemplateResolvers(subspec, reqPart, path, resolvers) {
+    if (!resolvers) {
+        resolvers = [];
+    }
+    if (!path) {
+        path = reqPart;
+    }
+    Object.keys(subspec).forEach(function(key) {
+        if (subspec[key] instanceof Object) {
+            _createTemplateResolvers(subspec[key], reqPart, path + '.' + key, resolvers);
+        } else if (/^\{[^}]+}$/.test(subspec[key])) {
+            var template = /^\{([^}]+)}$/.exec(subspec[key])[1];
+            if (template.indexOf('$.req') === 0) {
+                template.replace('$.req', 'm');
+            } else {
+                template = 'm.' + reqPart + '.' + template;
+            }
+            var compiled = TAssembly.compile([['raw', template]], {
+                cb: function(val) { return val; }
+            });
+            resolvers.push(function(newReq, req) {
+                var value = compiled(req);
+                _setAtPath(newReq, value, path + '.' + key);
+            });
+        }
+    });
+    return resolvers;
+}
+
+function Template(spec) {
+    var uriTemplate = new URI(spec.uri, {}, true);
+    var self = this;
+
+    self.spec = spec;
+    self._evalUri = function(req) {
+        return uriTemplate.expand(req.params);
+    };
+    if (!spec.method) {
+        self._evalMethod = function(req) {
+            return req.method;
+        };
+    }
+    self.resolvers = [];
+    ['headers', 'body', 'query'].forEach(function(reqPart) {
+        if (spec[reqPart]) {
+            self.resolvers = self.resolvers.concat(_createTemplateResolvers(spec[reqPart], reqPart));
+        }
+    });
+}
+
+Template.prototype.eval = function(req) {
+    var self = this;
+    var newReq = self.spec;
+    newReq.uri = self._evalUri(req);
+    if (self._evalMethod) {
+        newReq.method = self._evalMethod(req);
+    }
+    self.resolvers.forEach(function(resolver) {
+        resolver(newReq, req);
+    });
+    return newReq;
+};
+
+module.exports = Template;

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -4,6 +4,10 @@ var URI = require('swagger-router').URI;
 var rbUtil = require('./rbUtil');
 var TAssembly = require('tassembly');
 
+/**
+ * Creates a function that sets a value at the path
+ * or deletes if undefined values is provided.
+ */
 function _setAtPathFun(path) {
     var ref = path.split('.').map(function(elem) {
         return '["' + elem + '"]';
@@ -56,6 +60,11 @@ function _createTemplateResolvers(subspec, reqPart, path, resolvers) {
     return resolvers;
 }
 
+/**
+ * Creates and compiles a new Template object using the provided JSON spec
+ *
+ * @param spec request spec
+ */
 function Template(spec) {
     var uriTemplate = new URI(spec.uri, {}, true);
     var self = this;
@@ -77,8 +86,15 @@ function Template(spec) {
     });
 }
 
+/**
+ * Evaluates the compiled template using the provided request
+ *
+ * @param req a request object where to take data from
+ * @returns {*} a new request object with all templates either substituted or dropped
+ */
 Template.prototype.eval = function(req) {
-    var newReq = this.spec;
+    // Deep copy the spec, because it's faster than traverse it trying to find added values
+    var newReq = JSON.parse(JSON.stringify(this.spec));
     newReq.uri = this._evalUri(req);
     newReq.params = req.params;
     if (this._evalMethod) {

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -62,7 +62,6 @@ function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
             return _createTemplateResolvers(origSpec, templateSpec, reqPart, templatePath);
         } else if (/^\{[^}]+}$/.test(templateSpec)) {
             var template = /^\{([^}]+)}$/.exec(templateSpec)[1];
-            var buildModel;
 
             if (!/^(\$\.)?([a-zA-Z][a-zA-Z0-9-_]*)(\.[a-zA-Z][a-zA-Z0-9-_]*)*$/.test(template)) {
                 throw new Error('Invalid template ' + template);
@@ -70,17 +69,35 @@ function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
 
             if (template[0] === '$') {
                 template = 'rm' + template.slice(1);
-                buildModel = function(req) { return { request: req }; };
             } else {
-                template = 'm.' + template;
-                buildModel = function(req) { return req[reqPart]; };
+                template = 'm.request.' + reqPart + '.' + template;
             }
-
-            var getValue = TAssembly.compile([['raw', template]], {
-                errorHandler: function() { return undefined; }
+            template = template.replace(/\.([^.]*(?:-[^.]*)+)/g, function(all, paren) {
+                return "['" + paren.replace(/'/g, "\\'") + "']";
             });
 
-            return [ function(newReq, req) { setValue(newReq, getValue(buildModel(req))); } ];
+            var res;
+            var resolveTemplate = TAssembly.compile([['raw', template]], {
+                errorHandler: function() { return undefined; },
+                cb: function(bit) {
+                    if (res === undefined) {
+                        res = bit;
+                    } else {
+                        res += '' + bit;
+                    }
+                }
+            });
+            var getValue = function(model) {
+                resolveTemplate(model);
+                return res;
+            };
+
+            return [ function(newReq, context) {
+                resolveTemplate(context);
+                var value = res;
+                res = undefined; // Unitialize res to prepare to the next request
+                setValue(newReq, value);
+            } ];
         } else {
             return [ function(newReq) { setValue(newReq, templateSpec); } ];
         }
@@ -112,8 +129,8 @@ function Template(spec) {
         if (reqPart === 'uri') {
             var uriTemplate = new URI(spec.uri, {}, true);
             setValue = _setAtPath('uri', spec);
-            self.resolvers.push(function(newReq, req) {
-                setValue(newReq, uriTemplate.expand(req.params));
+            self.resolvers.push(function(newReq, context) {
+                setValue(newReq, uriTemplate.expand(context.request.params));
             });
         } else if (reqPart === 'method') {
             setValue = _setAtPath('method', spec);
@@ -132,10 +149,10 @@ function Template(spec) {
  * @param req a request object where to take data from
  * @returns {*} a new request object with all templates either substituted or dropped
  */
-Template.prototype.eval = function(req) {
-    var newReq = { method: req.method };
+Template.prototype.eval = function(context) {
+    var newReq = { method: context.request.method };
     this.resolvers.forEach(function(resolver) {
-        resolver(newReq, req);
+        resolver(newReq, context);
     });
     return newReq;
 };

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -27,8 +27,8 @@ function _createTemplateResolvers(subspec, reqPart, path, resolvers) {
             _createTemplateResolvers(templateSpec, reqPart, templatePath, resolvers);
         } else if (/^\{[^}]+}$/.test(templateSpec)) {
             var template = /^\{([^}]+)}$/.exec(templateSpec)[1];
-            if (template.indexOf('$.req') === 0) {
-                template = template.replace('$.req', 'm');
+            if (template.indexOf('$.request') === 0) {
+                template = template.replace('$.request', 'm');
             } else {
                 template = 'm.' + reqPart + '.' + template;
             }

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -64,7 +64,7 @@ function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
             var template = /^\{([^}]+)}$/.exec(templateSpec)[1];
             var buildModel;
 
-            if (!/^(\$\.)?([a-zA-Z0-9-_]*)(\.[a-zA-Z0-9-_]*)*$/.test(template)) {
+            if (!/^(\$\.)?([a-zA-Z][a-zA-Z0-9-_]*)(\.[a-zA-Z][a-zA-Z0-9-_]*)*$/.test(template)) {
                 throw new Error('Invalid template ' + template);
             }
 

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -5,82 +5,111 @@ var rbUtil = require('./rbUtil');
 var TAssembly = require('tassembly');
 
 /**
- * Creates a function that sets a value at the path
- * or deletes if undefined values is provided.
+ * Creates a function that sets a value at the path and initializes all objects along the path.
+ *
+ * @param path the path within an object separated with dots {e.g. test.body.a.b.c}
+ * @returns {Function} the function to set a value at path and initialize object along the path if needed
+ * @private
  */
-function _setAtPathFun(path) {
-    var ref = path.split('.').map(function(elem) {
+function _setAtPath(path) {
+    var refArr = path.split('.').map(function(elem) {
         return '["' + elem + '"]';
-    }).join('');
-    var code =  'if (value !== undefined) {\n' +
-                '   obj' + ref + ' = value;\n' +
-                '} else {\n' +
-                '   delete obj' + ref +';\n' +
-                '}';
+    });
+    var code =  'if (value !== undefined) {\n';
+    for (var i = 1; i < refArr.length; i++) {
+        var ref = refArr.slice(0, i).join('');
+        code += 'obj' + ref + ' = obj' + ref + ' || {};\n';
+    }
+    code += 'obj' + refArr.join('') + ' = value;\n';
+    code += '}';
     /* jslint evil: true */
     return new Function('obj', 'value', code);
 }
 
-function _createTemplateResolvers(subspec, reqPart, path, resolvers) {
-    var resolveTemplate = function(templateSpec, templatePath) {
+/**
+ *  Constructs a list of resolvers for all templates in a request spec
+ *
+ * @param subspec a request spec or subspec for a part of request
+ * @param reqPart name of request part (e.g. headers, body, query)
+ * @param path path to the current subspec within a full spec
+ * @returns {Array} an array of template resolvers for every template found in the spec.
+ *          Resolvers are functions with (newRequest, request) arguments that modify newRequest param.
+ * @private
+ */
+function _createTemplateResolvers(subspec, reqPart, path) {
+
+    /**
+     * Makes an array of resolvers for every template found within a template spec object.
+     *
+     * @param templateSpec A subspec of an original request spec.
+     * @param templatePath A path to the current subspec
+     * @returns {Array} and array of resolvers for each template found in the subspec
+     */
+    function makeResolvers(templateSpec, templatePath) {
+        var setValue = _setAtPath(templatePath);
         if (templateSpec instanceof Object) {
-            _createTemplateResolvers(templateSpec, reqPart, templatePath, resolvers);
+            return _createTemplateResolvers(templateSpec, reqPart, templatePath);
         } else if (/^\{[^}]+}$/.test(templateSpec)) {
             var template = /^\{([^}]+)}$/.exec(templateSpec)[1];
-            if (template.indexOf('$.request') === 0) {
-                template = template.replace('$.request', 'm');
-            } else {
-                template = 'm.' + reqPart + '.' + template;
-            }
-            var getValue = TAssembly.compile([['raw', template]], {
-                errorHandler: function() { return undefined; },
-                identityCallback: true
-            });
-            var setValue = _setAtPathFun(templatePath);
-            resolvers.push(function(newReq, req) {
-                var value = getValue(req);
-                setValue(newReq, value);
-            });
-        }
-    };
+            var buildModel;
 
-    if (!resolvers) {
-        resolvers = [];
+            if (!/^(\$\.)?([a-zA-Z][a-zA-Z0-9-]*)(\.[a-zA-Z][a-zA-Z0-9-]*)*$/.test(template)) {
+                throw new Error('Invalid template ' + template);
+            }
+
+            if (template.indexOf('$.') === 0) {
+                template = template.replace('$', 'rm');
+                buildModel = function(req) { return { request: req }; };
+            } else {
+                template = 'm.' + template;
+                buildModel = function(req) { return req[reqPart]; };
+            }
+
+            var getValue = TAssembly.compile([['raw', template]], {
+                errorHandler: function() { return undefined; }
+            });
+
+            return [ function(newReq, req) { setValue(newReq, getValue(buildModel(req))); } ];
+        } else {
+            return [ function(newReq) { setValue(newReq, templateSpec); } ];
+        }
     }
-    if (!path) {
-        path = reqPart;
-    }
+
+    if (!path) { path = reqPart; }
     if (subspec instanceof Object) {
-        Object.keys(subspec).forEach(function(key) {
-            resolveTemplate(subspec[key], path + '.' + key);
-        });
+        return Object.keys(subspec).map(function(key) {
+            return makeResolvers(subspec[key], path + '.' + key);
+        }).reduce(function(arr1, arr2) { return arr1.concat(arr2); });
     } else {
-        resolveTemplate(subspec, path);
+        return makeResolvers(subspec, path);
     }
-    return resolvers;
 }
 
 /**
  * Creates and compiles a new Template object using the provided JSON spec
  *
- * @param spec request spec
+ * @param spec  Request spec provided in a Swagger spec. This is a JSON object
+ *              containing all request parts templated in the form of {a.b.c}.
+ *              Only fields in the spec would be included in the resulting request,
+ *              fields that couldn't be resolved from original request would be ignored.
  */
 function Template(spec) {
-    var uriTemplate = new URI(spec.uri, {}, true);
     var self = this;
-
-    self.spec = spec;
-    self._evalUri = function(req) {
-        return uriTemplate.expand(req.params);
-    };
-    if (!spec.method) {
-        self._evalMethod = function(req) {
-            return req.method;
-        };
-    }
     self.resolvers = [];
-    ['headers', 'body', 'query'].forEach(function(reqPart) {
-        if (spec[reqPart]) {
+    Object.keys(spec).forEach(function(reqPart) {
+        var setValue;
+        if (reqPart === 'uri') {
+            var uriTemplate = new URI(spec.uri, {}, true);
+            setValue = _setAtPath('uri');
+            self.resolvers.push(function(newReq, req) {
+                setValue(newReq, uriTemplate.expand(req.params));
+            });
+        } else if (reqPart === 'method') {
+            setValue = _setAtPath('method');
+            self.resolvers.push(function(newReq) {
+                setValue(newReq, spec.method);
+            });
+        } else if (spec[reqPart]) {
             self.resolvers = self.resolvers.concat(_createTemplateResolvers(spec[reqPart], reqPart));
         }
     });
@@ -93,13 +122,7 @@ function Template(spec) {
  * @returns {*} a new request object with all templates either substituted or dropped
  */
 Template.prototype.eval = function(req) {
-    // Deep copy the spec, because it's faster than traverse it trying to find added values
-    var newReq = JSON.parse(JSON.stringify(this.spec));
-    newReq.uri = this._evalUri(req);
-    newReq.params = req.params;
-    if (this._evalMethod) {
-        newReq.method = this._evalMethod(req);
-    }
+    var newReq = { method: req.method };
     this.resolvers.forEach(function(resolver) {
         resolver(newReq, req);
     });

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -5,23 +5,34 @@ var rbUtil = require('./rbUtil');
 var TAssembly = require('tassembly');
 
 /**
- * Creates a function that sets a value at the path and initializes all objects along the path.
+ * Creates a function that sets a value at the path and initializes all objects/arrays along the path.
  *
- * @param path the path within an object separated with dots {e.g. test.body.a.b.c}
+ * @param path the path within an object/array separated with dots {e.g. test.body.a.b.c}
  * @returns {Function} the function to set a value at path and initialize object along the path if needed
  * @private
  */
-function _setAtPath(path) {
-    var refArr = path.split('.').map(function(elem) {
-        return '["' + elem + '"]';
-    });
-    var code =  'if (value !== undefined) {\n';
-    for (var i = 1; i < refArr.length; i++) {
-        var ref = refArr.slice(0, i).join('');
-        code += 'obj' + ref + ' = obj' + ref + ' || {};\n';
+function _setAtPath(path, spec) {
+    var pathArr = path.split('.');
+    var refArr = [];
+    var subspec = spec;
+    var code;
+
+    for (var idx = 0; idx < pathArr.length; idx++) {
+        var curRef = {};
+        curRef.ref = Array.isArray(subspec) ? '[' + pathArr[idx] + ']' : '["' + pathArr[idx] + '"]';
+        subspec = subspec[pathArr[idx]];
+        curRef.initializer = Array.isArray(subspec) ? '[]' : '{}';
+        refArr.push(curRef);
     }
-    code += 'obj' + refArr.join('') + ' = value;\n';
+
+    code =  'if (value !== undefined) {\n';
+    for (var i = 1; i < refArr.length; i++) {
+        var ref = refArr.slice(0, i).map(function(elem) { return elem.ref; }).join('');
+        code += 'obj' + ref + ' = obj' + ref + ' || ' + refArr[i - 1].initializer + ';\n';
+    }
+    code += 'obj' + refArr.map(function(elem) { return elem.ref; }).join('') + ' = value;\n';
     code += '}';
+
     /* jslint evil: true */
     return new Function('obj', 'value', code);
 }
@@ -36,7 +47,7 @@ function _setAtPath(path) {
  *          Resolvers are functions with (newRequest, request) arguments that modify newRequest param.
  * @private
  */
-function _createTemplateResolvers(subspec, reqPart, path) {
+function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
 
     /**
      * Makes an array of resolvers for every template found within a template spec object.
@@ -46,19 +57,19 @@ function _createTemplateResolvers(subspec, reqPart, path) {
      * @returns {Array} and array of resolvers for each template found in the subspec
      */
     function makeResolvers(templateSpec, templatePath) {
-        var setValue = _setAtPath(templatePath);
+        var setValue = _setAtPath(templatePath, origSpec);
         if (templateSpec instanceof Object) {
-            return _createTemplateResolvers(templateSpec, reqPart, templatePath);
+            return _createTemplateResolvers(origSpec, templateSpec, reqPart, templatePath);
         } else if (/^\{[^}]+}$/.test(templateSpec)) {
             var template = /^\{([^}]+)}$/.exec(templateSpec)[1];
             var buildModel;
 
-            if (!/^(\$\.)?([a-zA-Z][a-zA-Z0-9-]*)(\.[a-zA-Z][a-zA-Z0-9-]*)*$/.test(template)) {
+            if (!/^(\$\.)?([a-zA-Z0-9-_]*)(\.[a-zA-Z0-9-_]*)*$/.test(template)) {
                 throw new Error('Invalid template ' + template);
             }
 
-            if (template.indexOf('$.') === 0) {
-                template = template.replace('$', 'rm');
+            if (template[0] === '$') {
+                template = 'rm' + template.slice(1);
                 buildModel = function(req) { return { request: req }; };
             } else {
                 template = 'm.' + template;
@@ -100,17 +111,17 @@ function Template(spec) {
         var setValue;
         if (reqPart === 'uri') {
             var uriTemplate = new URI(spec.uri, {}, true);
-            setValue = _setAtPath('uri');
+            setValue = _setAtPath('uri', spec);
             self.resolvers.push(function(newReq, req) {
                 setValue(newReq, uriTemplate.expand(req.params));
             });
         } else if (reqPart === 'method') {
-            setValue = _setAtPath('method');
+            setValue = _setAtPath('method', spec);
             self.resolvers.push(function(newReq) {
                 setValue(newReq, spec.method);
             });
         } else if (spec[reqPart]) {
-            self.resolvers = self.resolvers.concat(_createTemplateResolvers(spec[reqPart], reqPart));
+            self.resolvers = self.resolvers.concat(_createTemplateResolvers(spec, spec[reqPart], reqPart));
         }
     });
 }

--- a/lib/router.js
+++ b/lib/router.js
@@ -120,7 +120,7 @@ Router.prototype._loadModule = function (modDef) {
 function makeRequestTemplate(spec) {
     var reqTemplate = new Template(spec);
     return function requestTemplate (restbase, req) {
-        return restbase.request(reqTemplate.eval(req));
+        return restbase.request(reqTemplate.eval({request: req}));
     };
 }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -3,7 +3,7 @@
 var P = require('bluebird');
 var yaml = require('js-yaml');
 var fs = P.promisifyAll(require('fs'));
-var util = require('util');
+var Template = require('./reqTemplate');
 var rbUtil = require('./rbUtil');
 
 var swaggerRouter = require('swagger-router');
@@ -118,18 +118,9 @@ Router.prototype._loadModule = function (modDef) {
 };
 
 function makeRequestTemplate(spec) {
-    var uriTemplate = new URI(spec.uri, {}, true);
+    var reqTemplate = new Template(spec);
     return function requestTemplate (restbase, req) {
-        // FIXME:
-        // - Efficiently template other request parts
-        uriTemplate.params = req.params;
-        return restbase.request({
-            uri: uriTemplate.expand(),
-            method: req.method,
-            body: req.body,
-            headers: req.headers,
-            query: req.query
-        });
+        return restbase.request(reqTemplate.eval(req));
     };
 }
 

--- a/mods/simple_service.js
+++ b/mods/simple_service.js
@@ -45,7 +45,7 @@ SimpleService.prototype.processSpec = function(spec) {
                 }
 
                 function backendRequest() {
-                    return restbase.request(backendRequestTemplate.eval(req));
+                    return restbase.request(backendRequestTemplate.eval({request:req}));
                 }
 
                 function regenerateAndSave() {

--- a/mods/simple_service.js
+++ b/mods/simple_service.js
@@ -7,6 +7,7 @@
 var P = require('bluebird');
 var URI = require('swagger-router').URI;
 var rbUtil = require('../lib/rbUtil');
+var Template = require('../lib/reqTemplate');
 
 
 function SimpleService(options) {
@@ -16,17 +17,6 @@ function SimpleService(options) {
     };
 
     this.exports = this.processSpec(this.spec);
-}
-
-var headerWhitelist = ['accept', 'accept-language'];
-function filterHeaders(headers) {
-    var res = {};
-    headerWhitelist.forEach(function(name) {
-        if (headers[name]) {
-            res[name] = headers[name];
-        }
-    });
-    return res;
 }
 
 SimpleService.prototype.processSpec = function(spec) {
@@ -47,7 +37,7 @@ SimpleService.prototype.processSpec = function(spec) {
                 storageUriTemplate = new URI(conf.storage.item_request.uri, {}, true);
                 resources.push(conf.storage.bucket_request);
             }
-            var backendUriTemplate = new URI(conf.backend_request.uri, {}, true);
+            var backendRequestTemplate = new Template(conf.backend_request);
             operations[conf.operationId] = function(restbase, req) {
                 var rp = req.params;
                 if (rp.key) {
@@ -55,17 +45,7 @@ SimpleService.prototype.processSpec = function(spec) {
                 }
 
                 function backendRequest() {
-                    var beReq = {
-                        uri: backendUriTemplate.toString({
-                            params: req.params
-                        }),
-                        // TODO: be more selective / only configure a whitelist of
-                        // headers
-                        headers: filterHeaders(req.headers),
-                        method: method,
-                        body: req.body,
-                    };
-                    return restbase.request(beReq);
+                    return restbase.request(backendRequestTemplate.eval(req));
                 }
 
                 function regenerateAndSave() {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "service-runner": "^0.2.0",
     "swagger-router": "^0.1.0",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
-    "tassembly": "git+https://github.com/Pchelolo/tassembly#safe"
+    "tassembly": "^0.1.4"
   },
   "devDependencies": {
     "bunyan": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "restbase-mod-table-cassandra": "^0.7.6",
     "service-runner": "^0.2.0",
     "swagger-router": "^0.1.0",
-    "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master"
+    "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
+    "tassembly": "/Users/pchelko/sandbox/wiki/tassembly"
   },
   "devDependencies": {
     "bunyan": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "service-runner": "^0.2.0",
     "swagger-router": "^0.1.0",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
-    "tassembly": "/Users/pchelko/sandbox/wiki/tassembly"
+    "tassembly": "git+https://github.com/Pchelolo/tassembly#safe"
   },
   "devDependencies": {
     "bunyan": "^1.4.0",

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -229,6 +229,10 @@ paths:
           description: The page title.
           type: string
           required: true
+        - name: sections
+          in: query
+          description: Comma-separated list of dection IDs
+          type: string
       produces:
         - text/html; profile=mediawiki.org/specs/html/1.1.0
       responses:
@@ -255,6 +259,8 @@ paths:
           if-unmodified-since: '{if-unmodified-since}'
           x-restbase-mode: '{x-restbase-mode}'
           x-restbase-parentrevision: '{x-restbase-parentrevision}'
+        query:
+          sections: '{sections}'
       x-monitor: true
       x-amples:
         - title: Get html by title from Parsoid
@@ -420,6 +426,10 @@ paths:
           in: path
           description: The revision's time ID
           type: string
+        - name: sections
+          in: query
+          description: Comma-separated list of dection IDs
+          type: string
       responses:
         '200':
           description: >
@@ -448,6 +458,8 @@ paths:
           if-unmodified-since: '{if-unmodified-since}'
           x-restbase-mode: '{x-restbase-mode}'
           x-restbase-parentrevision: '{x-restbase-parentrevision}'
+        query:
+          sections: '{sections}'
       x-monitor: false
 
   /{module:page}/data-parsoid/:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -231,7 +231,7 @@ paths:
           required: true
         - name: sections
           in: query
-          description: Comma-separated list of dection IDs
+          description: Comma-separated list of section IDs
           type: string
       produces:
         - text/html; profile=mediawiki.org/specs/html/1.1.0
@@ -428,7 +428,7 @@ paths:
           type: string
         - name: sections
           in: query
-          description: Comma-separated list of dection IDs
+          description: Comma-separated list of section IDs
           type: string
       responses:
         '200':

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -63,6 +63,8 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/
+        query:
+          page: '{page}'
       x-monitor: false
 
   /{module:page}/title/{title}:
@@ -97,6 +99,9 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/{title}
+        headers:
+          cache-control: '{cache-control}'
+          if-unmodified-since: '{if-unmodified-since}'
       x-monitor: true
       x-amples:
         - title: Get rev of by title from MW
@@ -167,6 +172,8 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/{title}/
+        query:
+          page: '{page}'
       x-monitor: false
 
   /{module:page}/html/:
@@ -197,6 +204,8 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/page/
+        query:
+          page: '{page}'
       x-monitor: false
 
   /{module:page}/html/{title}:
@@ -241,6 +250,11 @@ paths:
         # work in current Chrome and Firefox.
         # See also http://tools.ietf.org/html/rfc7231#section-7.1.2
         uri: /{domain}/sys/parsoid/html/{title}
+        headers:
+          cache-control: '{cache-control}'
+          if-unmodified-since: '{if-unmodified-since}'
+          x-restbase-mode: '{x-restbase-mode}'
+          x-restbase-parentrevision: '{x-restbase-parentrevision}'
       x-monitor: true
       x-amples:
         - title: Get html by title from Parsoid
@@ -362,6 +376,13 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/html/{title}/
+        headers:
+          cache-control: '{cache-control}'
+          if-unmodified-since: '{if-unmodified-since}'
+          x-restbase-mode: '{x-restbase-mode}'
+          x-restbase-parentrevision: '{x-restbase-parentrevision}'
+        query:
+          page: '{page}'
       x-monitor: false
 
   /{module:page}/html/{title}/{revision}{/tid}:
@@ -422,6 +443,11 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/html/{title}/{revision}{/tid}
+        headers:
+          cache-control: '{cache-control}'
+          if-unmodified-since: '{if-unmodified-since}'
+          x-restbase-mode: '{x-restbase-mode}'
+          x-restbase-parentrevision: '{x-restbase-parentrevision}'
       x-monitor: false
 
   /{module:page}/data-parsoid/:
@@ -454,6 +480,8 @@ paths:
         # Fixme: only list pages that have at least one revision with content
         # model 'wikitext'
         uri: /{domain}/sys/page_revisions/page/
+        query:
+          page: '{page}'
       x-monitor: false
 
   /{module:page}/data-parsoid/{title}:
@@ -487,6 +515,11 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}
+        headers:
+          cache-control: '{cache-control}'
+          if-unmodified-since: '{if-unmodified-since}'
+          x-restbase-mode: '{x-restbase-mode}'
+          x-restbase-parentrevision: '{x-restbase-parentrevision}'
       x-monitor: true
       x-amples:
         - title: Get data-parsoid by title
@@ -540,6 +573,13 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}/
+        headers:
+          cache-control: '{cache-control}'
+          if-unmodified-since: '{if-unmodified-since}'
+          x-restbase-mode: '{x-restbase-mode}'
+          x-restbase-parentrevision: '{x-restbase-parentrevision}'
+        query:
+          page: '{page}'
       x-monitor: false
 
   /{module:page}/data-parsoid/{title}/{revision}{/tid}:
@@ -591,6 +631,11 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/data-parsoid/{title}/{revision}{/tid}
+        headers:
+          cache-control: '{cache-control}'
+          if-unmodified-since: '{if-unmodified-since}'
+          x-restbase-mode: '{x-restbase-mode}'
+          x-restbase-parentrevision: '{x-restbase-parentrevision}'
       x-monitor: false
 
   /{module:page}/revision/:
@@ -620,6 +665,8 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/rev/
+        query:
+          page: '{page}'
       x-monitor: false
 
   /{module:page}/revision/{revision}:
@@ -661,6 +708,8 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_revisions/rev/{revision}
+        headers:
+          cache-control: '{cache-control}'
       x-monitor: true
       x-amples:
         - title: Get rev by ID
@@ -788,6 +837,8 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/html/to/wikitext{/title}{/revision}
+        body:
+          html: '{html}'
       x-monitor: false
 
   /{module:transform}/wikitext/to/html{/title}{/revision}:
@@ -840,6 +891,9 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/wikitext/to/html{/title}{/revision}
+        body:
+          wikitext: '{wikitext}'
+          bodyOnly: '{bodyOnly}'
       x-monitor: true
       x-amples:
         - title: Transform wikitext to html
@@ -905,6 +959,9 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/html/to/html{/title}{/revision}
+        body:
+          html: '{html}'
+          bodyOnly: '{bodyOnly}'
       x-monitor: false
 
   /{module:transform}/sections/to/wikitext/{title}/{revision}:
@@ -956,6 +1013,8 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/parsoid/transform/sections/to/wikitext/{title}/{revision}
+        body:
+          sections: '{sections}'
       x-monitor: false
 
 definitions:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -851,6 +851,7 @@ paths:
         uri: /{domain}/sys/parsoid/transform/html/to/wikitext{/title}{/revision}
         body:
           html: '{html}'
+          scrubWikitext: '{scrubWikitext}'
       x-monitor: false
 
   /{module:transform}/wikitext/to/html{/title}{/revision}:

--- a/specs/mediawiki_v1_graphoid.yaml
+++ b/specs/mediawiki_v1_graphoid.yaml
@@ -50,6 +50,8 @@ paths:
 
       x-backend-request:
         uri: /{domain}/sys/graphoid/v1/png/{title}/{revision}/{graph_id}
+        headers:
+          cache-control: '{cache-control}'
 
       x-monitor: true
       x-amples:

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -74,5 +74,6 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_save/wikitext/{title}
+        body: '{$.req.body}'
       x-monitor: false
 

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -74,6 +74,6 @@ paths:
             $ref: '#/definitions/problem'
       x-backend-request:
         uri: /{domain}/sys/page_save/wikitext/{title}
-        body: '{$.req.body}'
+        body: '{$.request.body}'
       x-monitor: false
 

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -7,6 +7,8 @@ paths:
     get:
       x-backend-request:
         uri: /{domain}/sys/testservice/test/{title}{/revision}
+        headers:
+          cache-control: '{cache-control}'
       x-monitor: false
 
   /{module:page}/wikitext/{title}:

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -216,6 +216,20 @@ describe('transform api', function() {
             assert.deepEqual(/== Second Section ==/.test(res.body), true);
         });
     });
+
+    it('passes scrubWikitext parameter', function() {
+        return preq.post({
+            uri: server.config.baseURL + '/transform/html/to/wikitext',
+            body: {
+                html: '<h2></h2>',
+                scrubWikitext: 1
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body, '');
+        });
+    });
 });
 
 

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -112,7 +112,6 @@ describe('router - misc', function() {
                     }
                 },
                 'field_name_with_underscore': '{field_name_with_underscore}',
-                'array': ['one', '{$.request.params.domain}', '{object}', { 'field': '{object}'}]
             }
         };
         var testRequest = {
@@ -170,7 +169,6 @@ describe('router - misc', function() {
                     }
                 },
                 'field_name_with_underscore': 'field_value_with_underscore',
-                'array': ['one', 'testDomain', {'testField': 'testValue'}, { 'field': {'testField': 'testValue'}}]
             }
         };
         var result = new Template(requestTemplate).eval(testRequest);

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -112,6 +112,7 @@ describe('router - misc', function() {
                     }
                 },
                 'field_name_with_underscore': '{field_name_with_underscore}',
+                'additional_context_field': '{$.additional_context.field}'
             }
         };
         var testRequest = {
@@ -169,9 +170,15 @@ describe('router - misc', function() {
                     }
                 },
                 'field_name_with_underscore': 'field_value_with_underscore',
+                additional_context_field: 'additional_test_value'
             }
         };
-        var result = new Template(requestTemplate).eval(testRequest);
+        var result = new Template(requestTemplate).eval({
+            request: testRequest,
+            additional_context: {
+                field: 'additional_test_value'
+            }
+        });
         assert.deepEqual(result, expectedTemplatedRequest);
     });
 });

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -105,9 +105,9 @@ describe('router - misc', function() {
                 'global': '{$.request.params.domain}',
                 'added': 'addedValue',
                 'nested': {
-                    'a': {
-                        'b': {
-                            c: '{a.b.c}'
+                    'one': {
+                        'two': {
+                            'tree': '{a.b.c}'
                         }
                     }
                 }
@@ -141,9 +141,6 @@ describe('router - misc', function() {
             }
         };
         var expectedTemplatedRequest = {
-            params: {
-                'domain': 'testDomain'
-            },
             uri: new URI('testDomain/test'),
             method: 'post',
             headers: {
@@ -163,9 +160,9 @@ describe('router - misc', function() {
                 'global': 'testDomain',
                 'added': 'addedValue',
                 'nested': {
-                    'a': {
-                        b: {
-                            c: 'nestedValue'
+                    'one': {
+                        'two': {
+                            'tree': 'nestedValue'
                         }
                     }
                 }

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -92,17 +92,17 @@ describe('router - misc', function() {
             method: 'post',
             headers: {
                 'name-with-dashes': '{name-with-dashes}',
-                'global-header': '{$.req.params.domain}',
+                'global-header': '{$.request.params.domain}',
                 'added-string-header': 'added-string-header'
             },
             query: {
                 'simple': '{simple}',
                 'added': 'addedValue',
-                'global': '{$.req.headers.name-with-dashes}'
+                'global': '{$.request.headers.name-with-dashes}'
             },
             body: {
                 'object': '{object}',
-                'global': '{$.req.params.domain}',
+                'global': '{$.request.params.domain}',
                 'added': 'addedValue',
                 'nested': {
                     'a': {

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -110,7 +110,9 @@ describe('router - misc', function() {
                             'tree': '{a.b.c}'
                         }
                     }
-                }
+                },
+                'field_name_with_underscore': '{field_name_with_underscore}',
+                'array': ['one', '{$.request.params.domain}', '{object}', { 'field': '{object}'}]
             }
         };
         var testRequest = {
@@ -137,7 +139,8 @@ describe('router - misc', function() {
                     'b': {
                         'c': 'nestedValue'
                     }
-                }
+                },
+                'field_name_with_underscore': 'field_value_with_underscore'
             }
         };
         var expectedTemplatedRequest = {
@@ -165,7 +168,9 @@ describe('router - misc', function() {
                             'tree': 'nestedValue'
                         }
                     }
-                }
+                },
+                'field_name_with_underscore': 'field_value_with_underscore',
+                'array': ['one', 'testDomain', {'testField': 'testValue'}, { 'field': {'testField': 'testValue'}}]
             }
         };
         var result = new Template(requestTemplate).eval(testRequest);


### PR DESCRIPTION
Made more general request reemploying support. On startup template for each request is compiled - separate URI templating lib, and a tassembly for each '{...}' template. When request comes, we use an array of compiled tassembly functions to substitute all templates in a new request.

~~Important note, this PR depends on https://github.com/gwicke/tassembly/pull/1~~ 
The PR is rebased on current master

Bug: https://phabricator.wikimedia.org/T86737