### PR TITLE
Action module: Be backwards-compatible with apiURI-style configs

### DIFF
--- a/mods/action.js
+++ b/mods/action.js
@@ -107,6 +107,8 @@ function apiError(apiErr) {
 function ActionService (options) {
     // be backwards-compatible with apiURI-style configs
     if(!options.apiRequest && options.apiURI) {
+        // log a deprecation warning
+        options.log('warn/actionService', 'The config options for this module have changed. Please use the apiRequest template stanza');
         options.apiRequest = {
             method: 'post',
             // TODO: assume the URI is in the form https?://{domain}/w/api.php
@@ -122,6 +124,8 @@ function ActionService (options) {
         }
         // TODO: decide what to do when apiURI has got a host param, but
         // the rest isn't /w/api.php
+    } else if(!options.apiRequest) {
+        throw new Error('The action module needs the apiRequest temaplting stanza to exist!');
     }
     this.apiRequestTemplate = new Template(options.apiRequest);
 }

--- a/mods/action.js
+++ b/mods/action.js
@@ -105,6 +105,17 @@ function apiError(apiErr) {
  * Action module code
  */
 function ActionService (options) {
+    // be backwards-compatible with apiURI-style configs
+    if(!options.apiRequest && options.apiURI) {
+        options.apiRequest = {
+            method: 'post',
+            // assume the URI is in the form https?://{domain}/w/api.php
+            // as we cannot currently template the host in swagger-router
+            uri: '{$.default_uri}',
+            headers: { host: '{$.request.params.domain}' },
+            body: '{$.request.body}'
+        };
+    }
     this.apiRequestTemplate = new Template(options.apiRequest);
 }
 

--- a/mods/action.js
+++ b/mods/action.js
@@ -109,12 +109,19 @@ function ActionService (options) {
     if(!options.apiRequest && options.apiURI) {
         options.apiRequest = {
             method: 'post',
-            // assume the URI is in the form https?://{domain}/w/api.php
+            // TODO: assume the URI is in the form https?://{domain}/w/api.php
             // as we cannot currently template the host in swagger-router
             uri: '{$.default_uri}',
             headers: { host: '{$.request.params.domain}' },
             body: '{$.request.body}'
         };
+        // now check if there's really a param in the host of the URI
+        if(!/^(:?https?:\/\/){[^\s}]+}\//.test(options.apiURI)) {
+            // no host templating, use the string provided by the config
+            options.apiRequest.uri = options.apiURI;
+        }
+        // TODO: decide what to do when apiURI has got a host param, but
+        // the rest isn't /w/api.php
     }
     this.apiRequestTemplate = new Template(options.apiRequest);
 }


### PR DESCRIPTION
We have switched to request templating for `mods/action.js` configuration. However, some configs might still have the old-style `apiURI` config option. Translate that to the new style, since reading the old `config.yaml` file with the current RESTBase master fails to start the service entirely.

Note: this is a work-around, not a proper solution, as it assumes that either:
- there is no host templating in the URI, in which case the original `apiURI` string is used; or
- the URI host is templated and the rest of the URI is `/w/api.php`