### PR TITLE
Support ipv6 embedded addresses in private / public IP classifier

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -196,7 +196,7 @@ function handleRequest (opts, req, resp) {
     var xff = req.headers['x-forwarded-for'];
     var remoteAddr = xff && xff.split(',')[0].trim()
         || req.socket.remoteAddress;
-    if (/^(?:10|127)\./.test(remoteAddr)) {
+    if (/^(?:::ffff:)?(?:10|127)\./.test(remoteAddr)) {
         reqOpts.metrics.increment('requests.private');
     } else {
         reqOpts.metrics.increment('requests.public');


### PR DESCRIPTION
Production hosts running iojs return ipv6 addresses for socket.remoteAddress.
Those are typically derived from ipv4 addresses, so can be matched with a
simple extension to the ipv4 regexp.