### PR TITLE
Replaced constructor === Buffer with Buffer.isBuffer

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -399,7 +399,7 @@ PSP._getOriginalContent = function(restbase, req, revision, tid) {
             uri: new URI(path)
         })
         .then(function (res) {
-            if (res.body && res.body.constructor === Buffer) {
+            if (res.body && Buffer.isBuffer(res.body)) {
                 res.body = res.body.toString();
             }
             return {


### PR DESCRIPTION
restbase-mod-table-sqlite could return SlowBuffer under some circumstances, so we need to correctly check if the result is a Buffer object in RESTBase