### PR TITLE
Disable timeouts in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "service-runner",
-    "test": "sh test/utils/cleandb.sh && mocha",
+    "test": "sh test/utils/cleandb.sh && mocha --no-timeouts",
     "coverage": "sh test/utils/cleandb.sh && istanbul cover _mocha -- -R spec",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },


### PR DESCRIPTION
I think @cscott was right about timeouts being mostly annoying and very rarely
useful. They aren't deterministic, and easily trigger when Travis or some
external service is slow. They are essentially worthless for proper
performance regression testing.

So, this patch disables timeouts for our tests in general.