### PR TITLE
New method for URI templating

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -102,7 +102,7 @@ templates:
             options:
               apiRequest:
                 method: post
-                uri: '{$.default_uri}'
+                uri: 'http://{domain}/w/api.php'
                 headers:
                   host: '{$.request.params.domain}'
                 body: '{$.request.body}'

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -37,6 +37,15 @@ function _setAtPath(path, spec) {
     return new Function('obj', 'value', code);
 }
 
+/**
+ * Validates and prepares the template string - resolves local references
+ * and wraps property access to ["..."]
+ *
+ * @param {string} template an original template string
+ * @param {string} defaultLookupPath a default path withing the context which
+ *                 to look if template is local
+ * @returns {string} validated and
+ */
 function prepareTemplateString(template, defaultLookupPath) {
     if (!/^(\$\.)?([a-zA-Z][a-zA-Z0-9-_]*)(\.[a-zA-Z][a-zA-Z0-9-_]*)*$/.test(template)) {
         throw new Error('Invalid template ' + template);
@@ -51,16 +60,33 @@ function prepareTemplateString(template, defaultLookupPath) {
         return "['" + paren.replace(/'/g, "\\'") + "']";
     });
 }
+
+/**
+ * Wraps a template into a uriEncode function call
+ *
+ * @param {string} template and original template string
+ * @param {boolean} uriEncode if true the template string will be wrapped into a function call
+ * @returns {string} modified template string
+ */
+function wrapUriEncode(template, uriEncode) {
+    if (uriEncode) {
+        return 'rm.func.encode(' + template + ')';
+    }
+    return template;
+}
+
 /**
  * Compiles a template into a function
  *
  * @param templateSpec template string (e.g. '{$.request.body.a}')
  * @param reqPart part of the request to lookup local properties in (e.g. headers, body etc.)
  * @param setValue callback for a result of template evaluation
+ * @param {boolean} uriEncode if true the values are uri-encoded
  * @returns {[Function]} array of template resolvers for the provided template
  */
-function compileTemplate(templateSpec, setValue, reqPart) {
+function compileTemplate(templateSpec, setValue, reqPart, uriEncode) {
     var template;
+    var templatedString;
     var prevIndex = 0;
     var completeTemplate = /^\{([^}]+)}$/.exec(templateSpec);
     if (completeTemplate && completeTemplate.length > 0) {
@@ -72,18 +98,18 @@ function compileTemplate(templateSpec, setValue, reqPart) {
                 template.push(templateSpec.substring(prevIndex, index));
             }
             if (spec[0] === '+') {
-                spec = spec.substr(1);
-            }
-            if (spec[0] === '/') {
+                template.push(['text', prepareTemplateString(spec.substr(1), reqPart)]);
+            } else if (spec[0] === '/') {
                 // Support for optional path parts (e.g. {/tid})
                 spec = spec.substr(1);
-                var templatedString = prepareTemplateString(spec, reqPart);
+                templatedString = prepareTemplateString(spec, reqPart);
                 template.push(['if', {
                     data: templatedString,
-                    tpl: ['/', ['text', templatedString]]
+                    tpl: ['/', ['text', wrapUriEncode(templatedString, uriEncode)]]
                 }]);
             } else {
-                template.push(['text', prepareTemplateString(spec, reqPart)]);
+                templatedString = prepareTemplateString(spec, reqPart);
+                template.push(['text', wrapUriEncode(templatedString, uriEncode)]);
             }
             prevIndex = index + full.length;
         });
@@ -173,7 +199,7 @@ function Template(spec) {
                 uriSetter(newReq, value);
             };
             if (/\{[^\{}]+}/.test(spec.uri)) {
-                compileTemplate(spec.uri, setValue, 'params').forEach(function(resolver) {
+                compileTemplate(spec.uri, setValue, 'params', true).forEach(function(resolver) {
                     self.resolvers.push(resolver);
                 });
             } else {
@@ -194,6 +220,19 @@ function Template(spec) {
 }
 
 /**
+ * Adds common functions to the context.func object,
+ * so that they could be used in templates as rm.func.funcName
+ *
+ * @param {object} context a request context to put common functions to
+ */
+function appendCommonOperators(context) {
+    context.func = {
+        encode: function(value) {
+            return encodeURIComponent(value);
+        }
+    };
+}
+/**
  * Evaluates the compiled template using the provided request
  *
  * @param req a request object where to take data from
@@ -201,10 +240,10 @@ function Template(spec) {
  */
 Template.prototype.eval = function(context) {
     var newReq = { method: context.request.method };
+    appendCommonOperators(context);
     this.resolvers.forEach(function(resolver) {
         resolver(newReq, context);
     });
-    console.log(newReq.uri);
     return newReq;
 };
 

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -62,29 +62,14 @@ function prepareTemplateString(template, defaultLookupPath) {
 }
 
 /**
- * Wraps a template into a uriEncode function call
- *
- * @param {string} template and original template string
- * @param {boolean} uriEncode if true the template string will be wrapped into a function call
- * @returns {string} modified template string
- */
-function wrapUriEncode(template, uriEncode) {
-    if (uriEncode) {
-        return 'rm.func.encode(' + template + ')';
-    }
-    return template;
-}
-
-/**
  * Compiles a template into a function
  *
  * @param templateSpec template string (e.g. '{$.request.body.a}')
  * @param reqPart part of the request to lookup local properties in (e.g. headers, body etc.)
  * @param setValue callback for a result of template evaluation
- * @param {boolean} uriEncode if true the values are uri-encoded
  * @returns {[Function]} array of template resolvers for the provided template
  */
-function compileTemplate(templateSpec, setValue, reqPart, uriEncode) {
+function compileTemplate(templateSpec, setValue, reqPart) {
     var template;
     var templatedString;
     var prevIndex = 0;
@@ -97,20 +82,8 @@ function compileTemplate(templateSpec, setValue, reqPart, uriEncode) {
             if (prevIndex !== index) {
                 template.push(templateSpec.substring(prevIndex, index));
             }
-            if (spec[0] === '+') {
-                template.push(['text', prepareTemplateString(spec.substr(1), reqPart)]);
-            } else if (spec[0] === '/') {
-                // Support for optional path parts (e.g. {/tid})
-                spec = spec.substr(1);
-                templatedString = prepareTemplateString(spec, reqPart);
-                template.push(['if', {
-                    data: templatedString,
-                    tpl: ['/', ['text', wrapUriEncode(templatedString, uriEncode)]]
-                }]);
-            } else {
-                templatedString = prepareTemplateString(spec, reqPart);
-                template.push(['text', wrapUriEncode(templatedString, uriEncode)]);
-            }
+            templatedString = prepareTemplateString(spec, reqPart);
+            template.push(['text', templatedString]);
             prevIndex = index + full.length;
         });
         if (prevIndex !== templateSpec.length) {
@@ -178,6 +151,40 @@ function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
 }
 
 /**
+ * Creates a template resolver functuons for URI part of the spec
+ * @param {object} spec a root request spec object
+ * @returns {[Function]} array of template resolvers which should be applied to resolve URI
+ */
+function createURIResolver(spec) {
+    var setter = _setAtPath('uri', spec);
+    if (/^\{[^\{}]+}$/.test(spec.uri)) {
+        var setValue = function(newReq, value) {
+            if (value.constructor !== URI) {
+                value = new URI(value, {}, false);
+            }
+            setter(newReq, value);
+        };
+        return compileTemplate(spec.uri, setValue, 'params');
+    } else if (/^(?:https?:\/\/)?\{[^\/]+}\//.test(spec.uri)) {
+        // The host is templated - replace it with TAssembly and use URI.expand for path templates
+        var hostTemplate = /^((?:https?:\/\/)?\{[^\/]+}\/)/.exec(spec.uri)[1];
+        return compileTemplate(hostTemplate, setter, 'params').map(function(resolver) {
+            return function(newReq, context) {
+                var uriSpec;
+                resolver(newReq, context);
+                uriSpec = newReq.uri + spec.uri.substr(hostTemplate.length);
+                setter(newReq, new URI(uriSpec, {}, true).expand(context.request.params));
+            };
+        });
+    } else {
+        var uriTemplate = new URI(spec.uri, {}, true);
+        return [function(newReq, context) {
+            setter(newReq, uriTemplate.expand(context.request.params));
+        }];
+    }
+}
+
+/**
  * Creates and compiles a new Template object using the provided JSON spec
  *
  * @param spec  Request spec provided in a Swagger spec. This is a JSON object
@@ -191,23 +198,7 @@ function Template(spec) {
     Object.keys(spec).forEach(function(reqPart) {
         var setValue;
         if (reqPart === 'uri') {
-            var uriSetter = _setAtPath('uri', spec);
-            setValue = function(newReq, value) {
-                if (value.constructor !== URI) {
-                    value = new URI(value, {}, false);
-                }
-                uriSetter(newReq, value);
-            };
-            if (/\{[^\{}]+}/.test(spec.uri)) {
-                compileTemplate(spec.uri, setValue, 'params', true).forEach(function(resolver) {
-                    self.resolvers.push(resolver);
-                });
-            } else {
-                var uriTemplate = new URI(spec.uri, {}, false);
-                self.resolvers.push(function(newReq) {
-                    setValue(newReq, uriTemplate);
-                });
-            }
+            self.resolvers = self.resolvers.concat(createURIResolver(spec));
         } else if (reqPart === 'method') {
             setValue = _setAtPath('method', spec);
             self.resolvers.push(function(newReq) {
@@ -220,19 +211,6 @@ function Template(spec) {
 }
 
 /**
- * Adds common functions to the context.func object,
- * so that they could be used in templates as rm.func.funcName
- *
- * @param {object} context a request context to put common functions to
- */
-function appendCommonOperators(context) {
-    context.func = {
-        encode: function(value) {
-            return encodeURIComponent(value);
-        }
-    };
-}
-/**
  * Evaluates the compiled template using the provided request
  *
  * @param req a request object where to take data from
@@ -240,7 +218,6 @@ function appendCommonOperators(context) {
  */
 Template.prototype.eval = function(context) {
     var newReq = { method: context.request.method };
-    appendCommonOperators(context);
     this.resolvers.forEach(function(resolver) {
         resolver(newReq, context);
     });

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -37,6 +37,20 @@ function _setAtPath(path, spec) {
     return new Function('obj', 'value', code);
 }
 
+function prepareTemplateString(template, defaultLookupPath) {
+    if (!/^(\$\.)?([a-zA-Z][a-zA-Z0-9-_]*)(\.[a-zA-Z][a-zA-Z0-9-_]*)*$/.test(template)) {
+        throw new Error('Invalid template ' + template);
+    }
+
+    if (template[0] === '$') {
+        template = 'rm' + template.slice(1);
+    } else {
+        template = 'm.request.' + defaultLookupPath + '.' + template;
+    }
+    return template.replace(/\.([^.]*(?:-[^.]*)+)/g, function(all, paren) {
+        return "['" + paren.replace(/'/g, "\\'") + "']";
+    });
+}
 /**
  * Compiles a template into a function
  *
@@ -46,23 +60,40 @@ function _setAtPath(path, spec) {
  * @returns {[Function]} array of template resolvers for the provided template
  */
 function compileTemplate(templateSpec, setValue, reqPart) {
-    var template = /^\{([^}]+)}$/.exec(templateSpec)[1];
-
-    if (!/^(\$\.)?([a-zA-Z][a-zA-Z0-9-_]*)(\.[a-zA-Z][a-zA-Z0-9-_]*)*$/.test(template)) {
-        throw new Error('Invalid template ' + template);
-    }
-
-    if (template[0] === '$') {
-        template = 'rm' + template.slice(1);
+    var template;
+    var prevIndex = 0;
+    var completeTemplate = /^\{([^}]+)}$/.exec(templateSpec);
+    if (completeTemplate && completeTemplate.length > 0) {
+        template = [['raw', prepareTemplateString(completeTemplate[1], reqPart)]];
     } else {
-        template = 'm.request.' + reqPart + '.' + template;
+        template = [];
+        templateSpec.replace(/\{([^}]+)}/g, function(full, spec, index) {
+            if (prevIndex !== index) {
+                template.push(templateSpec.substring(prevIndex, index));
+            }
+            if (spec[0] === '+') {
+                spec = spec.substr(1);
+            }
+            if (spec[0] === '/') {
+                // Support for optional path parts (e.g. {/tid})
+                spec = spec.substr(1);
+                var templatedString = prepareTemplateString(spec, reqPart);
+                template.push(['if', {
+                    data: templatedString,
+                    tpl: ['/', ['text', templatedString]]
+                }]);
+            } else {
+                template.push(['text', prepareTemplateString(spec, reqPart)]);
+            }
+            prevIndex = index + full.length;
+        });
+        if (prevIndex !== templateSpec.length) {
+            template.push(templateSpec.substring(prevIndex, templateSpec.length));
+        }
     }
-    template = template.replace(/\.([^.]*(?:-[^.]*)+)/g, function(all, paren) {
-        return "['" + paren.replace(/'/g, "\\'") + "']";
-    });
 
     var res;
-    var resolveTemplate = TAssembly.compile([['raw', template]], {
+    var resolveTemplate = TAssembly.compile(template, {
         errorHandler: function() { return undefined; },
         cb: function(bit) {
             if (res === undefined) {
@@ -103,7 +134,7 @@ function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
         var setValue = _setAtPath(templatePath, origSpec);
         if (templateSpec instanceof Object) {
             return _createTemplateResolvers(origSpec, templateSpec, reqPart, templatePath);
-        } else if (/^\{[^}]+}$/.test(templateSpec)) {
+        } else if (/\{[^}]+}/.test(templateSpec)) {
             return compileTemplate(templateSpec, setValue, reqPart);
         } else {
             return [ function(newReq) { setValue(newReq, templateSpec); } ];
@@ -134,15 +165,21 @@ function Template(spec) {
     Object.keys(spec).forEach(function(reqPart) {
         var setValue;
         if (reqPart === 'uri') {
-            setValue = _setAtPath('uri', spec);
-            if (/^\{[^\{}]+}$/.test(spec.uri)) {
-                compileTemplate(spec.uri, setValue, 'uri').forEach(function(resolver) {
+            var uriSetter = _setAtPath('uri', spec);
+            setValue = function(newReq, value) {
+                if (value.constructor !== URI) {
+                    value = new URI(value, {}, false);
+                }
+                uriSetter(newReq, value);
+            };
+            if (/\{[^\{}]+}/.test(spec.uri)) {
+                compileTemplate(spec.uri, setValue, 'params').forEach(function(resolver) {
                     self.resolvers.push(resolver);
                 });
             } else {
-                var uriTemplate = new URI(spec.uri, {}, true);
-                self.resolvers.push(function(newReq, context) {
-                    setValue(newReq, uriTemplate.expand(context.request.params));
+                var uriTemplate = new URI(spec.uri, {}, false);
+                self.resolvers.push(function(newReq) {
+                    setValue(newReq, uriTemplate);
                 });
             }
         } else if (reqPart === 'method') {
@@ -167,6 +204,7 @@ Template.prototype.eval = function(context) {
     this.resolvers.forEach(function(resolver) {
         resolver(newReq, context);
     });
+    console.log(newReq.uri);
     return newReq;
 };
 

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -3,11 +3,13 @@
 var URI = require('swagger-router').URI;
 var rbUtil = require('./rbUtil');
 var TAssembly = require('tassembly');
+var url = require('url');
 
 /**
  * Creates a function that sets a value at the path and initializes all objects/arrays along the path.
  *
- * @param path the path within an object/array separated with dots {e.g. test.body.a.b.c}
+ * @param {string} path the path within an object/array separated with dots {e.g. test.body.a.b.c}
+ * @param {object} spec spec element that contains provided path
  * @returns {Function} the function to set a value at path and initialize object along the path if needed
  * @private
  */
@@ -71,24 +73,26 @@ function prepareTemplateString(template, defaultLookupPath) {
  */
 function compileTemplate(templateSpec, setValue, reqPart) {
     var template;
-    var templatedString;
     var prevIndex = 0;
     var completeTemplate = /^\{([^}]+)}$/.exec(templateSpec);
     if (completeTemplate && completeTemplate.length > 0) {
         template = [['raw', prepareTemplateString(completeTemplate[1], reqPart)]];
     } else {
+        var re = /\{([^}]+)}/g;
         template = [];
-        templateSpec.replace(/\{([^}]+)}/g, function(full, spec, index) {
-            if (prevIndex !== index) {
-                template.push(templateSpec.substring(prevIndex, index));
+        var match;
+        do {
+            match = re.exec(templateSpec);
+            if (match) {
+                if (match.index !== prevIndex) {
+                    template.push(templateSpec.substring(prevIndex, match.index));
+                }
+                template.push(['raw', prepareTemplateString(match[1], reqPart)]);
+                prevIndex = match.index + match[0].length;
+            } else if (prevIndex !== templateSpec.length) {
+                template.push(templateSpec.substring(prevIndex, templateSpec.length));
             }
-            templatedString = prepareTemplateString(spec, reqPart);
-            template.push(['text', templatedString]);
-            prevIndex = index + full.length;
-        });
-        if (prevIndex !== templateSpec.length) {
-            template.push(templateSpec.substring(prevIndex, templateSpec.length));
-        }
+        } while (match);
     }
 
     var res;
@@ -113,6 +117,7 @@ function compileTemplate(templateSpec, setValue, reqPart) {
 /**
  *  Constructs a list of resolvers for all templates in a request spec
  *
+ * @param origSpec original full spec
  * @param subspec a request spec or subspec for a part of request
  * @param reqPart name of request part (e.g. headers, body, query)
  * @param path path to the current subspec within a full spec
@@ -169,11 +174,13 @@ function createURIResolver(spec) {
         // The host is templated - replace it with TAssembly and use URI.expand for path templates
         var hostTemplate = /^((?:https?:\/\/)?\{[^\/]+}\/)/.exec(spec.uri)[1];
         return compileTemplate(hostTemplate, setter, 'params').map(function(resolver) {
+            var path = spec.uri.substr(hostTemplate.length);
+            var pathTemplate = new URI('/' + path, {}, true);
             return function(newReq, context) {
-                var uriSpec;
                 resolver(newReq, context);
-                uriSpec = newReq.uri + spec.uri.substr(hostTemplate.length);
-                setter(newReq, new URI(uriSpec, {}, true).expand(context.request.params));
+                var newUri = pathTemplate.expand(context.request.params);
+                newUri.urlObj = url.parse(newReq.uri + path);
+                setter(newReq, newUri);
             };
         });
     } else {
@@ -213,8 +220,8 @@ function Template(spec) {
 /**
  * Evaluates the compiled template using the provided request
  *
- * @param req a request object where to take data from
- * @returns {*} a new request object with all templates either substituted or dropped
+ * @param {object} context a context object where to take data from
+ * @returns {object} a new request object with all templates either substituted or dropped
  */
 Template.prototype.eval = function(context) {
     var newReq = { method: context.request.method };

--- a/mods/action.js
+++ b/mods/action.js
@@ -145,8 +145,7 @@ function buildEditResponse(res) {
 
 ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     var apiRequest = this.apiRequestTemplate.eval({
-        request: req,
-        default_uri: 'http://' + req.params.domain + '/w/api.php'
+        request: req
     });
     apiRequest.body.action = defBody.action;
     apiRequest.body.format = apiRequest.body.format || defBody.format || 'json';

--- a/mods/simple_service.js
+++ b/mods/simple_service.js
@@ -56,7 +56,7 @@ SimpleService.prototype.processSpec = function(spec) {
                         return restbase.put({
                             uri: storageUriTemplate.expand(req.params),
                             headers: res.headers,
-                            body: res.body,
+                            body: res.body
                         })
                         .then(function(storeRes) {
                             res.headers.etag = storeRes.headers.etag;
@@ -93,7 +93,7 @@ SimpleService.prototype.processSpec = function(spec) {
     return {
         spec: spec,
         operations: operations,
-        resources: resources,
+        resources: resources
     };
 };
 

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -186,7 +186,7 @@ describe('router - misc', function() {
 
     it('should encode uri components', function() {
         var requestTemplate = {
-            uri: '{domain}/path1/{path2}'
+            uri: 'http://{domain}/path1/{path2}'
         };
         var result = new Template(requestTemplate).eval({
             request: {
@@ -196,12 +196,15 @@ describe('router - misc', function() {
                 }
             }
         });
-        assert.deepEqual(result.uri, new URI('en.wikipedia.org/path1/test1%2Ftest2%2Ftest3'))
+        assert.deepEqual(result.uri,
+            new URI('http://en.wikipedia.org/path1/{path2}', {}, true).expand({
+                path2: 'test1/test2/test3'
+        }));
     });
 
     it('should support optional path elements in uri template', function() {
         var requestTemplate = {
-            uri: '{domain}/path1{/optional}'
+            uri: '/{domain}/path1{/optional}'
         };
         var resultNoOptional = new Template(requestTemplate).eval({
             request: {
@@ -210,7 +213,7 @@ describe('router - misc', function() {
                 }
             }
         });
-        assert.deepEqual(resultNoOptional.uri, new URI('en.wikipedia.org/path1'));
+        assert.deepEqual(resultNoOptional.uri, new URI('/en.wikipedia.org/path1{/optional}', {}, true).expand());
         var resultWithOptional = new Template(requestTemplate).eval({
             request: {
                 params: {
@@ -219,12 +222,14 @@ describe('router - misc', function() {
                 }
             }
         });
-        assert.deepEqual(resultWithOptional.uri, new URI('en.wikipedia.org/path1/value'));
+        assert.deepEqual(resultWithOptional.uri, new URI('/en.wikipedia.org/path1{/optional}', {}, true).expand({
+            optional: 'value'
+        }));
     });
 
     it('should support + templates in path', function() {
         var requestTemplate = {
-            uri: '{domain}/path1/{+path}'
+            uri: 'http://{domain}/path1/{+path}'
         };
         var result = new Template(requestTemplate).eval({
             request: {
@@ -234,7 +239,10 @@ describe('router - misc', function() {
                 }
             }
         });
-        assert.deepEqual(result.uri, new URI('en.wikipedia.org/path1/test1/test2/test3'));
+        assert.deepEqual(result.uri,
+            new URI('http://en.wikipedia.org/path1/{+path}', {}, true).expand({
+            path: 'test1/test2/test3'
+        }));
     });
 
     it('should support templating the whole uri', function() {
@@ -248,6 +256,6 @@ describe('router - misc', function() {
                 }
             }
         });
-        assert.deepEqual(result.uri, new URI('en.wikipedia.org/path1/test1/test2/test3'));
+        assert.deepEqual(result.uri, new URI('en.wikipedia.org/path1/test1/test2/test3', {}, false));
     });
 });

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -112,7 +112,8 @@ describe('router - misc', function() {
                     }
                 },
                 'field_name_with_underscore': '{field_name_with_underscore}',
-                'additional_context_field': '{$.additional_context.field}'
+                'additional_context_field': '{$.additional_context.field}',
+                'string_templated': 'test {field_name_with_underscore}'
             }
         };
         var testRequest = {
@@ -170,7 +171,8 @@ describe('router - misc', function() {
                     }
                 },
                 'field_name_with_underscore': 'field_value_with_underscore',
-                additional_context_field: 'additional_test_value'
+                additional_context_field: 'additional_test_value',
+                'string_templated': 'test field_value_with_underscore'
             }
         };
         var result = new Template(requestTemplate).eval({
@@ -180,5 +182,72 @@ describe('router - misc', function() {
             }
         });
         assert.deepEqual(result, expectedTemplatedRequest);
+    });
+
+    it('should encode uri components', function() {
+        var requestTemplate = {
+            uri: '{domain}/path1/{path2}'
+        };
+        var result = new Template(requestTemplate).eval({
+            request: {
+                params: {
+                    domain: 'en.wikipedia.org',
+                    path2: 'test1/test2/test3'
+                }
+            }
+        });
+        assert.deepEqual(result.uri, new URI('en.wikipedia.org/path1/test1%2Ftest2%2Ftest3'))
+    });
+
+    it('should support optional path elements in uri template', function() {
+        var requestTemplate = {
+            uri: '{domain}/path1{/optional}'
+        };
+        var resultNoOptional = new Template(requestTemplate).eval({
+            request: {
+                params: {
+                    domain: 'en.wikipedia.org'
+                }
+            }
+        });
+        assert.deepEqual(resultNoOptional.uri, new URI('en.wikipedia.org/path1'));
+        var resultWithOptional = new Template(requestTemplate).eval({
+            request: {
+                params: {
+                    domain: 'en.wikipedia.org',
+                    optional: 'value'
+                }
+            }
+        });
+        assert.deepEqual(resultWithOptional.uri, new URI('en.wikipedia.org/path1/value'));
+    });
+
+    it('should support + templates in path', function() {
+        var requestTemplate = {
+            uri: '{domain}/path1/{+path}'
+        };
+        var result = new Template(requestTemplate).eval({
+            request: {
+                params: {
+                    domain: 'en.wikipedia.org',
+                    path: 'test1/test2/test3'
+                }
+            }
+        });
+        assert.deepEqual(result.uri, new URI('en.wikipedia.org/path1/test1/test2/test3'));
+    });
+
+    it('should support templating the whole uri', function() {
+        var requestTemplate = {
+            uri: '{uri}'
+        };
+        var result = new Template(requestTemplate).eval({
+            request: {
+                params: {
+                    uri: 'en.wikipedia.org/path1/test1/test2/test3'
+                }
+            }
+        });
+        assert.deepEqual(result.uri, new URI('en.wikipedia.org/path1/test1/test2/test3'));
     });
 });


### PR DESCRIPTION
Added support for substring templating e.g. 'string {this_is_replaced_by_value}'. This is used to template URIs with plain tassembly without using the URI.expand method. This is not only more efficient (~20% perf improvement on my laptop) but also we now support host templating. With this new functionality we can get rid of a hack with default_uri template in the action service.