### PR TITLE
Count public & private requests

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -192,6 +192,16 @@ function handleRequest (opts, req, resp) {
     };
     reqOpts.log = reqOpts.logger.log.bind(reqOpts.logger);
 
+    // Simplistic count of requests from public & private networks
+    var xff = req.headers['x-forwarded-for'];
+    var remoteAddr = xff && xff.split(',')[0].trim()
+        || req.socket.remoteAddress;
+    if (/^(?:10|127)\./.test(remoteAddr)) {
+        reqOpts.metrics.increment('requests.private');
+    } else {
+        reqOpts.metrics.increment('requests.public');
+    }
+
     // Create a new, clean request object
     var urlData = rbUtil.parseURL(req.url);
 


### PR DESCRIPTION
Keep a simplistic count of requests from public & private networks.