### PR TITLE
Created SQLite backend testing mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+restbase
 coverage
 config.yaml
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ notifications:
   email:
     - services@wikimedia.org
 
-script: npm run-script coverage -- all && (npm run-script coveralls || exit 0)
+script: sh test/utils/run_tests.sh coverage all && (npm run-script coveralls || exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ notifications:
   email:
     - services@wikimedia.org
 
-script: npm run-script coverage && (npm run-script coveralls || exit 0)
+script: npm run-script coverage -- all && (npm run-script coveralls || exit 0)

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "swagger-test": "0.2.0",
     "url-template": "^2.0.6",
     "nock": "^2.6.0",
-    "restbase-mod-table-sqlite": "git+https://github.com/wikimedia/restbase-mod-table-sqlite#master"
+    "restbase-mod-table-sqlite": "^0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "service-runner",
     "test": "sh test/utils/run_tests.sh test",
-    "coverage": "sh test/utils/run_test.sh coverage",
+    "coverage": "sh test/utils/run_tests.sh coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "service-runner",
-    "test": "sh test/utils/cleandb.sh && mocha",
-    "coverage": "sh test/utils/cleandb.sh && istanbul cover _mocha -- -R spec",
+    "test": "sh test/utils/run_tests.sh test",
+    "coverage": "sh test/utils/run_test.sh coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
@@ -54,6 +54,7 @@
     "mocha-lcov-reporter": "^0.0.2",
     "swagger-test": "0.2.0",
     "url-template": "^2.0.6",
-    "nock": "^2.6.0"
+    "nock": "^2.6.0",
+    "restbase-mod-table-sqlite": "git+https://github.com/wikimedia/restbase-mod-table-sqlite#master"
   }
 }

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -8,6 +8,7 @@ var yaml = require('js-yaml');
 
 var assert = require('assert');
 var Router = require('../../../lib/router');
+var loadConfig = require('../../utils/server').loadConfig;
 var router = new Router();
 
 var rootSpec = {
@@ -100,7 +101,7 @@ var overlappingMethodSpec = {
     }
 };
 
