### PR TITLE
TEST: Fix rb-mod-table-cass version to 0.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jsonwebtoken": "^5.0.1",
     "cassandra-uuid": "^0.0.2",
     "preq": "^0.4.3",
-    "restbase-mod-table-cassandra": "^0.7.6",
+    "restbase-mod-table-cassandra": "0.7.6",
     "service-runner": "^0.2.0",
     "swagger-router": "^0.1.0",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",


### PR DESCRIPTION
Travis seems to be having problems today with the back-end module
version 0.7.7, so let's see if reverting to 0.7.6 helps.