### PR TITLE
Pass through scrubWikitext to Parsoid

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -482,6 +482,13 @@ PSP.transformRevision = function (restbase, req, from, to) {
             body2[from] = req.body[from];
         }
 
+        // For now, simply pass this through.
+        // See https://phabricator.wikimedia.org/T106909 for the discussion
+        // about the longer term plan.
+        if (req.body.scrubWikitext) {
+            body2.scrubWikitext = true;
+        }
+
         var path = [rp.domain,'sys','parsoid','transform',from,'to',to];
         if (rp.title) {
             path.push(rbUtil.normalizeTitle(rp.title));


### PR DESCRIPTION
Parsoid added an API flag to fix up HTML in ways that results in cleaner wikitext.
While it's not clear that this is going to be the longer-term API, we agreed
to pass this through as-is without documenting it to allow VE and other
clients to take advantage of the feature quickly.

We can then discuss the longer-term API design in
https://phabricator.wikimedia.org/T106909.