-var fullSpec = yaml.safeLoad(fs.readFileSync('config.example.yaml'));
+var fullSpec = loadConfig('config.example.yaml');
 
 describe('tree building', function() {
 

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -50,6 +50,5 @@ fi
 
 if [ "$2" = "all" ]
 then
-    runTest "sqlite" $1
-    runTest "cassandra" $1
+    runTest "sqlite" $1 && runTest "cassandra" $1
 fi

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-PATH=$PATH:node_modules/.bin
+mod_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )/node_modules
+mocha="$mod_dir"/mocha/bin/mocha
+istambul="$mod_dir"/istambul/bin/istambul
 
 runTest ( ) {
     if [ "$1" = "sqlite" ]
@@ -14,18 +16,16 @@ runTest ( ) {
         sh ./test/utils/cleandb.sh
     fi
 
-    if [ "$2" = "test" ]
+    if [[ "$2" = "test" ]]
     then
-        mocha
-    fi
-
-    if [ "$2" = "coverage" ]
+        ${mocha}
+    elif [[ "$2" = "coverage" ]]
     then
-        istanbul cover node_modules/.bin/_mocha -- -R spec
+        ${istanbul} cover node_modules/.bin/_mocha -- -R spec
     fi
 }
 
-if [ -z ${2+x} ]
+if [[ -z ${2+x} ]]
 then
     # no concrete backend is provided, check for cassandra
     `echo exit;` | cqlsh
@@ -38,17 +38,16 @@ then
     fi
 fi
 
-if [ "$2" = "sqlite" ]
+if [[ "$2" = "sqlite" ]]
 then
     runTest "sqlite" $1
-fi
-
-if [ "$2" = "cassandra" ]
+elif [[ "$2" = "cassandra" ]]
 then
     runTest "cassandra" $1
-fi
-
-if [ "$2" = "all" ]
+elif [[ "$2" = "all" ]]
 then
     runTest "sqlite" $1 && runTest "cassandra" $1
+else
+    echo "Invalid  testing mode"
+    exit 1
 fi

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -2,7 +2,7 @@
 
 mod_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )/node_modules
 mocha="$mod_dir"/mocha/bin/mocha
-istanbul="$mod_dir"/istanbul/bin/istanbul
+istanbul="$mod_dir"/istanbul/lib/cli.js
 
 runTest ( ) {
     if [ "$1" = "sqlite" ]

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -2,7 +2,7 @@
 
 mod_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )/node_modules
 mocha="$mod_dir"/mocha/bin/mocha
-istambul="$mod_dir"/istambul/bin/istambul
+istanbul="$mod_dir"/istanbul/bin/istanbul
 
 runTest ( ) {
     if [ "$1" = "sqlite" ]

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-mod_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )/node_modules
+mod_dir=$( cd "$( dirname "$0" )"/../.. && pwd )/node_modules
 mocha="$mod_dir"/mocha/bin/mocha
 istanbul="$mod_dir"/istanbul/lib/cli.js
 

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -22,7 +22,7 @@ runTest ( ) {
     fi
 }
 
-if [ "x$2" == "x" ]; then
+if [ "x$2" = "x" ]; then
     # no concrete backend is provided, check for cassandra
     `echo exit;` | cqlsh 2> /dev/null
     if [ "$?" -eq 0 ]; then

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -21,7 +21,7 @@ runTest ( ) {
 
     if [ "$2" = "coverage" ]
     then
-        istanbul cover _mocha -- -R spec
+        istanbul cover node_modules/.bin/_mocha -- -R spec
     fi
 }
 

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+runTest ( ) {
+    if [ "$1" = "sqlite" ]
+    then
+        echo "Running with SQLite backend"
+        export RB_TEST_BACKEND=sqlite
+        rm -f restbase
+    else
+        echo "Running with Cassandra backend"
+         export RB_TEST_BACKEND=cassandra
+        sh ./test/utils/cleandb.sh
+    fi
+
+    if [ "$2" = "test" ]
+    then
+        mocha
+    fi
+
+    if [ "$2" = "coverage" ]
+    then
+        istanbul cover _mocha -- -R spec
+    fi
+}
+
+if [ -z ${2+x} ]
+then
+    # no concrete backend is provided, check for cassandra
+    `echo exit;` | cqlsh
+    if [ "$?" -eq 0 ]
+    then
+        runTest "cassandra" $1
+    else
+        echo "Cassandra not available. Using SQLite backed for tests"
+        runTest "sqlite" $1
+    fi
+fi
+
+if [ "$2" = "sqlite" ]
+then
+    runTest "sqlite" $1
+fi
+
+if [ "$2" = "cassandra" ]
+then
+    runTest "cassandra" $1
+fi
+
+if [ "$2" = "all" ]
+then
+    runTest "sqlite" $1
+    runTest "cassandra" $1
+fi

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -5,8 +5,7 @@ mocha="$mod_dir"/mocha/bin/mocha
 istanbul="$mod_dir"/istanbul/lib/cli.js
 
 runTest ( ) {
-    if [ "$1" = "sqlite" ]
-    then
+    if [ "$1" = "sqlite" ]; then
         echo "Running with SQLite backend"
         export RB_TEST_BACKEND=sqlite
         rm -f restbase
@@ -16,35 +15,29 @@ runTest ( ) {
         sh ./test/utils/cleandb.sh
     fi
 
-    if [ "$2" = "test" ]
-    then
-        ${mocha}
-    elif [ "$2" = "coverage" ]
-    then
-        ${istanbul} cover node_modules/.bin/_mocha -- -R spec
+    if [ "$2" = "test" ]; then
+        "${mocha}"
+    elif [ "$2" = "coverage" ]; then
+        "${istanbul}" cover node_modules/.bin/_mocha -- -R spec
     fi
 }
 
-if [ "x$2" == "x" ]
-then
+if [ "x$2" == "x" ]; then
     # no concrete backend is provided, check for cassandra
     `echo exit;` | cqlsh 2> /dev/null
-    if [ "$?" -eq 0 ]
-    then
+    if [ "$?" -eq 0 ]; then
         runTest "cassandra" $1
     else
         echo "Cassandra not available. Using SQLite backed for tests"
         runTest "sqlite" $1
     fi
-elif [ "$2" = "sqlite" ]
-then
+elif [ "$2" = "sqlite" ]; then
     runTest "sqlite" $1
-elif [ "$2" = "cassandra" ]
-then
+elif [ "$2" = "cassandra" ]; then
     runTest "cassandra" $1
-elif [ "$2" = "all" ]
-then
-    runTest "sqlite" $1 && runTest "cassandra" $1
+elif [ "$2" = "all" ]; then
+    runTest "sqlite" $1
+    runTest "cassandra" $1
 else
     echo "Invalid testing mode"
     exit 1

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -25,10 +25,10 @@ runTest ( ) {
     fi
 }
 
-if [ -z ${2+x} ]
+if [ "x$2" == "x" ]
 then
     # no concrete backend is provided, check for cassandra
-    `echo exit;` | cqlsh
+    `echo exit;` | cqlsh 2> /dev/null
     if [ "$?" -eq 0 ]
     then
         runTest "cassandra" $1
@@ -36,9 +36,7 @@ then
         echo "Cassandra not available. Using SQLite backed for tests"
         runTest "sqlite" $1
     fi
-fi
-
-if [ "$2" = "sqlite" ]
+elif [ "$2" = "sqlite" ]
 then
     runTest "sqlite" $1
 elif [ "$2" = "cassandra" ]
@@ -48,6 +46,6 @@ elif [ "$2" = "all" ]
 then
     runTest "sqlite" $1 && runTest "cassandra" $1
 else
-    echo "Invalid  testing mode"
+    echo "Invalid testing mode"
     exit 1
 fi

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PATH=$PATH:node_modules/.bin
+
 runTest ( ) {
     if [ "$1" = "sqlite" ]
     then
@@ -8,7 +10,7 @@ runTest ( ) {
         rm -f restbase
     else
         echo "Running with Cassandra backend"
-         export RB_TEST_BACKEND=cassandra
+        export RB_TEST_BACKEND=cassandra
         sh ./test/utils/cleandb.sh
     fi
 

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 mod_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )/node_modules
 mocha="$mod_dir"/mocha/bin/mocha
@@ -16,16 +16,16 @@ runTest ( ) {
         sh ./test/utils/cleandb.sh
     fi
 
-    if [[ "$2" = "test" ]]
+    if [ "$2" = "test" ]
     then
         ${mocha}
-    elif [[ "$2" = "coverage" ]]
+    elif [ "$2" = "coverage" ]
     then
         ${istanbul} cover node_modules/.bin/_mocha -- -R spec
     fi
 }
 
-if [[ -z ${2+x} ]]
+if [ -z ${2+x} ]
 then
     # no concrete backend is provided, check for cassandra
     `echo exit;` | cqlsh
@@ -38,13 +38,13 @@ then
     fi
 fi
 
-if [[ "$2" = "sqlite" ]]
+if [ "$2" = "sqlite" ]
 then
     runTest "sqlite" $1
-elif [[ "$2" = "cassandra" ]]
+elif [ "$2" = "cassandra" ]
 then
     runTest "cassandra" $1
-elif [[ "$2" = "all" ]]
+elif [ "$2" = "all" ]
 then
     runTest "sqlite" $1 && runTest "cassandra" $1
 else

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -14,13 +14,28 @@ var hostPort  = 'http://localhost:7231';
 var baseURL   = hostPort + '/en.wikipedia.test.local/v1';
 var bucketURL = baseURL + '/page';
 
+function loadConfig(path) {
+    var confString = fs.readFileSync(path).toString();
+    var backendImpl = process.env.RB_TEST_BACKEND;
+    if (backendImpl) {
+        if (backendImpl !== 'cassandra' && backendImpl !== 'sqlite') {
+            throw new Error('Invalid test_backend config variable value. Allowed values: "cassandra", "sqlite"');
+        }
+        if (backendImpl === 'sqlite') {
+            confString = confString.replace('restbase-mod-table-cassandra', 'restbase-mod-table-sqlite')
+        }
+    }
+    return yaml.safeLoad(confString);
+}
+
 var config = {
     hostPort: hostPort,
     baseURL: baseURL,
     bucketURL: bucketURL,
     logStream: logStream(),
-    conf: yaml.safeLoad(fs.readFileSync(__dirname + '/../../config.test.yaml')),
+    conf: loadConfig(__dirname + '/../../config.test.yaml')
 };
+
 config.conf.num_workers = 0;
 config.conf.logging = {
     name: 'restbase-tests',
@@ -61,3 +76,4 @@ function start(_options) {
 
 module.exports.config = config;
 module.exports.start  = start;
+module.exports.loadConfig = loadConfig;

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -19,7 +19,7 @@ function loadConfig(path) {
     var backendImpl = process.env.RB_TEST_BACKEND;
     if (backendImpl) {
         if (backendImpl !== 'cassandra' && backendImpl !== 'sqlite') {
-            throw new Error('Invalid test_backend config variable value. Allowed values: "cassandra", "sqlite"');
+            throw new Error('Invalid RB_TEST_BACKEND env variable value. Allowed values: "cassandra", "sqlite"');
         }
         if (backendImpl === 'sqlite') {
             confString = confString.replace('restbase-mod-table-cassandra', 'restbase-mod-table-sqlite')


### PR DESCRIPTION
Now we are able to test restbase with sqlite backend and cassandra backend. 

Simple npm test would check if cassandra is present and run against it, but if it's not, it would run tests against sqlite. In node > 0.10, we could specify what's being tests bug doing `npm test -- sqlite|cassandra|all`. I node 0.10 the same can be achieved by running `run_tests.sh test sqlite|cassandra|all`. Travis is changed to tests both backends.