### PR TITLE
Enforce code style

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -17,6 +17,7 @@
 
   "excludeFiles": [
     "node_modules/**",
-    "test/**"
+    "test/**",
+    "coverage/**"
   ]
 }

--- a/.jscs.json
+++ b/.jscs.json
@@ -14,6 +14,8 @@
   "requireCapitalizedComments": null,
   "maximumLineLength": 100,
   "validateQuoteMarks": null,
+  "requireTrailingComma": null,
+  "disallowTrailingComma": true,
 
   "excludeFiles": [
     "node_modules/**",

--- a/.jscs.json
+++ b/.jscs.json
@@ -11,11 +11,11 @@
   ],
   "validateIndentation": 4,
   "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
-  "requireCapitalizedComments": { "allExcept": ["jslint"] },
+  "requireCapitalizedComments": null,
   "maximumLineLength": 100,
   "validateQuoteMarks": null,
   "requireTrailingComma": null,
-  "disallowTrailingComma": true,
+  "disallowTrailingComma": null,
   "requireSpacesInsideObjectBrackets": "all",
 
   "excludeFiles": [

--- a/.jscs.json
+++ b/.jscs.json
@@ -1,0 +1,22 @@
+{
+  "preset": "node-style-guide",
+  "requireCurlyBraces": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "try",
+    "catch"
+  ],
+  "validateIndentation": 4,
+  "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
+  "requireCapitalizedComments": null,
+  "maximumLineLength": 100,
+  "validateQuoteMarks": null,
+
+  "excludeFiles": [
+    "node_modules/**",
+    "test/**"
+  ]
+}

--- a/.jscs.json
+++ b/.jscs.json
@@ -11,11 +11,12 @@
   ],
   "validateIndentation": 4,
   "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
-  "requireCapitalizedComments": null,
+  "requireCapitalizedComments": { "allExcept": ["jslint"] },
   "maximumLineLength": 100,
   "validateQuoteMarks": null,
   "requireTrailingComma": null,
   "disallowTrailingComma": true,
+  "requireSpacesInsideObjectBrackets": "all",
 
   "excludeFiles": [
     "node_modules/**",

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -17,7 +17,7 @@ var rbUtil = {};
 var qs = require('querystring');
 // Should make it into 0.12, see https://github.com/joyent/node/pull/7878
 var SIMPLE_PATH = /^(\/(?!\/)[^\?#\s]*)(?:\?([^#\s]*))?$/;
-rbUtil.parseURL = function parseURL (uri) {
+rbUtil.parseURL = function parseURL(uri) {
     // Fast path for simple path uris
     var fastMatch = SIMPLE_PATH.exec(uri);
     if (fastMatch) {
@@ -33,7 +33,7 @@ rbUtil.parseURL = function parseURL (uri) {
             pathname: fastMatch[1],
             path: fastMatch[1],
             query: fastMatch[2] && qs.parse(fastMatch[2]) || {},
-            href: uri
+            href: uri,
         };
     } else {
         return url.parse(uri, true);
@@ -81,7 +81,7 @@ rbUtil.constructCSP = function(domain, options) {
 // @returns {Promise<>}
 
 function read(req) {
-    return new P(function (resolve) {
+    return new P(function(resolve) {
         var chunks = [];
         req.on('data', function(chunk) {
             chunks.push(chunk);
@@ -112,13 +112,13 @@ rbUtil.parsePOST = function parsePOST(req) {
             var bboy = new Busboy({
                 headers: req.headers,
                 // Increase the form field size limit from the 1M default.
-                limits: { fieldSize: 15 * 1024 * 1024 }
+                limits: { fieldSize: 15 * 1024 * 1024 },
             });
             var body = {};
-            bboy.on('field', function (field, val) {
+            bboy.on('field', function(field, val) {
                 body[field] = val;
             });
-            bboy.on('finish', function () {
+            bboy.on('finish', function() {
                 resolve(body);
             });
             req.pipe(bboy);
@@ -126,7 +126,7 @@ rbUtil.parsePOST = function parsePOST(req) {
     }
 };
 
-rbUtil.reverseDomain = function reverseDomain (domain) {
+rbUtil.reverseDomain = function reverseDomain(domain) {
     return domain.toLowerCase().split('.').reverse().join('.');
 };
 
@@ -151,7 +151,7 @@ rbUtil.tidFromDate = function tidFromDate(date) {
 /**
  * Check if a string is a valid timeuuid
  */
-rbUtil.isTimeUUID = function (s) {
+rbUtil.isTimeUUID = function(s) {
     return uuid.test(s);
 };
 

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -33,7 +33,7 @@ rbUtil.parseURL = function parseURL(uri) {
             pathname: fastMatch[1],
             path: fastMatch[1],
             query: fastMatch[2] && qs.parse(fastMatch[2]) || {},
-            href: uri,
+            href: uri
         };
     } else {
         return url.parse(uri, true);
@@ -112,7 +112,7 @@ rbUtil.parsePOST = function parsePOST(req) {
             var bboy = new Busboy({
                 headers: req.headers,
                 // Increase the form field size limit from the 1M default.
-                limits: { fieldSize: 15 * 1024 * 1024 },
+                limits: { fieldSize: 15 * 1024 * 1024 }
             });
             var body = {};
             bboy.on('field', function(field, val) {
@@ -200,7 +200,7 @@ rbUtil.parseETag = function(etag) {
     if (bits) {
         return {
             rev: bits[1],
-            tid: bits[2],
+            tid: bits[2]
         };
     } else {
         return null;

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -132,10 +132,10 @@ rbUtil.reverseDomain = function reverseDomain(domain) {
 
 rbUtil.tidFromDate = function tidFromDate(date) {
     if (typeof date === 'object') {
-        // convert Date object to numeric milliseconds
+        // Convert Date object to numeric milliseconds
         date = date.getTime();
     } else if (typeof date === 'string') {
-        // convert date string to numeric milliseconds
+        // Convert date string to numeric milliseconds
         date = Date.parse(date);
     }
     if (isNaN(+date)) {

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -6,11 +6,14 @@ var TAssembly = require('tassembly');
 var url = require('url');
 
 /**
- * Creates a function that sets a value at the path and initializes all objects/arrays along the path.
+ * Creates a function that sets a value at the path
+ * and initializes all objects/arrays along the path.
  *
- * @param {string} path the path within an object/array separated with dots {e.g. test.body.a.b.c}
+ * @param {string} path the path within an object/array separated
+ *        with dots {e.g. test.body.a.b.c}
  * @param {object} spec spec element that contains provided path
- * @returns {Function} the function to set a value at path and initialize object along the path if needed
+ * @returns {Function} the function to set a value at path
+ *          and initialize object along the path if needed
  * @private
  */
 function _setAtPath(path, spec) {
@@ -104,14 +107,14 @@ function compileTemplate(templateSpec, setValue, reqPart) {
             } else {
                 res += '' + bit;
             }
-        }
+        },
     });
     return [ function(newReq, context) {
         resolveTemplate(context);
         var value = res;
         res = undefined; // Unitialize res to prepare to the next request
         setValue(newReq, value);
-    } ];
+    }, ];
 }
 
 /**
@@ -122,7 +125,8 @@ function compileTemplate(templateSpec, setValue, reqPart) {
  * @param reqPart name of request part (e.g. headers, body, query)
  * @param path path to the current subspec within a full spec
  * @returns {Array} an array of template resolvers for every template found in the spec.
- *          Resolvers are functions with (newRequest, request) arguments that modify newRequest param.
+ *          Resolvers are functions with (newRequest, request) arguments
+ *          that modify newRequest param.
  * @private
  */
 function _createTemplateResolvers(origSpec, subspec, reqPart, path) {

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -191,7 +191,7 @@ function createURIResolver(spec) {
         var uriTemplate = new URI(spec.uri, {}, true);
         return [function(newReq, context) {
             setter(newReq, uriTemplate.expand(context.request.params));
-        }];
+        }, ];
     }
 }
 
@@ -216,7 +216,8 @@ function Template(spec) {
                 setValue(newReq, spec.method);
             });
         } else if (spec[reqPart]) {
-            self.resolvers = self.resolvers.concat(_createTemplateResolvers(spec, spec[reqPart], reqPart));
+            self.resolvers = self.resolvers.concat(
+                _createTemplateResolvers(spec, spec[reqPart], reqPart));
         }
     });
 }

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -107,14 +107,14 @@ function compileTemplate(templateSpec, setValue, reqPart) {
             } else {
                 res += '' + bit;
             }
-        },
+        }
     });
     return [ function(newReq, context) {
         resolveTemplate(context);
         var value = res;
         res = undefined; // Unitialize res to prepare to the next request
         setValue(newReq, value);
-    }, ];
+    }];
 }
 
 /**
@@ -191,7 +191,7 @@ function createURIResolver(spec) {
         var uriTemplate = new URI(spec.uri, {}, true);
         return [function(newReq, context) {
             setter(newReq, uriTemplate.expand(context.request.params));
-        }, ];
+        }];
     }
 }
 

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -23,11 +23,11 @@ function cloneRequest(req) {
         headers: req.headers || {},
         query: req.query || {},
         body: req.body || null,
-        params: req.params || {}
+        params: req.params || {},
     };
 }
 
-function RESTBase (options, req) {
+function RESTBase(options, req) {
     if (options && options.constructor === RESTBase) {
         // Child instance
         var par = this._parent = options;
@@ -60,7 +60,7 @@ function RESTBase (options, req) {
         // Private state, shared with child instances
         this._priv = {
             options: options,
-            router: options.router
+            router: options.router,
         };
 
         this.rb_config = options.conf;
@@ -74,7 +74,7 @@ function RESTBase (options, req) {
 RESTBase.prototype.setRequestId = function(req) {
 
     req.headers = req.headers || {};
-    if(req.headers['x-request-id']) {
+    if (req.headers['x-request-id']) {
         return;
     }
     req.headers['x-request-id'] = this.reqId;
@@ -97,17 +97,17 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
     if (rq.spec !== undefined && value.specRoot) {
         var spec = Object.assign({}, value.specRoot, {
             // Set the base path dynamically
-            basePath: req.uri.toString().replace(/\/$/, '')
+            basePath: req.uri.toString().replace(/\/$/, ''),
         });
 
-        if (req.params.domain === req.headers.host.replace(/:[0-9]+$/,'')) {
+        if (req.params.domain === req.headers.host.replace(/:[0-9]+$/, '')) {
             // This is a host-based request. Set an appropriate base path.
             spec.basePath = spec['x-host-basePath'] || spec.basePath;
         }
 
         return P.resolve({
             status: 200,
-            body: spec
+            body: spec,
         });
     } else if (rq.doc !== undefined) {
         // Return swagger UI & load spec from /?spec
@@ -148,7 +148,7 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
         return swaggerUI(restbase, req)
         .then(function(res) {
             res.body = res.body
-                .replace(/window\.swaggerUi\.load/,'')
+                .replace(/window\.swaggerUi\.load/, '')
                 .replace(/<div id="swagger-ui-container" class="swagger-ui-wrap">/, html);
             return res;
         });
@@ -157,8 +157,8 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
         return P.resolve({
             status: 200,
             body: {
-                items: req.params._ls
-            }
+                items: req.params._ls,
+            },
         });
     }
 };
@@ -171,7 +171,7 @@ RESTBase.prototype.defaultWebRequestHandler = function(req) {
     this.setRequestId(req);
     this.log('trace/webrequest', {
         req: req,
-        request_id: req.headers['x-request-id']
+        request_id: req.headers['x-request-id'],
     });
     // Make sure we have a string
     req.uri = '' + req.uri;
@@ -181,7 +181,7 @@ RESTBase.prototype.defaultWebRequestHandler = function(req) {
 
 
 // Process one request
-RESTBase.prototype.request = function (req) {
+RESTBase.prototype.request = function(req) {
     // Protect the sys api from direct access
     // Could consider opening this up with a specific permission later.
     if (this._recursionDepth === 0 &&
@@ -192,8 +192,8 @@ RESTBase.prototype.request = function (req) {
             status: 403,
             body: {
                 type: 'access_denied#sys',
-                title: 'Access to the /{domain}/sys/ hierarchy is restricted to system users.'
-            }
+                title: 'Access to the /{domain}/sys/ hierarchy is restricted to system users.',
+            },
         }));
     }
 
@@ -206,7 +206,7 @@ RESTBase.prototype.request = function (req) {
 
 
 // Internal request handler
-RESTBase.prototype._request = function (req) {
+RESTBase.prototype._request = function(req) {
     var self = this;
 
     // Special handling for https? requests
@@ -231,8 +231,8 @@ RESTBase.prototype._request = function (req) {
                 uri: req.uri,
                 method: req.method,
                 parents: parents,
-                depth: this._recursionDepth
-            }
+                depth: this._recursionDepth,
+            },
         });
     }
 
@@ -250,7 +250,7 @@ RESTBase.prototype._request = function (req) {
         // A GET for an URL that ends with /: return a default listing
         if (!match.value) { match.value = {}; }
         if (!match.value.path) { match.value.path = '_defaultListingHandler'; }
-        handler = function (restbase, req) {
+        handler = function(restbase, req) {
             return self.defaultListingHandler(match.value, restbase, req);
         };
     }
@@ -273,7 +273,7 @@ RESTBase.prototype._request = function (req) {
 
         // Call the handler with P.try to catch synchronous exceptions.
         return P.try(handler, [childRESTBase, childReq])
-        .then(function(res){
+        .then(function(res) {
             // Record request metrics & log
             var statusClass = Math.floor(res.status / 100) + 'xx';
             self.metrics.endTiming([statName + statusClass, statName + 'ALL'], startTime);
@@ -281,7 +281,7 @@ RESTBase.prototype._request = function (req) {
             self.log('trace', {
                 req: req,
                 res: res,
-                request_id: childRESTBase.reqId
+                request_id: childRESTBase.reqId,
             });
 
             if (!res) {
@@ -290,8 +290,8 @@ RESTBase.prototype._request = function (req) {
                     body: {
                         type: 'empty_response',
                         description: 'Empty response received',
-                        req: req
-                    }
+                        req: req,
+                    },
                 });
             } else if (res.status >= 400 && !(res instanceof Error)) {
                 var err = new HTTPError(res);
@@ -303,7 +303,7 @@ RESTBase.prototype._request = function (req) {
                 return res;
             }
         },
-        function(err){
+        function(err) {
             var statusClass = '5xx';
             if (err && err.status) {
                 statusClass = Math.floor(err.status / 100) + 'xx';
@@ -320,8 +320,8 @@ RESTBase.prototype._request = function (req) {
                 title: 'Not found.',
                 internalURI: req.uri,
                 method: req.method,
-                depth: self._recursionDepth
-            }
+                depth: self._recursionDepth,
+            },
         }));
     }
 };
@@ -331,7 +331,7 @@ RESTBase.prototype._request = function (req) {
 // * If the first parameter is a string, it's expected to be the URL.
 // * If the second parameter is a String or Buffer, it's expected to be a
 //   resource body.
-function makeRequest (uri, reqOrBody, method) {
+function makeRequest(uri, reqOrBody, method) {
     var req;
     if (uri.constructor === Object) {
         // fast path
@@ -346,7 +346,7 @@ function makeRequest (uri, reqOrBody, method) {
         req = {
             uri: uri,
             method: method,
-            body: reqOrBody
+            body: reqOrBody,
         };
     }
     return req;
@@ -354,7 +354,7 @@ function makeRequest (uri, reqOrBody, method) {
 
 // Convenience wrappers
 var methods = ['get', 'post', 'put', 'delete', 'head', 'options',
-    'trace', 'connect', 'copy', 'move', 'purge', 'search'];
+    'trace', 'connect', 'copy', 'move', 'purge', 'search', ];
 methods.forEach(function(method) {
     RESTBase.prototype[method] = function(uri, req) {
         return this._request(makeRequest(uri, req, method));
@@ -368,7 +368,7 @@ methods.forEach(function(method) {
 // @param {string} token
 // @return {string} JWT signed token
 RESTBase.prototype.encodeToken = function(token) {
-    var newToken = jwt.sign({next:token}, this._priv.options.conf.salt);
+    var newToken = jwt.sign({next: token, }, this._priv.options.conf.salt);
     return newToken;
 };
 
@@ -379,13 +379,13 @@ RESTBase.prototype.decodeToken = function(token) {
     try {
         var next = jwt.verify(token, this._priv.options.conf.salt);
         return next.next;
-    } catch(e) {
+    } catch (e) {
         throw new HTTPError({
             status: 400,
             body: {
                 type: 'invalid_paging_token',
-                title: 'Invalid paging token'
-            }
+                title: 'Invalid paging token',
+            },
         });
     }
 };

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -41,7 +41,7 @@ function RESTBase(options, req) {
         this.rb_config = this._priv.options.conf;
     } else {
         // Brand new instance
-        this.log = options.log; // logging method
+        this.log = options.log; // Logging method
         this.metrics = options.metrics;
         this.reqId = null;
 
@@ -69,7 +69,7 @@ function RESTBase(options, req) {
 
 }
 
-// sets the request id for this instance and adds it to
+// Sets the request id for this instance and adds it to
 // the request header, if defined
 RESTBase.prototype.setRequestId = function(req) {
 
@@ -165,7 +165,7 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
 
 // Special handling for external web requests
 RESTBase.prototype.defaultWebRequestHandler = function(req) {
-    // enforce the usage of UA
+    // Enforce the usage of UA
     req.headers = req.headers || {};
     req.headers['User-Agent'] = req.headers['User-Agent'] || this.rb_config.user_agent;
     this.setRequestId(req);
@@ -264,7 +264,7 @@ RESTBase.prototype._request = function(req) {
         // Normalize invalid chars
         statName = self.metrics.normalizeName(statName);
 
-        // start timer
+        // Start timer
         var startTime = Date.now();
 
         // Prepare to call the handler with a child restbase instance
@@ -334,7 +334,7 @@ RESTBase.prototype._request = function(req) {
 function makeRequest(uri, reqOrBody, method) {
     var req;
     if (uri.constructor === Object) {
-        // fast path
+        // Fast path
         req = uri;
         req.method = method;
         return req;
@@ -368,7 +368,7 @@ methods.forEach(function(method) {
 // @param {string} token
 // @return {string} JWT signed token
 RESTBase.prototype.encodeToken = function(token) {
-    var newToken = jwt.sign({next: token}, this._priv.options.conf.salt);
+    var newToken = jwt.sign({ next: token }, this._priv.options.conf.salt);
     return newToken;
 };
 

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -23,7 +23,7 @@ function cloneRequest(req) {
         headers: req.headers || {},
         query: req.query || {},
         body: req.body || null,
-        params: req.params || {},
+        params: req.params || {}
     };
 }
 
@@ -60,7 +60,7 @@ function RESTBase(options, req) {
         // Private state, shared with child instances
         this._priv = {
             options: options,
-            router: options.router,
+            router: options.router
         };
 
         this.rb_config = options.conf;
@@ -97,7 +97,7 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
     if (rq.spec !== undefined && value.specRoot) {
         var spec = Object.assign({}, value.specRoot, {
             // Set the base path dynamically
-            basePath: req.uri.toString().replace(/\/$/, ''),
+            basePath: req.uri.toString().replace(/\/$/, '')
         });
 
         if (req.params.domain === req.headers.host.replace(/:[0-9]+$/, '')) {
@@ -107,7 +107,7 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
 
         return P.resolve({
             status: 200,
-            body: spec,
+            body: spec
         });
     } else if (rq.doc !== undefined) {
         // Return swagger UI & load spec from /?spec
@@ -157,8 +157,8 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
         return P.resolve({
             status: 200,
             body: {
-                items: req.params._ls,
-            },
+                items: req.params._ls
+            }
         });
     }
 };
@@ -171,7 +171,7 @@ RESTBase.prototype.defaultWebRequestHandler = function(req) {
     this.setRequestId(req);
     this.log('trace/webrequest', {
         req: req,
-        request_id: req.headers['x-request-id'],
+        request_id: req.headers['x-request-id']
     });
     // Make sure we have a string
     req.uri = '' + req.uri;
@@ -192,8 +192,8 @@ RESTBase.prototype.request = function(req) {
             status: 403,
             body: {
                 type: 'access_denied#sys',
-                title: 'Access to the /{domain}/sys/ hierarchy is restricted to system users.',
-            },
+                title: 'Access to the /{domain}/sys/ hierarchy is restricted to system users.'
+            }
         }));
     }
 
@@ -231,8 +231,8 @@ RESTBase.prototype._request = function(req) {
                 uri: req.uri,
                 method: req.method,
                 parents: parents,
-                depth: this._recursionDepth,
-            },
+                depth: this._recursionDepth
+            }
         });
     }
 
@@ -281,7 +281,7 @@ RESTBase.prototype._request = function(req) {
             self.log('trace', {
                 req: req,
                 res: res,
-                request_id: childRESTBase.reqId,
+                request_id: childRESTBase.reqId
             });
 
             if (!res) {
@@ -290,8 +290,8 @@ RESTBase.prototype._request = function(req) {
                     body: {
                         type: 'empty_response',
                         description: 'Empty response received',
-                        req: req,
-                    },
+                        req: req
+                    }
                 });
             } else if (res.status >= 400 && !(res instanceof Error)) {
                 var err = new HTTPError(res);
@@ -320,8 +320,8 @@ RESTBase.prototype._request = function(req) {
                 title: 'Not found.',
                 internalURI: req.uri,
                 method: req.method,
-                depth: self._recursionDepth,
-            },
+                depth: self._recursionDepth
+            }
         }));
     }
 };
@@ -346,7 +346,7 @@ function makeRequest(uri, reqOrBody, method) {
         req = {
             uri: uri,
             method: method,
-            body: reqOrBody,
+            body: reqOrBody
         };
     }
     return req;
@@ -354,7 +354,7 @@ function makeRequest(uri, reqOrBody, method) {
 
 // Convenience wrappers
 var methods = ['get', 'post', 'put', 'delete', 'head', 'options',
-    'trace', 'connect', 'copy', 'move', 'purge', 'search', ];
+    'trace', 'connect', 'copy', 'move', 'purge', 'search'];
 methods.forEach(function(method) {
     RESTBase.prototype[method] = function(uri, req) {
         return this._request(makeRequest(uri, req, method));
@@ -368,7 +368,7 @@ methods.forEach(function(method) {
 // @param {string} token
 // @return {string} JWT signed token
 RESTBase.prototype.encodeToken = function(token) {
-    var newToken = jwt.sign({next: token, }, this._priv.options.conf.salt);
+    var newToken = jwt.sign({next: token}, this._priv.options.conf.salt);
     return newToken;
 };
 
@@ -384,8 +384,8 @@ RESTBase.prototype.decodeToken = function(token) {
             status: 400,
             body: {
                 type: 'invalid_paging_token',
-                title: 'Invalid paging token',
-            },
+                title: 'Invalid paging token'
+            }
         });
     }
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -64,20 +64,20 @@ Router.prototype._loadModule = function(modDef) {
 
     var self = this;
     var loadPath;
-    // determine the module's load path
+    // Determine the module's load path
     switch (modDef.type) {
         case 'file':
             if (modDef.path && /^\//.test(modDef.path)) {
-                // absolute path
+                // Absolute path
                 loadPath = modDef.path;
             } else {
-                // relative path or missing
+                // Relative path or missing
                 loadPath = __dirname + '/../mods/';
                 if (modDef.path) {
-                    // the path has been provided, use it
+                    // The path has been provided, use it
                     loadPath += modDef.path;
                 } else {
-                    // no path given, so assume the file
+                    // No path given, so assume the file
                     // name matches the module name
                     loadPath += modDef.name;
                 }
@@ -90,12 +90,12 @@ Router.prototype._loadModule = function(modDef) {
             throw new Error('unknown module type '
                 + modDef.type + ' (for module ' + modDef.name + ').');
     }
-    // append the log property to module options, if it is not present
+    // Append the log property to module options, if it is not present
     modDef.options = modDef.options || {};
     if (!modDef.options.log) {
         modDef.options.log = this._options.log || function() {};
     }
-    // let the error propagate in case the module cannot be loaded
+    // Let the error propagate in case the module cannot be loaded
     var modObj = require(loadPath);
     if (!modObj) {
         return P.reject("Loading module " + loadPath + " failed.");
@@ -105,11 +105,10 @@ Router.prototype._loadModule = function(modDef) {
         modObj = modObj(modDef.options);
     }
     if (!(modObj instanceof P)) {
-        // wrap
+        // Wrap
         modObj = P.resolve(modObj);
     }
     return modObj.then(function(mod) {
-        // console.log(loadPath, mod);
         if (!mod.operations) {
             throw new Error('No operations exported by module ' + loadPath);
         }
@@ -121,7 +120,7 @@ Router.prototype._loadModule = function(modDef) {
 function makeRequestTemplate(spec) {
     var reqTemplate = new Template(spec);
     return function requestTemplate(restbase, req) {
-        return restbase.request(reqTemplate.eval({request: req}));
+        return restbase.request(reqTemplate.eval({ request: req }));
     };
 }
 
@@ -191,7 +190,6 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
                 // Share modules
                 return self._loadModule(m)
                 .then(function(module) {
-                    // console.log(module);
                     if (!module) {
                         throw new Error('Null return when loading module ' + m.name);
                     }
@@ -238,14 +236,12 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
                 // Set up a templated backend request handler
                 var templatedReq = makeRequestTemplate(backendRequest);
                 node.value.methods[methodName] = function(restbase, req) {
-                    // console.log('template', req);
                     return templatedReq(restbase, req);
                 };
             } else if (method.operationId) {
                 var handler = operations[method.operationId];
                 if (handler) {
                     node.value.methods[methodName] = handler;
-                    // console.log(method.operationId, node.value);
                 } else {
                     throw new Error('No known handler associated with operationId '
                         + method.operationId);
@@ -277,7 +273,7 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specR
     var self = this;
     function handlePaths(paths) {
         if (!paths || !Object.keys(paths).length) {
-            // no paths here, nothing to do
+            // No paths here, nothing to do
             return P.resolve();
         }
         // Handle paths
@@ -303,8 +299,6 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specR
             var subtree = self._nodes.get(pathSpec);
             var specPromise;
             if (!subtree) {
-                // console.log('not shared:', pathPattern);
-
                 var segment = path[path.length - 1];
 
                 // Check if the subtree already exists, which can happen when
@@ -339,7 +333,6 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specR
                 specPromise = self._handleSwaggerPathSpec(subtree, pathSpec,
                         operations, specRoot, subPrefixPath);
             } else {
-                // console.log('shared:', pathPattern);
                 var origSubtree = subtree;
                 subtree = subtree.clone();
                 subtree.value = value;
@@ -394,7 +387,6 @@ Router.prototype.handleResources = function(restbase) {
                     domain: path[0]
                 }, true).expand();
                 req.method = req.method || 'put';
-                // console.log(path, req.uri);
                 return restbase.request(req);
             });
         } else {
@@ -425,7 +417,6 @@ Router.prototype.loadSpec = function(spec, restbase) {
     .then(function() {
         // Only set the tree after loading everything
         self.tree = rootNode;
-        // console.log(JSON.stringify(rootNode, null, 2));
         self.router.setTree(rootNode);
         return self.handleResources(restbase);
     })

--- a/lib/router.js
+++ b/lib/router.js
@@ -11,7 +11,7 @@ var Node = swaggerRouter.Node;
 var URI = swaggerRouter.URI;
 var SwaggerRouter = swaggerRouter.Router;
 
-function Router (options) {
+function Router(options) {
     this._options = options || {};
     this._nodes = new Map();
     this._modules = new Map();
@@ -55,7 +55,7 @@ Router.prototype._buildPath = function route(node, path, value) {
 /**
  * Load and initialize a module
  */
-Router.prototype._loadModule = function (modDef) {
+Router.prototype._loadModule = function(modDef) {
     var cachedModule = this._modules.get(modDef);
     if (cachedModule) {
         // Found a cached instance. Return it.
@@ -87,7 +87,8 @@ Router.prototype._loadModule = function (modDef) {
             loadPath = modDef.name;
             break;
         default:
-            throw new Error('unknown module type ' + modDef.type + ' (for module ' + modDef.name + ').');
+            throw new Error('unknown module type '
+                + modDef.type + ' (for module ' + modDef.name + ').');
     }
     // append the log property to module options, if it is not present
     modDef.options = modDef.options || {};
@@ -108,7 +109,7 @@ Router.prototype._loadModule = function (modDef) {
         modObj = P.resolve(modObj);
     }
     return modObj.then(function(mod) {
-        //console.log(loadPath, mod);
+        // console.log(loadPath, mod);
         if (!mod.operations) {
             throw new Error('No operations exported by module ' + loadPath);
         }
@@ -119,7 +120,7 @@ Router.prototype._loadModule = function (modDef) {
 
 function makeRequestTemplate(spec) {
     var reqTemplate = new Template(spec);
-    return function requestTemplate (restbase, req) {
+    return function requestTemplate(restbase, req) {
         return restbase.request(reqTemplate.eval({request: req}));
     };
 }
@@ -128,8 +129,7 @@ function makeRequestTemplate(spec) {
  * Process a Swagger path spec object
  */
 Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
-        operations, specRoot, prefixPath)
-{
+        operations, specRoot, prefixPath) {
     var self = this;
     if (!pathspec) {
         return P.resolve();
@@ -155,7 +155,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
             listNode.value = {
                 specRoot: specRoot,
                 methods: {},
-                path: specRoot.basePath + '/'
+                path: specRoot.basePath + '/',
             };
             node.setChild('', listNode);
             subSpecs = [subSpec];
@@ -191,7 +191,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
                 // Share modules
                 return self._loadModule(m)
                 .then(function(module) {
-                    //console.log(module);
+                    // console.log(module);
                     if (!module) {
                         throw new Error('Null return when loading module ' + m.name);
                     }
@@ -237,17 +237,18 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
             if (backendRequest) {
                 // Set up a templated backend request handler
                 var templatedReq = makeRequestTemplate(backendRequest);
-                node.value.methods[methodName] = function (restbase, req) {
-                    //console.log('template', req);
+                node.value.methods[methodName] = function(restbase, req) {
+                    // console.log('template', req);
                     return templatedReq(restbase, req);
                 };
             } else if (method.operationId) {
                 var handler = operations[method.operationId];
                 if (handler) {
                     node.value.methods[methodName] = handler;
-                    //console.log(method.operationId, node.value);
+                    // console.log(method.operationId, node.value);
                 } else {
-                    throw new Error('No known handler associated with operationId ' + method.operationId);
+                    throw new Error('No known handler associated with operationId '
+                        + method.operationId);
                 }
             }
         });
@@ -257,7 +258,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
 /**
  * Process a Swagger spec
  */
-Router.prototype._handleSwaggerSpec = function (rootNode, spec, operations, specRoot, prefixPath) {
+Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specRoot, prefixPath) {
     if (!specRoot) {
         specRoot = spec;
         if (!spec.paths) { spec.paths = {}; }
@@ -274,12 +275,12 @@ Router.prototype._handleSwaggerSpec = function (rootNode, spec, operations, spec
         Object.assign(specRoot['x-default-params'], spec['x-default-params']);
     }
     var self = this;
-    function handlePaths (paths) {
+    function handlePaths(paths) {
         if (!paths || !Object.keys(paths).length) {
             // no paths here, nothing to do
             return P.resolve();
         }
-        // handle paths
+        // Handle paths
         return P.all(Object.keys(paths).map(function(pathPattern) {
             var pathSpec = paths[pathPattern];
             var pathURI = new URI(pathPattern, {}, true);
@@ -290,7 +291,7 @@ Router.prototype._handleSwaggerSpec = function (rootNode, spec, operations, spec
             // to it for optional path segments.
             var value = {
                 path: undefined,
-                methods: {}
+                methods: {},
             };
 
             // Expected to return
@@ -302,7 +303,7 @@ Router.prototype._handleSwaggerSpec = function (rootNode, spec, operations, spec
             var subtree = self._nodes.get(pathSpec);
             var specPromise;
             if (!subtree) {
-                //console.log('not shared:', pathPattern);
+                // console.log('not shared:', pathPattern);
 
                 var segment = path[path.length - 1];
 
@@ -338,7 +339,7 @@ Router.prototype._handleSwaggerSpec = function (rootNode, spec, operations, spec
                 specPromise = self._handleSwaggerPathSpec(subtree, pathSpec,
                         operations, specRoot, subPrefixPath);
             } else {
-                //console.log('shared:', pathPattern);
+                // console.log('shared:', pathPattern);
                 var origSubtree = subtree;
                 subtree = subtree.clone();
                 subtree.value = value;
@@ -376,12 +377,12 @@ Router.prototype.handleResources = function(restbase) {
     return this.tree.visitAsync(function(value, path) {
         if (value && Array.isArray(value.resources)) {
             return P.resolve(value.resources)
-            // Workaround (forces setTimeout) to avoid excessive nextTick
-            // recursion in bluebird with node 0.10. Otherwise, we see errors
-            // like this with >~500 domains:
-            // (node) warning: Recursive process.nextTick detected. This will
-            // break in the next version of node. Please use setImmediate for
-            // recursive deferral.
+            /* Workaround (forces setTimeout) to avoid excessive nextTick
+               recursion in bluebird with node 0.10. Otherwise, we see errors
+               like this with >~500 domains:
+               (node) warning: Recursive process.nextTick detected. This will
+               break in the next version of node. Please use setImmediate for
+               recursive deferral. */
             .delay(0)
             .each(function(reqTemplate) {
                 if (!reqTemplate.uri) {
@@ -390,10 +391,10 @@ Router.prototype.handleResources = function(restbase) {
                 }
                 var req = Object.assign({}, reqTemplate);
                 req.uri = new URI(req.uri, {
-                    domain: path[0]
+                    domain: path[0],
                 }, true).expand();
                 req.method = req.method || 'put';
-                //console.log(path, req.uri);
+                // console.log(path, req.uri);
                 return restbase.request(req);
             });
         } else {
@@ -424,7 +425,7 @@ Router.prototype.loadSpec = function(spec, restbase) {
     .then(function() {
         // Only set the tree after loading everything
         self.tree = rootNode;
-        //console.log(JSON.stringify(rootNode, null, 2));
+        // console.log(JSON.stringify(rootNode, null, 2));
         self.router.setTree(rootNode);
         return self.handleResources(restbase);
     })
@@ -445,7 +446,7 @@ Router.prototype.loadSpec = function(spec, restbase) {
  * - @prop {object} params: Object with path parameters and optionally `_ls`
  *   for URIs ending in `/`.
  */
-Router.prototype.route = function (uri) {
+Router.prototype.route = function(uri) {
     return this.router.lookup(uri);
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -155,7 +155,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
             listNode.value = {
                 specRoot: specRoot,
                 methods: {},
-                path: specRoot.basePath + '/',
+                path: specRoot.basePath + '/'
             };
             node.setChild('', listNode);
             subSpecs = [subSpec];
@@ -291,7 +291,7 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specR
             // to it for optional path segments.
             var value = {
                 path: undefined,
-                methods: {},
+                methods: {}
             };
 
             // Expected to return
@@ -391,7 +391,7 @@ Router.prototype.handleResources = function(restbase) {
                 }
                 var req = Object.assign({}, reqTemplate);
                 req.uri = new URI(req.uri, {
-                    domain: path[0],
+                    domain: path[0]
                 }, true).expand();
                 req.method = req.method || 'put';
                 // console.log(path, req.uri);

--- a/lib/server.js
+++ b/lib/server.js
@@ -297,7 +297,7 @@ function main(options) {
     opts.restbase = new Restbase(opts);
     // Use a child restbase instance to sidestep the security protection for
     // direct requests to /sys
-    var childRestBase = opts.restbase.makeChild({uri: '#internal-startup'});
+    var childRestBase = opts.restbase.makeChild({ uri: '#internal-startup' });
     // Main app startup happens during async spec loading:
     return opts.router.loadSpec(conf.spec, childRestBase)
     .then(function(router) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -17,8 +17,7 @@ var Router = require('./router');
 var URI = require('swagger-router').URI;
 var zlib = require('zlib');
 
-function handleResponse (opts, req, resp, response) {
-    //console.log('resp', response);
+function handleResponse(opts, req, resp, response) {
     if (response && response.status) {
         if (!response.headers) {
             response.headers = {};
@@ -44,16 +43,16 @@ function handleResponse (opts, req, resp, response) {
         if (!/^application\/json/.test(rh['content-type'])) {
             rh['X-XSS-Protection'] = '1; mode=block';
             if (!rh['Content-Security-Policy']) {
-                rh['Content-Security-Policy'] = rbUtil.constructCSP(req.params ? req.params.domain : undefined);
+                rh['Content-Security-Policy'] =
+                    rbUtil.constructCSP(req.params ? req.params.domain : undefined);
             }
             // For IE 10 & 11
             rh['X-Content-Security-Policy'] = rh['Content-Security-Policy'];
-            // For Chrome <= v25 (seems to be <1% traffic; should we still
-            // care?)
+            // For Chrome <= v25 (seems to be <1% traffic; should we still care?)
             rh['X-WebKit-CSP'] = rh['Content-Security-Policy'];
         }
 
-        // propagate the request id header
+        // Propagate the request id header
         rh['X-Request-Id'] = opts.reqId;
 
         var logLevel = 'trace/request';
@@ -66,7 +65,7 @@ function handleResponse (opts, req, resp, response) {
             message: response.message,
             req: req,
             res: response,
-            stack: response.stack
+            stack: response.stack,
         });
 
         var body;
@@ -75,14 +74,14 @@ function handleResponse (opts, req, resp, response) {
             if (!response.body) {
                 response.body = {};
             }
-            // whitelist fields to avoid leaking sensitive info
+            // Whitelist fields to avoid leaking sensitive info
             var rBody = response.body;
             body = {
                 type: rBody.type,
                 title: rBody.title,
                 method: rBody.method,
                 detail: rBody.detail || rBody.description,
-                uri: rBody.uri
+                uri: rBody.uri,
             };
 
             if (!response.headers['content-type']) {
@@ -118,7 +117,7 @@ function handleResponse (opts, req, resp, response) {
                         response.headers['content-type'] = 'application/json';
                     }
                     body = new Buffer(JSON.stringify(body));
-                } else  {
+                } else {
                     body = new Buffer(body);
                 }
             }
@@ -127,7 +126,7 @@ function handleResponse (opts, req, resp, response) {
             if (/\bgzip\b/.test(req.headers['accept-encoding'])
                     && /^application\/json\b|^text\//.test(cType)) {
                 if (response.headers['content-length']) {
-                   delete response.headers['content-length'];
+                    delete response.headers['content-length'];
                 }
                 response.headers['content-encoding'] = 'gzip';
                 resp.writeHead(response.status, '', response.headers);
@@ -144,7 +143,7 @@ function handleResponse (opts, req, resp, response) {
                 opts.log('warn/response/content-length', {
                     req: req,
                     res: response,
-                    reason: new Error('Invalid content-length')
+                    reason: new Error('Invalid content-length'),
                 });
                 delete response.headers['content-length'];
             }
@@ -154,7 +153,7 @@ function handleResponse (opts, req, resp, response) {
     } else {
         opts.log('error/request', {
             req: req,
-            msg: "No content returned"
+            msg: "No content returned",
         });
 
         if (!response) { response = {}; }
@@ -166,14 +165,14 @@ function handleResponse (opts, req, resp, response) {
             type: 'https://restbase.org/errors/no_content',
             title: 'RESTBase error: No content returned by backend.',
             uri: req.url,
-            method: req.method
+            method: req.method,
         }));
     }
 }
 
 // Handle a single request
-function handleRequest (opts, req, resp) {
-    // set the request ID early on for external requests
+function handleRequest(opts, req, resp) {
+    // Set the request ID early on for external requests
     req.headers = req.headers || {};
     req.headers['x-request-id'] = req.headers['x-request-id'] || rbUtil.generateRequestId();
 
@@ -182,13 +181,13 @@ function handleRequest (opts, req, resp) {
         logger: opts.logger.child({
             req: {
                 method: req.method.toLowerCase(),
-                uri: req.url
+                uri: req.url,
             },
-            request_id: req.headers['x-request-id']
+            request_id: req.headers['x-request-id'],
         }),
         log: null,
         reqId: req.headers['x-request-id'],
-        metrics: opts.metrics
+        metrics: opts.metrics,
     };
     reqOpts.log = reqOpts.logger.log.bind(reqOpts.logger);
 
@@ -219,8 +218,8 @@ function handleRequest (opts, req, resp) {
         throw new rbUtil.HTTPError({
             status: 400,
             body: {
-                type: 'invalid_request'
-            }
+                type: 'invalid_request',
+            },
         });
     })
 
@@ -240,7 +239,7 @@ function handleRequest (opts, req, resp) {
         // Quick hack to set up general CORS
         if (newReq.method === 'options') {
             return P.resolve({
-                status: 200
+                status: 200,
             });
         } else {
             return opts.restbase.request(newReq);
@@ -251,7 +250,7 @@ function handleRequest (opts, req, resp) {
     .then(function(result) {
         return handleResponse(reqOpts, newReq, resp, result);
     })
-    .catch (function(e) {
+    .catch(function(e) {
         if (!e || e.name !== 'HTTPError') {
             var originalError = e;
             var stack = e && e.stack;
@@ -261,8 +260,8 @@ function handleRequest (opts, req, resp) {
                     type: 'internal_error',
                     description: e + '',
                     // Probably better to keep this private for now
-                    //stack: e.stack
-                }
+                    // stack: e.stack
+                },
             });
             // Log this internally
             e.stack = stack;
@@ -291,14 +290,14 @@ function main(options) {
         conf: conf,
         logger: options.logger,
         log: options.logger.log.bind(options.logger),
-        metrics: options.metrics
+        metrics: options.metrics,
     };
 
     opts.router = new Router(opts);
     opts.restbase = new Restbase(opts);
     // Use a child restbase instance to sidestep the security protection for
     // direct requests to /sys
-    var childRestBase = opts.restbase.makeChild({uri:'#internal-startup'});
+    var childRestBase = opts.restbase.makeChild({uri: '#internal-startup', });
     // Main app startup happens during async spec loading:
     return opts.router.loadSpec(conf.spec, childRestBase)
     .then(function(router) {
@@ -317,7 +316,7 @@ function main(options) {
         opts.log('fatal/startup', {
             status: e.status,
             err: e,
-            stack: e.body && e.body.stack || e.stack
+            stack: e.body && e.body.stack || e.stack,
         });
         // Delay exiting to avoid heavy restart load & let the logger finish its business
         setTimeout(function() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -65,7 +65,7 @@ function handleResponse(opts, req, resp, response) {
             message: response.message,
             req: req,
             res: response,
-            stack: response.stack,
+            stack: response.stack
         });
 
         var body;
@@ -81,7 +81,7 @@ function handleResponse(opts, req, resp, response) {
                 title: rBody.title,
                 method: rBody.method,
                 detail: rBody.detail || rBody.description,
-                uri: rBody.uri,
+                uri: rBody.uri
             };
 
             if (!response.headers['content-type']) {
@@ -143,7 +143,7 @@ function handleResponse(opts, req, resp, response) {
                 opts.log('warn/response/content-length', {
                     req: req,
                     res: response,
-                    reason: new Error('Invalid content-length'),
+                    reason: new Error('Invalid content-length')
                 });
                 delete response.headers['content-length'];
             }
@@ -153,7 +153,7 @@ function handleResponse(opts, req, resp, response) {
     } else {
         opts.log('error/request', {
             req: req,
-            msg: "No content returned",
+            msg: "No content returned"
         });
 
         if (!response) { response = {}; }
@@ -165,7 +165,7 @@ function handleResponse(opts, req, resp, response) {
             type: 'https://restbase.org/errors/no_content',
             title: 'RESTBase error: No content returned by backend.',
             uri: req.url,
-            method: req.method,
+            method: req.method
         }));
     }
 }
@@ -181,13 +181,13 @@ function handleRequest(opts, req, resp) {
         logger: opts.logger.child({
             req: {
                 method: req.method.toLowerCase(),
-                uri: req.url,
+                uri: req.url
             },
-            request_id: req.headers['x-request-id'],
+            request_id: req.headers['x-request-id']
         }),
         log: null,
         reqId: req.headers['x-request-id'],
-        metrics: opts.metrics,
+        metrics: opts.metrics
     };
     reqOpts.log = reqOpts.logger.log.bind(reqOpts.logger);
 
@@ -208,7 +208,7 @@ function handleRequest(opts, req, resp) {
         uri: new URI(urlData.pathname),
         query: urlData.query,
         method: req.method.toLowerCase(),
-        headers: req.headers,
+        headers: req.headers
     };
 
     // Start off by parsing any POST data with BusBoy
@@ -218,8 +218,8 @@ function handleRequest(opts, req, resp) {
         throw new rbUtil.HTTPError({
             status: 400,
             body: {
-                type: 'invalid_request',
-            },
+                type: 'invalid_request'
+            }
         });
     })
 
@@ -239,7 +239,7 @@ function handleRequest(opts, req, resp) {
         // Quick hack to set up general CORS
         if (newReq.method === 'options') {
             return P.resolve({
-                status: 200,
+                status: 200
             });
         } else {
             return opts.restbase.request(newReq);
@@ -258,10 +258,10 @@ function handleRequest(opts, req, resp) {
                 status: 500,
                 body: {
                     type: 'internal_error',
-                    description: e + '',
+                    description: e + ''
                     // Probably better to keep this private for now
                     // stack: e.stack
-                },
+                }
             });
             // Log this internally
             e.stack = stack;
@@ -290,14 +290,14 @@ function main(options) {
         conf: conf,
         logger: options.logger,
         log: options.logger.log.bind(options.logger),
-        metrics: options.metrics,
+        metrics: options.metrics
     };
 
     opts.router = new Router(opts);
     opts.restbase = new Restbase(opts);
     // Use a child restbase instance to sidestep the security protection for
     // direct requests to /sys
-    var childRestBase = opts.restbase.makeChild({uri: '#internal-startup', });
+    var childRestBase = opts.restbase.makeChild({uri: '#internal-startup'});
     // Main app startup happens during async spec loading:
     return opts.router.loadSpec(conf.spec, childRestBase)
     .then(function(router) {
@@ -316,7 +316,7 @@ function main(options) {
         opts.log('fatal/startup', {
             status: e.status,
             err: e,
-            stack: e.body && e.body.stack || e.stack,
+            stack: e.body && e.body.stack || e.stack
         });
         // Delay exiting to avoid heavy restart load & let the logger finish its business
         setTimeout(function() {

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -3,10 +3,10 @@
 var P = require('bluebird');
 var fs = P.promisifyAll(require('fs'));
 var path = require('path');
-// swagger-ui helpfully exports the absolute path of its dist directory
+// Swagger-ui helpfully exports the absolute path of its dist directory
 var docRoot = require('swagger-ui').dist + '/';
 
-function staticServe (restbase, req) {
+function staticServe(restbase, req) {
     // Expand any relative paths for security
     var filePath = req.query.path.replace(/\.\.\//g, '');
     return fs.readFileAsync(docRoot + filePath, 'utf8')
@@ -21,7 +21,9 @@ function staticServe (restbase, req) {
                         '<title>RESTBase docs</title>')
                 // Replace the default url with ours, switch off validation &
                 // limit the size of documents to apply syntax highlighting to
-                .replace(/sorter *: "alpha"/, 'sorter: "alpha", url: "?spec", validatorUrl: null, highlightSizeThreshold: 10000, docExpansion: "list",');
+                .replace(/sorter *: "alpha"/, 'sorter: "alpha", ' +
+                    'url: "?spec", validatorUrl: null, ' +
+                    'highlightSizeThreshold: 10000, docExpansion: "list",');
         }
 
         var contentType = 'text/html';
@@ -37,9 +39,11 @@ function staticServe (restbase, req) {
             status: 200,
             headers: {
                 'content-type': contentType,
-                'Content-Security-Policy': "default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self';"
+                'Content-Security-Policy': "default-src 'none'; " +
+                    "script-src 'self' 'unsafe-inline'; connect-src 'self'; " +
+                    "style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self';",
             },
-            body: body
+            body: body,
         });
     });
 }

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -41,9 +41,9 @@ function staticServe(restbase, req) {
                 'content-type': contentType,
                 'Content-Security-Policy': "default-src 'none'; " +
                     "script-src 'self' 'unsafe-inline'; connect-src 'self'; " +
-                    "style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self';",
+                    "style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self';"
             },
-            body: body,
+            body: body
         });
     });
 }

--- a/maintenance/generate-wikimedia-domain-config.js
+++ b/maintenance/generate-wikimedia-domain-config.js
@@ -14,7 +14,7 @@ var downloadUrl = "https://en.wikipedia.org/w/api.php?action=sitematrix&format=j
 var filename = "sitematrix.json";
 
 preq.get({
-	uri: downloadUrl,
+    uri: downloadUrl,
 })
 .then(function(res) {
     var sm = res.body.sitematrix;
@@ -28,7 +28,7 @@ preq.get({
         wikiversity: [],
         wikivoyage: [],
         wikimedia: [],
-        '*': []
+        '*': [],
     };
 
     Object.keys(sm).forEach(function(k) {

--- a/maintenance/generate-wikimedia-domain-config.js
+++ b/maintenance/generate-wikimedia-domain-config.js
@@ -14,7 +14,7 @@ var downloadUrl = "https://en.wikipedia.org/w/api.php?action=sitematrix&format=j
 var filename = "sitematrix.json";
 
 preq.get({
-    uri: downloadUrl,
+    uri: downloadUrl
 })
 .then(function(res) {
     var sm = res.body.sitematrix;
@@ -28,7 +28,7 @@ preq.get({
         wikiversity: [],
         wikivoyage: [],
         wikimedia: [],
-        '*': [],
+        '*': []
     };
 
     Object.keys(sm).forEach(function(k) {

--- a/mods/action.js
+++ b/mods/action.js
@@ -10,75 +10,75 @@ var Template = require('../lib/reqTemplate');
  * Error translation
  */
 var errDefs = {
-    '400': { status: 400, type: 'invalid_request' },
-    '401': { status: 401, type: 'unauthorized' },
-    '403': { status: 403, type: 'access_denied#edit' },
-    '409': { status: 409, type: 'conflict' },
-    '413': { status: 413, type: 'too_large' },
-    '429': { status: 429, type: 'rate_exceeded' },
-    '500': { status: 500, type: 'server_error' },
-    '501': { status: 501, type: 'not_supported' }
+    400: { status: 400, type: 'invalid_request', },
+    401: { status: 401, type: 'unauthorized', },
+    403: { status: 403, type: 'access_denied#edit', },
+    409: { status: 409, type: 'conflict', },
+    413: { status: 413, type: 'too_large', },
+    429: { status: 429, type: 'rate_exceeded', },
+    500: { status: 500, type: 'server_error', },
+    501: { status: 501, type: 'not_supported', },
 };
 
 var errCodes = {
     /* 400 - bad request */
-    'articleexists': errDefs['400'],
-    'badformat': errDefs['400'],
-    'badmd5': errDefs['400'],
-    'badtoken': errDefs['400'],
-    'invalidparammix': errDefs['400'],
-    'invalidsection': errDefs['400'],
-    'invalidtitle': errDefs['400'],
-    'invaliduser': errDefs['400'],
-    'missingparam': errDefs['400'],
-    'missingtitle': errDefs['400'],
-    'nosuchpageid': errDefs['400'],
-    'nosuchrcid': errDefs['400'],
-    'nosuchrevid': errDefs['400'],
-    'nosuchsection': errDefs['400'],
-    'nosuchuser': errDefs['400'],
-    'notext': errDefs['400'],
-    'notitle': errDefs['400'],
-    'pagecannotexist': errDefs['400'],
-    'revwrongpage': errDefs['400'],
+    articleexists: errDefs['400'],
+    badformat: errDefs['400'],
+    badmd5: errDefs['400'],
+    badtoken: errDefs['400'],
+    invalidparammix: errDefs['400'],
+    invalidsection: errDefs['400'],
+    invalidtitle: errDefs['400'],
+    invaliduser: errDefs['400'],
+    missingparam: errDefs['400'],
+    missingtitle: errDefs['400'],
+    nosuchpageid: errDefs['400'],
+    nosuchrcid: errDefs['400'],
+    nosuchrevid: errDefs['400'],
+    nosuchsection: errDefs['400'],
+    nosuchuser: errDefs['400'],
+    notext: errDefs['400'],
+    notitle: errDefs['400'],
+    pagecannotexist: errDefs['400'],
+    revwrongpage: errDefs['400'],
     /* 401 - unauthorised */
     'cantcreate-anon': errDefs['401'],
-    'confirmemail': errDefs['401'],
+    confirmemail: errDefs['401'],
     'noedit-anon': errDefs['401'],
     'noimageredirect-anon': errDefs['401'],
-    'protectedpage': errDefs['401'],
-    'readapidenied': errDefs['401'],
+    protectedpage: errDefs['401'],
+    readapidenied: errDefs['401'],
     /* 403 - access denied */
-    'autoblocked': errDefs['403'],
-    'blocked': errDefs['403'],
-    'cantcreate': errDefs['403'],
-    'customcssjsprotected': errDefs['403'],
-    'customcssprotected': errDefs['403'],
-    'customjsprotected': errDefs['403'],
-    'emptynewsection': errDefs['403'],
-    'emptypage': errDefs['403'],
-    'filtered': errDefs['403'],
-    'hookaborted': errDefs['403'],
-    'noedit': errDefs['403'],
-    'noimageredirect': errDefs['403'],
-    'permissiondenied': errDefs['403'],
-    'protectednamespace': errDefs['403'],
+    autoblocked: errDefs['403'],
+    blocked: errDefs['403'],
+    cantcreate: errDefs['403'],
+    customcssjsprotected: errDefs['403'],
+    customcssprotected: errDefs['403'],
+    customjsprotected: errDefs['403'],
+    emptynewsection: errDefs['403'],
+    emptypage: errDefs['403'],
+    filtered: errDefs['403'],
+    hookaborted: errDefs['403'],
+    noedit: errDefs['403'],
+    noimageredirect: errDefs['403'],
+    permissiondenied: errDefs['403'],
+    protectednamespace: errDefs['403'],
     'protectednamespace-interface': errDefs['403'],
-    'protectedtitle': errDefs['403'],
-    'readonly': errDefs['403'],
-    'unsupportednamespace': errDefs['403'],
-    'writeapidenied': errDefs['403'],
+    protectedtitle: errDefs['403'],
+    readonly: errDefs['403'],
+    unsupportednamespace: errDefs['403'],
+    writeapidenied: errDefs['403'],
     /* 409 - conflict */
-    'cascadeprotected': errDefs['409'],
-    'editconflict': errDefs['409'],
-    'pagedeleted': errDefs['409'],
-    'spamdetected': errDefs['409'],
+    cascadeprotected: errDefs['409'],
+    editconflict: errDefs['409'],
+    pagedeleted: errDefs['409'],
+    spamdetected: errDefs['409'],
     /* 413 - body too large */
-    'contenttoobig': errDefs['413'],
+    contenttoobig: errDefs['413'],
     /* 429 - rate limit exceeded */
-    'ratelimited': errDefs['429'],
+    ratelimited: errDefs['429'],
     /* 501 - not supported */
-    'editnotsupported': errDefs['501']
+    editnotsupported: errDefs['501'],
 };
 
 function apiError(apiErr) {
@@ -90,10 +90,10 @@ function apiError(apiErr) {
         body: {
             type: errDefs['500'].type,
             title: apiErr.code || 'MW API Error',
-            description: apiErr.info || 'Unknown MW API error'
-        }
+            description: apiErr.info || 'Unknown MW API error',
+        },
     };
-    if(apiErr.code && errCodes.hasOwnProperty(apiErr.code)) {
+    if (apiErr.code && errCodes.hasOwnProperty(apiErr.code)) {
         ret.status = errCodes[apiErr.code].status;
         ret.body.type = errCodes[apiErr.code].type;
     }
@@ -132,8 +132,11 @@ function ActionService (options) {
 
 function buildQueryResponse(res) {
     if (res.status !== 200) {
-        throw apiError({info: 'Unexpected response status (' + res.status + ') from the PHP action API.'});
-    } else if(!res.body || res.body.error) {
+        throw apiError({
+            info: 'Unexpected response status ('
+                    + res.status + ') from the PHP action API.',
+        });
+    } else if (!res.body || res.body.error) {
         throw apiError((res.body || {}).error);
     } else if (!res.body.query || !res.body.query.pages) {
         throw apiError({info: 'Missing query pages from the PHP action API response.'});
@@ -147,19 +150,22 @@ function buildQueryResponse(res) {
     // XXX: Clean this up!
     res.body = {
         items: newBody,
-        next: res.body["continue"]
+        next: res.body.continue,
     };
     return res;
 }
 
 function buildEditResponse(res) {
     if (res.status !== 200) {
-        throw apiError({info: 'Unexpected response status (' + res.status + ') from the PHP action API.'});
+        throw apiError({
+            info: 'Unexpected response status ('
+                    + res.status + ') from the PHP action API.',
+        });
     } else if (!res.body || res.body.error) {
         throw apiError((res.body || {}).error);
     }
     res.body = res.body.edit;
-    if(res.body && !res.body.nochange) {
+    if (res.body && !res.body.nochange) {
         res.status = 201;
     }
     return res;
@@ -181,7 +187,7 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
 ActionService.prototype.query = function(restbase, req) {
     return this._doRequest(restbase, req, {
         action: 'query',
-        format: 'json'
+        format: 'json',
     }, buildQueryResponse);
 };
 
@@ -189,31 +195,31 @@ ActionService.prototype.edit = function(restbase, req) {
     return this._doRequest(restbase, req, {
         action: 'edit',
         format: 'json',
-        formatversion: 2
+        formatversion: 2,
     }, buildEditResponse);
 };
 
 
-module.exports = function (options) {
+module.exports = function(options) {
     var actionService = new ActionService(options);
     return {
         spec: {
             paths: {
                 '/query': {
                     all: {
-                        operationId: 'mwApiQuery'
-                    }
+                        operationId: 'mwApiQuery',
+                    },
                 },
                 '/edit': {
                     post: {
-                        operationId: 'mwApiEdit'
-                    }
-                }
-            }
+                        operationId: 'mwApiEdit',
+                    },
+                },
+            },
         },
         operations: {
             mwApiQuery: actionService.query.bind(actionService),
-            mwApiEdit: actionService.edit.bind(actionService)
-        }
+            mwApiEdit: actionService.edit.bind(actionService),
+        },
     };
 };

--- a/mods/action.js
+++ b/mods/action.js
@@ -10,14 +10,14 @@ var Template = require('../lib/reqTemplate');
  * Error translation
  */
 var errDefs = {
-    400: { status: 400, type: 'invalid_request', },
-    401: { status: 401, type: 'unauthorized', },
-    403: { status: 403, type: 'access_denied#edit', },
-    409: { status: 409, type: 'conflict', },
-    413: { status: 413, type: 'too_large', },
-    429: { status: 429, type: 'rate_exceeded', },
-    500: { status: 500, type: 'server_error', },
-    501: { status: 501, type: 'not_supported', },
+    400: { status: 400, type: 'invalid_request'},
+    401: { status: 401, type: 'unauthorized'},
+    403: { status: 403, type: 'access_denied#edit'},
+    409: { status: 409, type: 'conflict'},
+    413: { status: 413, type: 'too_large'},
+    429: { status: 429, type: 'rate_exceeded'},
+    500: { status: 500, type: 'server_error'},
+    501: { status: 501, type: 'not_supported'}
 };
 
 var errCodes = {
@@ -78,7 +78,7 @@ var errCodes = {
     /* 429 - rate limit exceeded */
     ratelimited: errDefs['429'],
     /* 501 - not supported */
-    editnotsupported: errDefs['501'],
+    editnotsupported: errDefs['501']
 };
 
 function apiError(apiErr) {
@@ -90,8 +90,8 @@ function apiError(apiErr) {
         body: {
             type: errDefs['500'].type,
             title: apiErr.code || 'MW API Error',
-            description: apiErr.info || 'Unknown MW API error',
-        },
+            description: apiErr.info || 'Unknown MW API error'
+        }
     };
     if (apiErr.code && errCodes.hasOwnProperty(apiErr.code)) {
         ret.status = errCodes[apiErr.code].status;
@@ -116,8 +116,8 @@ function ActionService(options) {
             // TODO: assume the URI is in the form https?://{domain}/w/api.php
             // as we cannot currently template the host in swagger-router
             uri: 'http://{domain}/w/api.php',
-            headers: { host: '{$.request.params.domain}', },
-            body: '{$.request.body}',
+            headers: { host: '{$.request.params.domain}'},
+            body: '{$.request.body}'
         };
         // now check if there's really a param in the host of the URI
         if (!/^(:?https?:\/\/){[^\s}]+}\//.test(options.apiURI)) {
@@ -136,7 +136,7 @@ function buildQueryResponse(res) {
     if (res.status !== 200) {
         throw apiError({
             info: 'Unexpected response status ('
-                    + res.status + ') from the PHP action API.',
+                    + res.status + ') from the PHP action API.'
         });
     } else if (!res.body || res.body.error) {
         throw apiError((res.body || {}).error);
@@ -152,7 +152,7 @@ function buildQueryResponse(res) {
     // XXX: Clean this up!
     res.body = {
         items: newBody,
-        next: res.body.continue,
+        next: res.body.continue
     };
     return res;
 }
@@ -161,7 +161,7 @@ function buildEditResponse(res) {
     if (res.status !== 200) {
         throw apiError({
             info: 'Unexpected response status ('
-                    + res.status + ') from the PHP action API.',
+                    + res.status + ') from the PHP action API.'
         });
     } else if (!res.body || res.body.error) {
         throw apiError((res.body || {}).error);
@@ -175,7 +175,7 @@ function buildEditResponse(res) {
 
 ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     var apiRequest = this.apiRequestTemplate.eval({
-        request: req,
+        request: req
     });
     apiRequest.body.action = defBody.action;
     apiRequest.body.format = apiRequest.body.format || defBody.format || 'json';
@@ -189,7 +189,7 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
 ActionService.prototype.query = function(restbase, req) {
     return this._doRequest(restbase, req, {
         action: 'query',
-        format: 'json',
+        format: 'json'
     }, buildQueryResponse);
 };
 
@@ -197,7 +197,7 @@ ActionService.prototype.edit = function(restbase, req) {
     return this._doRequest(restbase, req, {
         action: 'edit',
         format: 'json',
-        formatversion: 2,
+        formatversion: 2
     }, buildEditResponse);
 };
 
@@ -209,19 +209,19 @@ module.exports = function(options) {
             paths: {
                 '/query': {
                     all: {
-                        operationId: 'mwApiQuery',
-                    },
+                        operationId: 'mwApiQuery'
+                    }
                 },
                 '/edit': {
                     post: {
-                        operationId: 'mwApiEdit',
-                    },
-                },
-            },
+                        operationId: 'mwApiEdit'
+                    }
+                }
+            }
         },
         operations: {
             mwApiQuery: actionService.query.bind(actionService),
-            mwApiEdit: actionService.edit.bind(actionService),
-        },
+            mwApiEdit: actionService.edit.bind(actionService)
+        }
     };
 };

--- a/mods/action.js
+++ b/mods/action.js
@@ -104,27 +104,29 @@ function apiError(apiErr) {
 /**
  * Action module code
  */
-function ActionService (options) {
+function ActionService(options) {
     // be backwards-compatible with apiURI-style configs
-    if(!options.apiRequest && options.apiURI) {
+    if (!options.apiRequest && options.apiURI) {
         // log a deprecation warning
-        options.log('warn/actionService', 'The config options for this module have changed. Please use the apiRequest template stanza');
+        options.log('warn/actionService',
+            'The config options for this module have changed. ' +
+            'Please use the apiRequest template stanza');
         options.apiRequest = {
             method: 'post',
             // TODO: assume the URI is in the form https?://{domain}/w/api.php
             // as we cannot currently template the host in swagger-router
-            uri: '{$.default_uri}',
-            headers: { host: '{$.request.params.domain}' },
-            body: '{$.request.body}'
+            uri: 'http://{domain}/w/api.php',
+            headers: { host: '{$.request.params.domain}', },
+            body: '{$.request.body}',
         };
         // now check if there's really a param in the host of the URI
-        if(!/^(:?https?:\/\/){[^\s}]+}\//.test(options.apiURI)) {
+        if (!/^(:?https?:\/\/){[^\s}]+}\//.test(options.apiURI)) {
             // no host templating, use the string provided by the config
             options.apiRequest.uri = options.apiURI;
         }
         // TODO: decide what to do when apiURI has got a host param, but
         // the rest isn't /w/api.php
-    } else if(!options.apiRequest) {
+    } else if (!options.apiRequest) {
         throw new Error('The action module needs the apiRequest temaplting stanza to exist!');
     }
     this.apiRequestTemplate = new Template(options.apiRequest);
@@ -173,7 +175,7 @@ function buildEditResponse(res) {
 
 ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     var apiRequest = this.apiRequestTemplate.eval({
-        request: req
+        request: req,
     });
     apiRequest.body.action = defBody.action;
     apiRequest.body.format = apiRequest.body.format || defBody.format || 'json';

--- a/mods/action.js
+++ b/mods/action.js
@@ -10,14 +10,14 @@ var Template = require('../lib/reqTemplate');
  * Error translation
  */
 var errDefs = {
-    400: { status: 400, type: 'invalid_request'},
-    401: { status: 401, type: 'unauthorized'},
-    403: { status: 403, type: 'access_denied#edit'},
-    409: { status: 409, type: 'conflict'},
-    413: { status: 413, type: 'too_large'},
-    429: { status: 429, type: 'rate_exceeded'},
-    500: { status: 500, type: 'server_error'},
-    501: { status: 501, type: 'not_supported'}
+    400: { status: 400, type: 'invalid_request' },
+    401: { status: 401, type: 'unauthorized' },
+    403: { status: 403, type: 'access_denied#edit' },
+    409: { status: 409, type: 'conflict' },
+    413: { status: 413, type: 'too_large' },
+    429: { status: 429, type: 'rate_exceeded' },
+    500: { status: 500, type: 'server_error' },
+    501: { status: 501, type: 'not_supported' }
 };
 
 var errCodes = {
@@ -105,9 +105,9 @@ function apiError(apiErr) {
  * Action module code
  */
 function ActionService(options) {
-    // be backwards-compatible with apiURI-style configs
+    // Be backwards-compatible with apiURI-style configs
     if (!options.apiRequest && options.apiURI) {
-        // log a deprecation warning
+        // Log a deprecation warning
         options.log('warn/actionService',
             'The config options for this module have changed. ' +
             'Please use the apiRequest template stanza');
@@ -116,12 +116,12 @@ function ActionService(options) {
             // TODO: assume the URI is in the form https?://{domain}/w/api.php
             // as we cannot currently template the host in swagger-router
             uri: 'http://{domain}/w/api.php',
-            headers: { host: '{$.request.params.domain}'},
+            headers: { host: '{$.request.params.domain}' },
             body: '{$.request.body}'
         };
-        // now check if there's really a param in the host of the URI
+        // Now check if there's really a param in the host of the URI
         if (!/^(:?https?:\/\/){[^\s}]+}\//.test(options.apiURI)) {
-            // no host templating, use the string provided by the config
+            // No host templating, use the string provided by the config
             options.apiRequest.uri = options.apiURI;
         }
         // TODO: decide what to do when apiURI has got a host param, but
@@ -141,7 +141,7 @@ function buildQueryResponse(res) {
     } else if (!res.body || res.body.error) {
         throw apiError((res.body || {}).error);
     } else if (!res.body.query || !res.body.query.pages) {
-        throw apiError({info: 'Missing query pages from the PHP action API response.'});
+        throw apiError({ info: 'Missing query pages from the PHP action API response.' });
     }
     // Rewrite res.body
     // XXX: Rethink!

--- a/mods/key_rev_value.js
+++ b/mods/key_rev_value.js
@@ -55,8 +55,8 @@ KRVBucket.prototype.makeSchema = function(opts) {
         },
         index: [
             { attribute: 'key', type: 'hash' },
-            { attribute: 'rev', type: 'range', order: 'desc'},
-            { attribute: 'tid', type: 'range', order: 'desc'}
+            { attribute: 'rev', type: 'range', order: 'desc' },
+            { attribute: 'tid', type: 'range', order: 'desc' }
         ]
     };
 
@@ -241,7 +241,7 @@ KRVBucket.prototype.listRevisions = function(restbase, req) {
             },
             body: {
                 items: res.body.items.map(function(row) {
-                    return { revision: row.rev, tid: row.tid};
+                    return { revision: row.rev, tid: row.tid };
                 }),
                 next: res.body.next
             }
@@ -292,7 +292,7 @@ KRVBucket.prototype.putRevision = function(restbase, req) {
     })
     .catch(function(error) {
         restbase.log('error/kv/putRevision', error);
-        return { status: 400};
+        return { status: 400 };
     });
 };
 

--- a/mods/key_rev_value.js
+++ b/mods/key_rev_value.js
@@ -25,7 +25,7 @@ KRVBucket.prototype.getBucketInfo = function(restbase, req, options) {
     var self = this;
     return P.resolve({
         status: 200,
-        body: options,
+        body: options
     });
 };
 
@@ -37,9 +37,9 @@ KRVBucket.prototype.makeSchema = function(opts) {
             compression: [
                 {
                     algorithm: 'deflate',
-                    block_size: 256,
-                },
-            ],
+                    block_size: 256
+                }
+            ]
         },
         attributes: {
             key: opts.keyType || 'string',
@@ -51,13 +51,13 @@ KRVBucket.prototype.makeSchema = function(opts) {
             'content-sha256': 'blob',
             // Redirect
             'content-location': 'string',
-            tags: 'set<string>',
+            tags: 'set<string>'
         },
         index: [
             { attribute: 'key', type: 'hash' },
-            { attribute: 'rev', type: 'range', order: 'desc', },
-            { attribute: 'tid', type: 'range', order: 'desc', },
-        ],
+            { attribute: 'rev', type: 'range', order: 'desc'},
+            { attribute: 'tid', type: 'range', order: 'desc'}
+        ]
     };
 
     if (opts.revisionRetentionPolicy) {
@@ -79,8 +79,8 @@ KRVBucket.prototype.createBucket = function(restbase, req) {
     schema.table = req.params.bucket;
     var rp = req.params;
     var storeRequest = {
-        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, ]),
-        body: schema,
+        uri: new URI([rp.domain, 'sys', 'table', rp.bucket]),
+        body: schema
     };
     return restbase.put(storeRequest);
 };
@@ -91,7 +91,7 @@ KRVBucket.prototype.getListQuery = function(options, bucket) {
         table: bucket,
         distinct: true,
         proj: 'key',
-        limit: 1000,
+        limit: 1000
     };
 };
 
@@ -104,8 +104,8 @@ KRVBucket.prototype.listBucket = function(restbase, req, options) {
 
     var listQuery = this.getListQuery(options, rp.bucket);
     return restbase.get({
-        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '', ]),
-        body: listQuery,
+        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '']),
+        body: listQuery
     })
     .then(function(result) {
         var listing = result.body.items.map(function(row) {
@@ -114,11 +114,11 @@ KRVBucket.prototype.listBucket = function(restbase, req, options) {
         return {
             status: 200,
             headers: {
-                'content-type': 'application/json',
+                'content-type': 'application/json'
             },
             body: {
-                items: listing,
-            },
+                items: listing
+            }
         };
     })
     .catch(function(error) {
@@ -135,12 +135,12 @@ function returnRevision(req) {
             var row = dbResult.body.items[0];
             var headers = {
                 etag: rbUtil.makeETag(row.rev, row.tid),
-                'content-type': row['content-type'],
+                'content-type': row['content-type']
             };
             return {
                 status: 200,
                 headers: headers,
-                body: row.value,
+                body: row.value
             };
         } else {
             throw new rbUtil.HTTPError({
@@ -148,8 +148,8 @@ function returnRevision(req) {
                 body: {
                     type: 'not_found',
                     uri: req.uri,
-                    method: req.method,
-                },
+                    method: req.method
+                }
             });
         }
     };
@@ -173,8 +173,8 @@ function coerceTid(tidString) {
         body: {
             type: 'key_rev_value/invalid_tid',
             title: 'Invalid tid parameter',
-            tid: tidString,
-        },
+            tid: tidString
+        }
     });
 }
 
@@ -185,8 +185,8 @@ function parseRevision(rev) {
             body: {
                 type: 'key_rev_value/invalid_revision',
                 title: 'Invalid revision parameter',
-                rev: rev,
-            },
+                rev: rev
+            }
         });
     }
 
@@ -196,14 +196,14 @@ function parseRevision(rev) {
 KRVBucket.prototype.getRevision = function(restbase, req) {
     var rp = req.params;
     var storeReq = {
-        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '', ]),
+        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '']),
         body: {
             table: rp.bucket,
             attributes: {
-                key: rp.key,
+                key: rp.key
             },
-            limit: 1,
-        },
+            limit: 1
+        }
     };
     if (rp.revision) {
         storeReq.body.attributes.rev = parseRevision(rp.revision);
@@ -218,16 +218,16 @@ KRVBucket.prototype.getRevision = function(restbase, req) {
 KRVBucket.prototype.listRevisions = function(restbase, req) {
     var rp = req.params;
     var storeRequest = {
-        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '', ]),
+        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '']),
         body: {
             table: req.params.bucket,
             attributes: {
-                key: req.params.key,
+                key: req.params.key
             },
             proj: ['rev', 'tid'],
             limit: (req.body && req.body.limit) ?
-                        req.body.limit : restbase.rb_config.default_page_size,
-        },
+                        req.body.limit : restbase.rb_config.default_page_size
+        }
     };
     if (rp.revision) {
         storeRequest.body.attributes.rev = parseRevision(rp.revision);
@@ -237,14 +237,14 @@ KRVBucket.prototype.listRevisions = function(restbase, req) {
         return {
             status: 200,
             headers: {
-                'content-type': 'application/json',
+                'content-type': 'application/json'
             },
             body: {
                 items: res.body.items.map(function(row) {
-                    return { revision: row.rev, tid: row.tid, };
+                    return { revision: row.rev, tid: row.tid};
                 }),
-                next: res.body.next,
-            },
+                next: res.body.next
+            }
         };
     });
 };
@@ -260,7 +260,7 @@ KRVBucket.prototype.putRevision = function(restbase, req) {
     }
 
     var storeReq = {
-        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '', ]),
+        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '']),
         body: {
             table: rp.bucket,
             attributes: {
@@ -268,10 +268,10 @@ KRVBucket.prototype.putRevision = function(restbase, req) {
                 rev: rev,
                 tid: tid,
                 value: req.body,
-                'content-type': req.headers['content-type'],
+                'content-type': req.headers['content-type']
                 // TODO: include other data!
-            },
-        },
+            }
+        }
     };
     return restbase.put(storeReq)
     .then(function(res) {
@@ -279,12 +279,12 @@ KRVBucket.prototype.putRevision = function(restbase, req) {
             return {
                 status: 201,
                 headers: {
-                    etag: rbUtil.makeETag(rp.revision, tid),
+                    etag: rbUtil.makeETag(rp.revision, tid)
                 },
                 body: {
                     message: "Created.",
-                    tid: rp.revision,
-                },
+                    tid: rp.revision
+                }
             };
         } else {
             throw res;
@@ -292,7 +292,7 @@ KRVBucket.prototype.putRevision = function(restbase, req) {
     })
     .catch(function(error) {
         restbase.log('error/kv/putRevision', error);
-        return { status: 400, };
+        return { status: 400};
     });
 };
 
@@ -307,7 +307,7 @@ module.exports = function(options) {
             listBucket: krvBucket.listBucket.bind(krvBucket),
             listRevisions: krvBucket.listRevisions.bind(krvBucket),
             getRevision: krvBucket.getRevision.bind(krvBucket),
-            putRevision: krvBucket.putRevision.bind(krvBucket),
-        },
+            putRevision: krvBucket.putRevision.bind(krvBucket)
+        }
     };
 };

--- a/mods/key_value.js
+++ b/mods/key_value.js
@@ -17,28 +17,28 @@ var spec = yaml.safeLoad(fs.readFileSync(__dirname + '/key_value.yaml'));
 var backend;
 var config;
 
-function KVBucket (options) {
-    this.log = options.log || function(){};
+function KVBucket(options) {
+    this.log = options.log || function() {};
 }
 
 KVBucket.prototype.getBucketInfo = function(restbase, req, options) {
     var self = this;
     return P.resolve({
         status: 200,
-        body: options
+        body: options,
     });
 };
 
-KVBucket.prototype.makeSchema = function (opts) {
+KVBucket.prototype.makeSchema = function(opts) {
     opts.schemaVersion = 1;
     return {
         options: {
             compression: [
                 {
                     algorithm: 'deflate',
-                    block_size: 256
-                }
-            ]
+                    block_size: 256,
+                },
+            ],
         },
         attributes: {
             key: opts.keyType || 'string',
@@ -47,15 +47,14 @@ KVBucket.prototype.makeSchema = function (opts) {
             value: opts.valueType || 'blob',
             'content-type': 'string',
             'content-sha256': 'blob',
-            // redirect
+            // Redirect
             'content-location': 'string',
             tags: 'set<string>',
-            //headers: 'map<string,string>'
         },
         index: [
-            { attribute: 'key', type: 'hash' },
-            { attribute: 'tid', type: 'range', order: 'desc' }
-        ]
+            { attribute: 'key', type: 'hash', },
+            { attribute: 'tid', type: 'range', order: 'desc', },
+        ],
     };
 };
 
@@ -68,19 +67,19 @@ KVBucket.prototype.createBucket = function(restbase, req) {
     schema.table = req.params.bucket;
     var rp = req.params;
     var storeRequest = {
-        uri: new URI([rp.domain,'sys','table',rp.bucket]),
-        body: schema
+        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, ]),
+        body: schema,
     };
     return restbase.put(storeRequest);
 };
 
 
-KVBucket.prototype.getListQuery = function (options, bucket) {
+KVBucket.prototype.getListQuery = function(options, bucket) {
     return {
         table: bucket,
         distinct: true,
         proj: 'key',
-        limit: 1000
+        limit: 1000,
     };
 };
 
@@ -93,8 +92,8 @@ KVBucket.prototype.listBucket = function(restbase, req, options) {
 
     var listQuery = this.getListQuery(options, rp.bucket);
     return restbase.get({
-        uri: new URI([rp.domain,'sys','table',rp.bucket,'']),
-        body: listQuery
+        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '', ]),
+        body: listQuery,
     })
     .then(function(result) {
         var listing = result.body.items.map(function(row) {
@@ -103,11 +102,11 @@ KVBucket.prototype.listBucket = function(restbase, req, options) {
         return {
             status: 200,
             headers: {
-                'content-type': 'application/json'
+                'content-type': 'application/json',
             },
             body: {
-                items: listing
-            }
+                items: listing,
+            },
         };
     })
     .catch(function(error) {
@@ -119,17 +118,17 @@ KVBucket.prototype.listBucket = function(restbase, req, options) {
 // Format a revision response. Shared between different ways to retrieve a
 // revision (latest & with explicit revision).
 function returnRevision(req) {
-    return function (dbResult) {
+    return function(dbResult) {
         if (dbResult.body && dbResult.body.items && dbResult.body.items.length) {
             var row = dbResult.body.items[0];
             var headers = {
                 etag: rbUtil.makeETag(row.rev, row.tid),
-                'content-type': row['content-type']
+                'content-type': row['content-type'],
             };
             return {
                 status: 200,
                 headers: headers,
-                body: row.value
+                body: row.value,
             };
         } else {
             throw new rbUtil.HTTPError({
@@ -137,23 +136,23 @@ function returnRevision(req) {
                 body: {
                     type: 'not_found',
                     uri: req.uri,
-                    method: req.method
-                }
+                    method: req.method,
+                },
             });
         }
     };
 }
 
-function coerceTid (tidString) {
+function coerceTid(tidString) {
     if (rbUtil.isTimeUUID(tidString)) {
         return tidString;
     }
 
     if (/^\d{4}-\d{2}-\d{2}/.test(tidString)) {
-        // timestamp
+        // Timestamp
         try {
             return rbUtil.tidFromDate(tidString);
-        } catch (e) {} // fall through
+        } catch (e) {} // Fall through
     }
 
     // Out of luck
@@ -162,20 +161,20 @@ function coerceTid (tidString) {
         body: {
             type: 'key_rev_value/invalid_tid',
             title: 'Invalid tid parameter',
-            tid: tidString
-        }
+            tid: tidString,
+        },
     });
 }
 
-function parseRevision (rev) {
+function parseRevision(rev) {
     if (!/^[0-9]+/.test(rev)) {
         throw new rbUtil.HTTPError({
             status: 400,
             body: {
                 type: 'key_rev_value/invalid_revision',
                 title: 'Invalid revision parameter',
-                rev: rev
-            }
+                rev: rev,
+            },
         });
     }
 
@@ -185,14 +184,14 @@ function parseRevision (rev) {
 KVBucket.prototype.getRevision = function(restbase, req) {
     var rp = req.params;
     var storeReq = {
-        uri: new URI([rp.domain,'sys','table',rp.bucket,'']),
+        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '', ]),
         body: {
             table: rp.bucket,
             attributes: {
-                key: rp.key
+                key: rp.key,
             },
-            limit: 1
-        }
+            limit: 1,
+        },
     };
     if (rp.tid) {
         storeReq.body.attributes.tid = coerceTid(rp.tid);
@@ -204,28 +203,28 @@ KVBucket.prototype.getRevision = function(restbase, req) {
 KVBucket.prototype.listRevisions = function(restbase, req) {
     var rp = req.params;
     var storeRequest = {
-        uri: new URI([rp.domain,'sys','table',rp.bucket,'']),
+        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '', ]),
         body: {
             table: req.params.bucket,
             attributes: {
-                key: req.params.key
+                key: req.params.key,
             },
             proj: ['tid'],
-            limit: 1000
-        }
+            limit: 1000,
+        },
     };
     return restbase.get(storeRequest)
     .then(function(res) {
         return {
             status: 200,
             headers: {
-                'content-type': 'application/json'
+                'content-type': 'application/json',
             },
             body: {
                 items: res.body.items.map(function(row) {
                     return row.tid;
-                })
-            }
+                }),
+            },
         };
     });
 };
@@ -237,17 +236,17 @@ KVBucket.prototype.putRevision = function(restbase, req) {
     var tid = uuid.now().toString();
 
     var storeReq = {
-        uri: new URI([rp.domain,'sys','table',rp.bucket,'']),
+        uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '', ]),
         body: {
             table: rp.bucket,
             attributes: {
                 key: rp.key,
                 tid: tid,
                 value: req.body,
-                'content-type': req.headers['content-type']
+                'content-type': req.headers['content-type'],
                 // TODO: include other data!
-            }
-        }
+            },
+        },
     };
     return restbase.put(storeReq)
     .then(function(res) {
@@ -255,12 +254,12 @@ KVBucket.prototype.putRevision = function(restbase, req) {
             return {
                 status: 201,
                 headers: {
-                    etag: rbUtil.makeETag(rp.revision, tid)
+                    etag: rbUtil.makeETag(rp.revision, tid),
                 },
                 body: {
                     message: "Created.",
-                    tid: rp.revision
-                }
+                    tid: rp.revision,
+                },
             };
         } else {
             throw res;
@@ -283,7 +282,7 @@ module.exports = function(options) {
             listBucket: kvBucket.listBucket.bind(kvBucket),
             listRevisions: kvBucket.listRevisions.bind(kvBucket),
             getRevision: kvBucket.getRevision.bind(kvBucket),
-            putRevision: kvBucket.putRevision.bind(kvBucket)
-        }
+            putRevision: kvBucket.putRevision.bind(kvBucket),
+        },
     };
 };

--- a/mods/key_value.js
+++ b/mods/key_value.js
@@ -52,8 +52,8 @@ KVBucket.prototype.makeSchema = function(opts) {
             tags: 'set<string>'
         },
         index: [
-            { attribute: 'key', type: 'hash'},
-            { attribute: 'tid', type: 'range', order: 'desc'}
+            { attribute: 'key', type: 'hash' },
+            { attribute: 'tid', type: 'range', order: 'desc' }
         ]
     };
 };

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -67,22 +67,22 @@ PRS.prototype.getTableSchema = function() {
         },
         index: [
             { attribute: 'title', type: 'hash' },
-            { attribute: 'rev', type: 'range', order: 'desc'},
-            { attribute: 'latest_rev', type: 'static'},
-            { attribute: 'tid', type: 'range', order: 'desc'}
+            { attribute: 'rev', type: 'range', order: 'desc' },
+            { attribute: 'latest_rev', type: 'static' },
+            { attribute: 'tid', type: 'range', order: 'desc' }
         ],
         secondaryIndexes: {
             by_rev: [
                 { attribute: 'rev', type: 'hash' },
-                { attribute: 'tid', type: 'range', order: 'desc'},
-                { attribute: 'title', type: 'range', order: 'asc'},
-                { attribute: 'restrictions', type: 'proj'}
+                { attribute: 'tid', type: 'range', order: 'desc' },
+                { attribute: 'title', type: 'range', order: 'asc' },
+                { attribute: 'restrictions', type: 'proj' }
             ],
             by_ns: [
                 { attribute: 'namespace', type: 'hash' },
-                { attribute: 'title', type: 'range', order: 'asc'},
-                { attribute: 'rev', type: 'range', order: 'desc'},
-                { attribute: 'tid', type: 'range', order: 'desc'}
+                { attribute: 'title', type: 'range', order: 'asc' },
+                { attribute: 'rev', type: 'range', order: 'desc' },
+                { attribute: 'tid', type: 'range', order: 'desc' }
             ]
         }
     };

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -30,7 +30,7 @@ function PRS(options) {
 
 PRS.prototype.tableName = 'title_revisions';
 PRS.prototype.tableURI = function(domain) {
-    return new URI([domain, 'sys', 'table', this.tableName, '', ]);
+    return new URI([domain, 'sys', 'table', this.tableName, '']);
 };
 
 // Get the schema for the revision table
@@ -63,28 +63,28 @@ PRS.prototype.getTableSchema = function() {
             user_text: 'string',
             timestamp: 'timestamp',
             comment: 'string',
-            redirect: 'boolean',
+            redirect: 'boolean'
         },
         index: [
             { attribute: 'title', type: 'hash' },
-            { attribute: 'rev', type: 'range', order: 'desc', },
-            { attribute: 'latest_rev', type: 'static', },
-            { attribute: 'tid', type: 'range', order: 'desc', },
+            { attribute: 'rev', type: 'range', order: 'desc'},
+            { attribute: 'latest_rev', type: 'static'},
+            { attribute: 'tid', type: 'range', order: 'desc'}
         ],
         secondaryIndexes: {
             by_rev: [
                 { attribute: 'rev', type: 'hash' },
-                { attribute: 'tid', type: 'range', order: 'desc', },
-                { attribute: 'title', type: 'range', order: 'asc', },
-                { attribute: 'restrictions', type: 'proj', },
+                { attribute: 'tid', type: 'range', order: 'desc'},
+                { attribute: 'title', type: 'range', order: 'asc'},
+                { attribute: 'restrictions', type: 'proj'}
             ],
             by_ns: [
                 { attribute: 'namespace', type: 'hash' },
-                { attribute: 'title', type: 'range', order: 'asc', },
-                { attribute: 'rev', type: 'range', order: 'desc', },
-                { attribute: 'tid', type: 'range', order: 'desc', },
-            ],
-        },
+                { attribute: 'title', type: 'range', order: 'asc'},
+                { attribute: 'rev', type: 'range', order: 'desc'},
+                { attribute: 'tid', type: 'range', order: 'desc'}
+            ]
+        }
     };
 };
 
@@ -108,8 +108,8 @@ PRS.prototype._checkRevReturn = function(res) {
                 status: 404,
                 body: {
                     type: 'not_found#page_revisions',
-                    description: 'Page was deleted',
-                },
+                    description: 'Page was deleted'
+                }
             });
         } else {
             throw new rbUtil.HTTPError({
@@ -118,8 +118,8 @@ PRS.prototype._checkRevReturn = function(res) {
                     type: 'access_denied#revision',
                     title: 'Access to resource denied',
                     description: 'Access is restricted for revision ' + item.rev,
-                    restrictions: item.restrictions,
-                },
+                    restrictions: item.restrictions
+                }
             });
         }
     }
@@ -130,14 +130,14 @@ PRS.prototype._checkRevReturn = function(res) {
 PRS.prototype.listTitles = function(restbase, req, options) {
     var rp = req.params;
     var listReq = {
-        uri: new URI([rp.domain, 'sys', 'action', 'query', ]),
+        uri: new URI([rp.domain, 'sys', 'action', 'query']),
         method: 'post',
         body: {
             generator: 'allpages',
             gaplimit: restbase.rb_config.default_page_size,
             prop: 'revisions',
-            format: 'json',
-        },
+            format: 'json'
+        }
     };
 
     if (req.query.page) {
@@ -158,8 +158,8 @@ PRS.prototype.listTitles = function(restbase, req, options) {
         if (res.body.next) {
             next = {
                 next: {
-                    href: "?page=" + restbase.encodeToken(res.body.next),
-                },
+                    href: "?page=" + restbase.encodeToken(res.body.next)
+                }
             };
         }
 
@@ -167,8 +167,8 @@ PRS.prototype.listTitles = function(restbase, req, options) {
             status: 200,
             body: {
                 items: items,
-                _links: next,
-            },
+                _links: next
+            }
         };
     });
 };
@@ -178,14 +178,14 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
     var rp = req.params;
     // Try to resolve MW oldids to tids
     var apiReq = {
-        uri: new URI([rp.domain, 'sys', 'action', 'query', ]),
+        uri: new URI([rp.domain, 'sys', 'action', 'query']),
         body: {
             format: 'json',
             action: 'query',
             prop: 'info|revisions',
             continue: '',
-            rvprop: 'ids|timestamp|user|userid|size|sha1|contentmodel|comment|tags',
-        },
+            rvprop: 'ids|timestamp|user|userid|size|sha1|contentmodel|comment|tags'
+        }
     };
     if (/^[0-9]+$/.test(rp.revision)) {
         apiReq.body.revids = rp.revision;
@@ -201,8 +201,8 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
                 body: {
                     type: 'not_found#page_revisions',
                     description: 'Page or revision not found.',
-                    apiResponse: apiRes,
-                },
+                    apiResponse: apiRes
+                }
             });
         }
         // The response item
@@ -238,9 +238,9 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
                     comment: apiRev.comment,
                     tags: apiRev.tags,
                     restrictions: restrictions,
-                    redirect: redirect,
-                },
-            },
+                    redirect: redirect
+                }
+            }
         })
         .then(function() {
             // If there are any restrictions imposed on this
@@ -253,8 +253,8 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
                         type: 'access_denied#revision',
                         title: 'Access to resource denied',
                         description: 'Access is restricted for revision ' + apiRev.revid,
-                        restrictions: restrictions,
-                    },
+                        restrictions: restrictions
+                    }
                 });
             }
             // No restrictions, continue
@@ -272,8 +272,8 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
                 body: {
                     type: 'not_found#page_revisions',
                     description: 'Page or revision not found.',
-                    apiRequest: apiReq,
-                },
+                    apiRequest: apiReq
+                }
             });
         }
         throw e;
@@ -291,10 +291,10 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
             body: {
                 table: self.tableName,
                 attributes: {
-                    title: rbUtil.normalizeTitle(rp.title),
+                    title: rbUtil.normalizeTitle(rp.title)
                 },
-                limit: 1,
-            },
+                limit: 1
+            }
         });
     }
 
@@ -306,10 +306,10 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
                 table: this.tableName,
                 attributes: {
                     title: rbUtil.normalizeTitle(rp.title),
-                    rev: parseInt(rp.revision),
+                    rev: parseInt(rp.revision)
                 },
-                limit: 1,
-            },
+                limit: 1
+            }
         })
         .catch(function(e) {
             if (e.status !== 404) {
@@ -335,8 +335,8 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
                         uri: self.tableURI(rp.domain),
                         body: {
                             table: self.tableName,
-                            attributes: result,
-                        },
+                            attributes: result
+                        }
                     })
                     .then(function() {
                         throw e;
@@ -378,17 +378,17 @@ PRS.prototype.listTitleRevisions = function(restbase, req) {
     var revisionRequest = {
         table: this.tableName,
         attributes: {
-            title: rbUtil.normalizeTitle(rp.title),
+            title: rbUtil.normalizeTitle(rp.title)
         },
         proj: ['rev'],
-        limit: restbase.rb_config.default_page_size,
+        limit: restbase.rb_config.default_page_size
     };
     if (req.query.page) {
         revisionRequest.next = restbase.decodeToken(req.query.page);
     }
     return restbase.get({
         uri: this.tableURI(rp.domain),
-        body: revisionRequest,
+        body: revisionRequest
     })
     .then(function(res) {
         // Flatten to an array of revisions rather than an array of objects &
@@ -404,8 +404,8 @@ PRS.prototype.listTitleRevisions = function(restbase, req) {
         if (res.body.next) {
             res.body._links = {
                 next: {
-                    href: "?page=" + restbase.encodeToken(res.body.next),
-                },
+                    href: "?page=" + restbase.encodeToken(res.body.next)
+                }
             };
         }
         res.body.items = items;
@@ -418,14 +418,14 @@ PRS.prototype.listRevisions = function(restbase, req) {
     var rp = req.params;
 
     var listReq = {
-        uri: new URI([rp.domain, 'sys', 'action', 'query', ]),
+        uri: new URI([rp.domain, 'sys', 'action', 'query']),
         method: 'post',
         body: {
             generator: 'allpages',
             gaplimit: restbase.rb_config.default_page_size,
             prop: 'revisions',
-            format: 'json',
-        },
+            format: 'json'
+        }
     };
     if (req.query.page) {
         Object.assign(listReq.body, restbase.decodeToken(req.query.page));
@@ -442,8 +442,8 @@ PRS.prototype.listRevisions = function(restbase, req) {
         if (res.body.next) {
             next = {
                 next: {
-                    href: "?page=" + restbase.encodeToken(res.body.next),
-                },
+                    href: "?page=" + restbase.encodeToken(res.body.next)
+                }
             };
         }
 
@@ -451,8 +451,8 @@ PRS.prototype.listRevisions = function(restbase, req) {
             status: 200,
             body: {
                 items: items,
-                _links: next,
-            },
+                _links: next
+            }
         };
     });
 };
@@ -466,8 +466,8 @@ PRS.prototype.getRevision = function(restbase, req) {
             status: 400,
             body: {
                 type: 'invalidRevision',
-                description: 'Invalid revision specified.',
-            },
+                description: 'Invalid revision specified.'
+            }
         });
     }
     if (req.headers && /no-cache/.test(req.headers['cache-control'])) {
@@ -483,10 +483,10 @@ PRS.prototype.getRevision = function(restbase, req) {
             table: this.tableName,
             index: 'by_rev',
             attributes: {
-                rev: parseInt(rp.revision),
+                rev: parseInt(rp.revision)
             },
-            limit: 1,
-        },
+            limit: 1
+        }
     })
     .then(function(res) {
         // Check the return
@@ -518,14 +518,14 @@ module.exports = function(options) {
             listTitleRevisions: prs.listTitleRevisions.bind(prs),
             getTitleRevision: prs.getTitleRevision.bind(prs),
             listRevisions: prs.listRevisions.bind(prs),
-            getRevision: prs.getRevision.bind(prs),
+            getRevision: prs.getRevision.bind(prs)
         },
         resources: [
             {
                 // Revision table
                 uri: '/{domain}/sys/table/' + prs.tableName,
-                body: prs.getTableSchema(),
-            },
-        ],
+                body: prs.getTableSchema()
+            }
+        ]
     };
 };

--- a/mods/page_save.js
+++ b/mods/page_save.js
@@ -20,39 +20,39 @@ function PageSave(options) {
         paths: {
             '/wikitext/{title}': {
                 post: {
-                    operationId: 'saveWikitext',
-                },
+                    operationId: 'saveWikitext'
+                }
             },
             '/html/{title}': {
                 post: {
-                    operationId: 'saveHTML',
-                },
-            },
-        },
+                    operationId: 'saveHTML'
+                }
+            }
+        }
     };
     this.operations = {
         saveWikitext: self.saveWikitext.bind(self),
-        saveHTML: self.saveHtml.bind(self),
+        saveHTML: self.saveHtml.bind(self)
     };
 }
 
 PageSave.prototype._getRevInfo = function(restbase, req) {
     var rp = req.params;
     var path = [rp.domain, 'sys', 'page_revisions', 'page',
-                         rbUtil.normalizeTitle(rp.title), ];
+                         rbUtil.normalizeTitle(rp.title)];
     if (!/^(?:[0-9]+)$/.test(req.body.revision)) {
         throw new rbUtil.HTTPError({
             status: 400,
             body: {
                 type: 'invalid_request',
                 title: 'Bad revision',
-                description: 'The supplied revision ID is invalid',
-            },
+                description: 'The supplied revision ID is invalid'
+            }
         });
     }
     path.push(req.body.revision);
     return restbase.get({
-        uri: new URI(path),
+        uri: new URI(path)
     })
     .then(function(res) {
         return res.body.items[0];
@@ -76,8 +76,8 @@ PageSave.prototype._checkParams = function(params) {
             body: {
                 type: 'invalid_request',
                 title: 'Missing parameters',
-                description: 'The html/wikitext and token parameters are required',
-            },
+                description: 'The html/wikitext and token parameters are required'
+            }
         });
     }
 };
@@ -97,7 +97,7 @@ PageSave.prototype.saveWikitext = function(restbase, req) {
             summary: req.body.comment || 'Change text to: ' + req.body.wikitext.substr(0, 100),
             minor: req.body.minor || false,
             bot: req.body.bot || false,
-            token: req.body.token,
+            token: req.body.token
         };
         // We need to add each info separately
         // since the presence of an empty value
@@ -113,9 +113,9 @@ PageSave.prototype.saveWikitext = function(restbase, req) {
         return restbase.post({
             uri: new URI([rp.domain, 'sys', 'action', 'edit']),
             headers: {
-                cookie: req.headers.cookie,
+                cookie: req.headers.cookie
             },
-            body: body,
+            body: body
         });
     });
 };
@@ -131,8 +131,8 @@ PageSave.prototype.saveHtml = function(restbase, req) {
         uri: new URI([rp.domain, 'sys', 'parsoid', 'transform', 'html', 'to', 'wikitext', title]),
         body: {
             revision: req.body.revision,
-            html: req.body.html,
-        },
+            html: req.body.html
+        }
     }).then(function(res) {
         // Then send it to the MW API
         req.body.wikitext = res.body;
@@ -146,7 +146,7 @@ module.exports = function(options) {
     var ps = new PageSave(options || {});
     return {
         spec: ps.spec,
-        operations: ps.operations,
+        operations: ps.operations
     };
 };
 

--- a/mods/page_save.js
+++ b/mods/page_save.js
@@ -63,7 +63,7 @@ PageSave.prototype._getRevInfo = function(restbase, req) {
         // We are dealing with a restricted revision
         // however, let MW deal with it as the user
         // might have sufficient permissions to do an edit
-        return {title: rbUtil.normalizeTitle(rp.title)};
+        return { title: rbUtil.normalizeTitle(rp.title) };
     });
 };
 

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -38,7 +38,7 @@ function ParsoidService(options) {
         transformHtmlToHtml: self.makeTransform('html', 'html'),
         transformHtmlToWikitext: self.makeTransform('html', 'wikitext'),
         transformWikitextToHtml: self.makeTransform('wikitext', 'html'),
-        transformSectionsToWikitext: self.makeTransform('sections', 'wikitext'),
+        transformSectionsToWikitext: self.makeTransform('sections', 'wikitext')
     };
 }
 
@@ -67,7 +67,7 @@ PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
     }
 
     var reqs = {
-        content: promise,
+        content: promise
     };
 
     // Bundle the promise together with a call to getRevisionInfo(). A
@@ -78,7 +78,7 @@ PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
     // offsets
     if (format === 'html' && req.query.sections) {
         reqs.sectionOffsets = restbase.get({
-            uri: this.getBucketURI(rp, 'section.offsets', tid),
+            uri: this.getBucketURI(rp, 'section.offsets', tid)
         });
     }
 
@@ -101,8 +101,8 @@ PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
                         status: 400,
                         body: {
                             type: 'invalid_request',
-                            detail: 'Unknown section id: ' + id,
-                        },
+                            detail: 'Unknown section id: ' + id
+                        }
                     });
                 }
                 // Offsets as returned by Parsoid are relative to body.innerHTML
@@ -113,9 +113,9 @@ PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
                 status: 200,
                 headers: {
                     etag: responses.content.headers.etag,
-                    'content-type': 'application/json',
+                    'content-type': 'application/json'
                 },
-                body: chunks,
+                body: chunks
             };
         } else {
             return ensureCharsetInContentType(responses.content);
@@ -124,7 +124,7 @@ PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
 };
 
 PSP.getBucketURI = function(rp, format, tid) {
-    var path = [rp.domain, 'sys', 'key_rev_value', 'parsoid.' + format, rp.title, ];
+    var path = [rp.domain, 'sys', 'key_rev_value', 'parsoid.' + format, rp.title];
     if (rp.revision) {
         path.push(rp.revision);
         if (tid) {
@@ -155,13 +155,13 @@ PSP.saveParsoidResult = function(restbase, req, format, tid, parsoidResp) {
             restbase.put({
                 uri: self.getBucketURI(rp, 'data-parsoid', tid),
                 headers: parsoidResp.body['data-parsoid'].headers,
-                body: parsoidResp.body['data-parsoid'].body,
+                body: parsoidResp.body['data-parsoid'].body
             }),
             restbase.put({
                 uri: self.getBucketURI(rp, 'section.offsets', tid),
                 headers: { 'content-type': 'application/json' },
-                body: parsoidResp.body['data-parsoid'].body.sectionOffsets,
-            }),
+                body: parsoidResp.body['data-parsoid'].body.sectionOffsets
+            })
         ])
         // Save HTML last, so that any error in metadata storage suppresses
         // HTML.
@@ -169,7 +169,7 @@ PSP.saveParsoidResult = function(restbase, req, format, tid, parsoidResp) {
             return restbase.put({
                 uri: self.getBucketURI(rp, 'html', tid),
                 headers: parsoidResp.body.html.headers,
-                body: parsoidResp.body.html.body,
+                body: parsoidResp.body.html.body
             });
         })
         // And return the response to the client
@@ -178,7 +178,7 @@ PSP.saveParsoidResult = function(restbase, req, format, tid, parsoidResp) {
             var resp = {
                 status: parsoidResp.status,
                 headers: parsoidResp.body[format].headers,
-                body: parsoidResp.body[format].body,
+                body: parsoidResp.body[format].body
             };
             resp.headers.etag = rbUtil.makeETag(rp.revision, tid);
             return self.wrapContentReq(restbase, req, P.resolve(resp), format, tid);
@@ -205,7 +205,7 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
     var rp = req.params;
 
     var pageBundleUri = new URI([rp.domain, 'sys', 'parsoid', 'pagebundle',
-                     rbUtil.normalizeTitle(rp.title), rp.revision, ]);
+                     rbUtil.normalizeTitle(rp.title), rp.revision]);
 
     // Helper for retrieving original content from storage & posting it to
     // the Parsoid pagebundle end point
@@ -213,15 +213,15 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
         return self._getOriginalContent(restbase, req, revision)
         .then(function(res) {
             var body = {
-                update: updateMode,
+                update: updateMode
             };
             body[contentName] = res;
             return restbase.post({
                 uri: pageBundleUri,
                 headers: {
-                    'content-type': 'application/json',
+                    'content-type': 'application/json'
                 },
-                body: body,
+                body: body
             });
         })
         .catch(function(e) {
@@ -275,7 +275,7 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
 PSP.getRevisionInfo = function(restbase, req) {
     var rp = req.params;
     var path = [rp.domain, 'sys', 'page_revisions', 'page',
-                         rbUtil.normalizeTitle(rp.title), ];
+                         rbUtil.normalizeTitle(rp.title)];
     if (/^(?:[0-9]+)$/.test(rp.revision)) {
         path.push(rp.revision);
     } else if (rp.revision) {
@@ -283,7 +283,7 @@ PSP.getRevisionInfo = function(restbase, req) {
     }
 
     return restbase.get({
-        uri: new URI(path),
+        uri: new URI(path)
     })
     .then(function(res) {
         return res.body.items[0];
@@ -316,7 +316,7 @@ PSP.getFormat = function(format, restbase, req) {
     }
 
     var contentReq = restbase.get({
-        uri: self.getBucketURI(rp, format, rp.tid),
+        uri: self.getBucketURI(rp, format, rp.tid)
     });
 
     if (req.headers && /no-cache/i.test(req.headers['cache-control'])
@@ -333,8 +333,8 @@ PSP.getFormat = function(format, restbase, req) {
                                 status: 412,
                                 body: {
                                     type: 'precondition_failed',
-                                    detail: 'The precondition failed',
-                                },
+                                    detail: 'The precondition failed'
+                                }
                             };
                         }
                     } catch (e) {} // Ignore errors from date parsing
@@ -365,10 +365,10 @@ PSP.listRevisions = function(format, restbase, req) {
     var rp = req.params;
     var revReq = {
         uri: new URI([rp.domain, 'sys', 'key_rev_value', 'parsoid.' + format,
-                        rbUtil.normalizeTitle(rp.title), '', ]),
+                        rbUtil.normalizeTitle(rp.title), '']),
         body: {
-            limit: restbase.rb_config.default_page_size,
-        },
+            limit: restbase.rb_config.default_page_size
+        }
     };
 
     if (req.query.page) {
@@ -380,8 +380,8 @@ PSP.listRevisions = function(format, restbase, req) {
         if (res.body.next) {
             res.body._links = {
                 next: {
-                    href: "?page=" + restbase.encodeToken(res.body.next),
-                },
+                    href: "?page=" + restbase.encodeToken(res.body.next)
+                }
             };
         }
         return res;
@@ -393,13 +393,13 @@ PSP._getOriginalContent = function(restbase, req, revision, tid) {
 
     function get(format) {
         var path = [rp.domain, 'sys', 'parsoid', format,
-                     rbUtil.normalizeTitle(rp.title), revision, ];
+                     rbUtil.normalizeTitle(rp.title), revision];
         if (tid) {
             path.push(tid);
         }
 
         return restbase.get({
-            uri: new URI(path),
+            uri: new URI(path)
         })
         .then(function(res) {
             if (res.body && Buffer.isBuffer(res.body)) {
@@ -407,16 +407,16 @@ PSP._getOriginalContent = function(restbase, req, revision, tid) {
             }
             return {
                 headers: {
-                    'content-type': res.headers['content-type'],
+                    'content-type': res.headers['content-type']
                 },
-                body: res.body,
+                body: res.body
             };
         });
     }
 
     return P.props({
         html: get('html'),
-        'data-parsoid': get('data-parsoid'),
+        'data-parsoid': get('data-parsoid')
     })
     .then(function(res) {
         res.revid = revision;
@@ -453,12 +453,12 @@ PSP.transformRevision = function(restbase, req, from, to) {
                 status: 400,
                 body: {
                     type: 'invalid_request',
-                    description: 'The page/revision has no associated Parsoid data',
-                },
+                    description: 'The page/revision has no associated Parsoid data'
+                }
             });
         }
         var body2 = {
-            original: original,
+            original: original
         };
         if (from === 'sections') {
             var sections = req.body.sections;
@@ -471,13 +471,13 @@ PSP.transformRevision = function(restbase, req, from, to) {
                         status: 400,
                         body: {
                             type: 'invalid_request',
-                            description: 'Invalid JSON provided in the request',
-                        },
+                            description: 'Invalid JSON provided in the request'
+                        }
                     });
                 }
             }
             body2.html = {
-                body: replaceSections(original, sections),
+                body: replaceSections(original, sections)
             };
             from = 'html';
         } else {
@@ -502,7 +502,7 @@ PSP.transformRevision = function(restbase, req, from, to) {
             uri: new URI(path),
             params: req.params,
             headers: { 'content-type': 'application/json' },
-            body: body2,
+            body: body2
         };
         return self.callParsoidTransform(restbase, newReq, from, to);
     });
@@ -541,7 +541,7 @@ PSP.callParsoidTransform = function callParsoidTransform(restbase, req, from, to
         uri: this.parsoidHost + '/v2/' + domain + '/'
             + parsoidTo + parsoidExtraPath,
         headers: { 'content-type': 'application/json' },
-        body: req.body,
+        body: req.body
     };
     return restbase.post(parsoidReq);
 };
@@ -576,8 +576,8 @@ function replaceSections(original, sectionsJson) {
             status: 400,
             body: {
                 type: 'invalid_request',
-                description: 'Invalid section ids',
-            },
+                description: 'Invalid section ids'
+            }
         });
     }
     sectionIds.sort(function(id1, id2) {
@@ -602,8 +602,8 @@ PSP.makeTransform = function(from, to) {
                 status: 400,
                 body: {
                     type: 'invalid_request',
-                    description: 'Missing request parameter: ' + from,
-                },
+                    description: 'Missing request parameter: ' + from
+                }
             });
         }
         var transform;
@@ -641,17 +641,17 @@ module.exports = function(options) {
                     revisionRetentionPolicy: {
                         type: 'latest',
                         count: 1,
-                        grace_ttl: 86400,
+                        grace_ttl: 86400
                     },
                     valueType: 'blob',
-                    version: 1,
-                },
+                    version: 1
+                }
             },
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.wikitext',
                 body: {
-                    valueType: 'blob',
-                },
+                    valueType: 'blob'
+                }
             },
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.data-parsoid',
@@ -659,11 +659,11 @@ module.exports = function(options) {
                     revisionRetentionPolicy: {
                         type: 'latest',
                         count: 1,
-                        grace_ttl: 86400,
+                        grace_ttl: 86400
                     },
                     valueType: 'json',
-                    version: 1,
-                },
+                    version: 1
+                }
             },
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.section.offsets',
@@ -671,18 +671,18 @@ module.exports = function(options) {
                     revisionRetentionPolicy: {
                         type: 'latest',
                         count: 1,
-                        grace_ttl: 86400,
+                        grace_ttl: 86400
                     },
                     valueType: 'json',
-                    version: 1,
-                },
+                    version: 1
+                }
             },
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.data-mw',
                 body: {
-                    valueType: 'json',
-                },
-            },
-        ],
+                    valueType: 'json'
+                }
+            }
+        ]
     };
 };

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -26,19 +26,19 @@ function ParsoidService(options) {
             return self.wrapContentReq(restbase, req,
                     self.pagebundle(restbase, req), 'pagebundle');
         },
-        // revision retrieval per format
+        // Revision retrieval per format
         getWikitext: self.getFormat.bind(self, 'wikitext'),
         getHtml: self.getFormat.bind(self, 'html'),
         getDataParsoid: self.getFormat.bind(self, 'data-parsoid'),
-        // listings
+        // Listings
         listWikitextRevisions: self.listRevisions.bind(self, 'wikitext'),
         listHtmlRevisions: self.listRevisions.bind(self, 'html'),
         listDataParsoidRevisions: self.listRevisions.bind(self, 'data-parsoid'),
-        // transforms
+        // Transforms
         transformHtmlToHtml: self.makeTransform('html', 'html'),
         transformHtmlToWikitext: self.makeTransform('html', 'wikitext'),
         transformWikitextToHtml: self.makeTransform('wikitext', 'html'),
-        transformSectionsToWikitext: self.makeTransform('sections', 'wikitext')
+        transformSectionsToWikitext: self.makeTransform('sections', 'wikitext'),
     };
 }
 
@@ -78,13 +78,13 @@ PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
     // offsets
     if (format === 'html' && req.query.sections) {
         reqs.sectionOffsets = restbase.get({
-            uri: this.getBucketURI(rp, 'section.offsets', tid)
+            uri: this.getBucketURI(rp, 'section.offsets', tid),
         });
     }
 
     return P.props(reqs)
     .then(function(responses) {
-        // if we have reached this point, it means access is not denied, and
+        // If we have reached this point, it means access is not denied, and
         // sections (if requested) were found
         if (format === 'html' && req.query.sections) {
             // Handle section requests
@@ -101,11 +101,11 @@ PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
                         status: 400,
                         body: {
                             type: 'invalid_request',
-                            detail: 'Unknown section id: ' + id
-                        }
+                            detail: 'Unknown section id: ' + id,
+                        },
                     });
                 }
-                // offsets as returned by Parsoid are relative to body.innerHTML
+                // Offsets as returned by Parsoid are relative to body.innerHTML
                 chunks[id] = body.substring(offsets.html[0], offsets.html[1]);
             });
 
@@ -124,7 +124,7 @@ PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
 };
 
 PSP.getBucketURI = function(rp, format, tid) {
-    var path = [rp.domain,'sys','key_rev_value','parsoid.' + format, rp.title];
+    var path = [rp.domain, 'sys', 'key_rev_value', 'parsoid.' + format, rp.title, ];
     if (rp.revision) {
         path.push(rp.revision);
         if (tid) {
@@ -146,21 +146,21 @@ PSP.pagebundle = function(restbase, req) {
     return restbase.request(newReq);
 };
 
-PSP.saveParsoidResult = function (restbase, req, format, tid, parsoidResp) {
+PSP.saveParsoidResult = function(restbase, req, format, tid, parsoidResp) {
     var self = this;
     var rp = req.params;
-    // handle the response from Parsoid
+    // Handle the response from Parsoid
     if (parsoidResp.status === 200) {
         return P.all([
             restbase.put({
                 uri: self.getBucketURI(rp, 'data-parsoid', tid),
                 headers: parsoidResp.body['data-parsoid'].headers,
-                body: parsoidResp.body['data-parsoid'].body
+                body: parsoidResp.body['data-parsoid'].body,
             }),
             restbase.put({
                 uri: self.getBucketURI(rp, 'section.offsets', tid),
                 headers: { 'content-type': 'application/json' },
-                body: parsoidResp.body['data-parsoid'].body.sectionOffsets
+                body: parsoidResp.body['data-parsoid'].body.sectionOffsets,
             }),
         ])
         // Save HTML last, so that any error in metadata storage suppresses
@@ -169,16 +169,16 @@ PSP.saveParsoidResult = function (restbase, req, format, tid, parsoidResp) {
             return restbase.put({
                 uri: self.getBucketURI(rp, 'html', tid),
                 headers: parsoidResp.body.html.headers,
-                body: parsoidResp.body.html.body
+                body: parsoidResp.body.html.body,
             });
         })
         // And return the response to the client
         // but only if the revision is accessible
         .then(function() {
             var resp = {
-                'status': parsoidResp.status,
+                status: parsoidResp.status,
                 headers: parsoidResp.body[format].headers,
-                body: parsoidResp.body[format].body
+                body: parsoidResp.body[format].body,
             };
             resp.headers.etag = rbUtil.makeETag(rp.revision, tid);
             return self.wrapContentReq(restbase, req, P.resolve(resp), format, tid);
@@ -204,8 +204,8 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
     // Try to generate HTML on the fly by calling Parsoid
     var rp = req.params;
 
-    var pageBundleUri = new URI([rp.domain,'sys','parsoid','pagebundle',
-                     rbUtil.normalizeTitle(rp.title),rp.revision]);
+    var pageBundleUri = new URI([rp.domain, 'sys', 'parsoid', 'pagebundle',
+                     rbUtil.normalizeTitle(rp.title), rp.revision, ]);
 
     // Helper for retrieving original content from storage & posting it to
     // the Parsoid pagebundle end point
@@ -213,15 +213,15 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
         return self._getOriginalContent(restbase, req, revision)
         .then(function(res) {
             var body = {
-                update: updateMode
+                update: updateMode,
             };
             body[contentName] = res;
             return restbase.post({
                 uri: pageBundleUri,
                 headers: {
-                    'content-type': 'application/json'
+                    'content-type': 'application/json',
                 },
-                body: body
+                body: body,
             });
         })
         .catch(function(e) {
@@ -274,8 +274,8 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
 // Get / check the revision metadata for a request
 PSP.getRevisionInfo = function(restbase, req) {
     var rp = req.params;
-    var path = [rp.domain,'sys','page_revisions','page',
-                         rbUtil.normalizeTitle(rp.title)];
+    var path = [rp.domain, 'sys', 'page_revisions', 'page',
+                         rbUtil.normalizeTitle(rp.title), ];
     if (/^(?:[0-9]+)$/.test(rp.revision)) {
         path.push(rp.revision);
     } else if (rp.revision) {
@@ -283,19 +283,19 @@ PSP.getRevisionInfo = function(restbase, req) {
     }
 
     return restbase.get({
-        uri: new URI(path)
+        uri: new URI(path),
     })
     .then(function(res) {
         return res.body.items[0];
     });
 };
 
-PSP.getFormat = function (format, restbase, req) {
+PSP.getFormat = function(format, restbase, req) {
     var self = this;
     var rp = req.params;
     rp.title = rbUtil.normalizeTitle(rp.title);
 
-    function generateContent (storageRes) {
+    function generateContent(storageRes) {
         if (storageRes.status === 404 || storageRes.status === 200) {
             return self.getRevisionInfo(restbase, req)
             .then(function(revInfo) {
@@ -316,12 +316,11 @@ PSP.getFormat = function (format, restbase, req) {
     }
 
     var contentReq = restbase.get({
-        uri: self.getBucketURI(rp, format, rp.tid)
+        uri: self.getBucketURI(rp, format, rp.tid),
     });
 
     if (req.headers && /no-cache/i.test(req.headers['cache-control'])
-            && rp.revision)
-    {
+            && rp.revision) {
         // Check content generation either way
         contentReq = contentReq.then(function(res) {
                 if (req.headers['if-unmodified-since']) {
@@ -334,8 +333,8 @@ PSP.getFormat = function (format, restbase, req) {
                                 status: 412,
                                 body: {
                                     type: 'precondition_failed',
-                                    detail: 'The precondition failed'
-                                }
+                                    detail: 'The precondition failed',
+                                },
                             };
                         }
                     } catch (e) {} // Ignore errors from date parsing
@@ -354,20 +353,22 @@ PSP.getFormat = function (format, restbase, req) {
     return contentReq
     .then(function(res) {
         if (res && res.headers && !/^application\/json/.test(res.headers['content-type'])) {
-            res.headers['Content-Security-Policy'] = rbUtil.constructCSP(rp.domain, { allowInline: true } );
+            res.headers['Content-Security-Policy'] =
+                rbUtil.constructCSP(rp.domain, { allowInline: true });
         }
         return res;
     });
 };
 
-PSP.listRevisions = function (format, restbase, req) {
+PSP.listRevisions = function(format, restbase, req) {
     var self = this;
     var rp = req.params;
     var revReq = {
-        uri: new URI([rp.domain, 'sys', 'key_rev_value', 'parsoid.' + format, rbUtil.normalizeTitle(rp.title), '']),
+        uri: new URI([rp.domain, 'sys', 'key_rev_value', 'parsoid.' + format,
+                        rbUtil.normalizeTitle(rp.title), '', ]),
         body: {
             limit: restbase.rb_config.default_page_size,
-        }
+        },
     };
 
     if (req.query.page) {
@@ -378,7 +379,9 @@ PSP.listRevisions = function (format, restbase, req) {
     .then(function(res) {
         if (res.body.next) {
             res.body._links = {
-                next: { "href": "?page="+restbase.encodeToken(res.body.next) }
+                next: {
+                    href: "?page=" + restbase.encodeToken(res.body.next),
+                },
             };
         }
         return res;
@@ -389,32 +392,31 @@ PSP._getOriginalContent = function(restbase, req, revision, tid) {
     var rp = req.params;
 
     function get(format) {
-        var path = [rp.domain,'sys','parsoid',format,
-                     rbUtil.normalizeTitle(rp.title),revision];
+        var path = [rp.domain, 'sys', 'parsoid', format,
+                     rbUtil.normalizeTitle(rp.title), revision, ];
         if (tid) {
             path.push(tid);
         }
 
         return restbase.get({
-            uri: new URI(path)
+            uri: new URI(path),
         })
-        .then(function (res) {
+        .then(function(res) {
             if (res.body && Buffer.isBuffer(res.body)) {
                 res.body = res.body.toString();
             }
             return {
                 headers: {
-                    'content-type': res.headers['content-type']
+                    'content-type': res.headers['content-type'],
                 },
-                body: res.body
+                body: res.body,
             };
         });
     }
 
     return P.props({
         html: get('html'),
-        // wikitext: get('wikitext'),
-        'data-parsoid': get('data-parsoid')
+        'data-parsoid': get('data-parsoid'),
     })
     .then(function(res) {
         res.revid = revision;
@@ -423,7 +425,7 @@ PSP._getOriginalContent = function(restbase, req, revision, tid) {
 
 };
 
-PSP.transformRevision = function (restbase, req, from, to) {
+PSP.transformRevision = function(restbase, req, from, to) {
     var self = this;
     var rp = req.params;
 
@@ -442,7 +444,7 @@ PSP.transformRevision = function (restbase, req, from, to) {
     }
 
     return this._getOriginalContent(restbase, req, rp.revision, tid)
-    .then(function (original) {
+    .then(function(original) {
         // Check if parsoid metadata is present as it's required by parsoid.
         if (!original['data-parsoid'].body
                 || original['data-parsoid'].body.constructor !== Object
@@ -451,31 +453,31 @@ PSP.transformRevision = function (restbase, req, from, to) {
                 status: 400,
                 body: {
                     type: 'invalid_request',
-                    description: 'The page/revision has no associated Parsoid data'
-                }
+                    description: 'The page/revision has no associated Parsoid data',
+                },
             });
         }
         var body2 = {
-            original: original
+            original: original,
         };
         if (from === 'sections') {
             var sections = req.body.sections;
             if (req.body.sections.constructor !== Object) {
                 try {
-                     sections = JSON.parse(req.body.sections.toString());
+                    sections = JSON.parse(req.body.sections.toString());
                 } catch (e) {
                     // Catch JSON parsing exception and return 400
                     throw new rbUtil.HTTPError({
                         status: 400,
                         body: {
                             type: 'invalid_request',
-                            description: 'Invalid JSON provided in the request'
-                        }
+                            description: 'Invalid JSON provided in the request',
+                        },
                     });
                 }
             }
             body2.html = {
-                body: replaceSections(original, sections)
+                body: replaceSections(original, sections),
             };
             from = 'html';
         } else {
@@ -489,7 +491,7 @@ PSP.transformRevision = function (restbase, req, from, to) {
             body2.scrubWikitext = true;
         }
 
-        var path = [rp.domain,'sys','parsoid','transform',from,'to',to];
+        var path = [rp.domain, 'sys', 'parsoid', 'transform', from, 'to', to];
         if (rp.title) {
             path.push(rbUtil.normalizeTitle(rp.title));
             if (rp.revision) {
@@ -500,14 +502,14 @@ PSP.transformRevision = function (restbase, req, from, to) {
             uri: new URI(path),
             params: req.params,
             headers: { 'content-type': 'application/json' },
-            body: body2
+            body: body2,
         };
         return self.callParsoidTransform(restbase, newReq, from, to);
     });
 
 };
 
-PSP.callParsoidTransform = function callParsoidTransform (restbase, req, from, to) {
+PSP.callParsoidTransform = function callParsoidTransform(restbase, req, from, to) {
     var rp = req.params;
     // Parsoid currently spells 'wikitext' as 'wt'
     var parsoidTo = to;
@@ -523,7 +525,7 @@ PSP.callParsoidTransform = function callParsoidTransform (restbase, req, from, t
     if (rp.title) {
         parsoidExtras.push(rbUtil.normalizeTitle(rp.title));
     } else {
-        // fake title to avoid Parsoid error: <400/No title or wikitext was provided>
+        // Fake title to avoid Parsoid error: <400/No title or wikitext was provided>
         parsoidExtras.push('Main_Page');
     }
     if (rp.revision) {
@@ -539,7 +541,7 @@ PSP.callParsoidTransform = function callParsoidTransform (restbase, req, from, t
         uri: this.parsoidHost + '/v2/' + domain + '/'
             + parsoidTo + parsoidExtraPath,
         headers: { 'content-type': 'application/json' },
-        body: req.body
+        body: req.body,
     };
     return restbase.post(parsoidReq);
 };
@@ -574,8 +576,8 @@ function replaceSections(original, sectionsJson) {
             status: 400,
             body: {
                 type: 'invalid_request',
-                description: 'Invalid section ids'
-            }
+                description: 'Invalid section ids',
+            },
         });
     }
     sectionIds.sort(function(id1, id2) {
@@ -590,18 +592,18 @@ function replaceSections(original, sectionsJson) {
     return '<body>' + newBody + '</body>';
 }
 
-PSP.makeTransform = function (from, to) {
+PSP.makeTransform = function(from, to) {
     var self = this;
 
-    return function (restbase, req) {
+    return function(restbase, req) {
         var rp = req.params;
         if (!req.body[from]) {
             throw new rbUtil.HTTPError({
                 status: 400,
                 body: {
                     type: 'invalid_request',
-                    description: 'Missing request parameter: ' + from
-                }
+                    description: 'Missing request parameter: ' + from,
+                },
             });
         }
         var transform;
@@ -625,7 +627,7 @@ PSP.makeTransform = function (from, to) {
 };
 
 
-module.exports = function (options) {
+module.exports = function(options) {
     var ps = new ParsoidService(options);
 
     return {
@@ -639,17 +641,17 @@ module.exports = function (options) {
                     revisionRetentionPolicy: {
                         type: 'latest',
                         count: 1,
-                        grace_ttl: 86400
+                        grace_ttl: 86400,
                     },
                     valueType: 'blob',
                     version: 1,
-                }
+                },
             },
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.wikitext',
                 body: {
                     valueType: 'blob',
-                }
+                },
             },
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.data-parsoid',
@@ -657,11 +659,11 @@ module.exports = function (options) {
                     revisionRetentionPolicy: {
                         type: 'latest',
                         count: 1,
-                        grace_ttl: 86400
+                        grace_ttl: 86400,
                     },
                     valueType: 'json',
                     version: 1,
-                }
+                },
             },
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.section.offsets',
@@ -669,18 +671,18 @@ module.exports = function (options) {
                     revisionRetentionPolicy: {
                         type: 'latest',
                         count: 1,
-                        grace_ttl: 86400
+                        grace_ttl: 86400,
                     },
                     valueType: 'json',
                     version: 1,
-                }
+                },
             },
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.data-mw',
                 body: {
                     valueType: 'json',
-                }
-            }
+                },
+            },
         ],
     };
 };

--- a/mods/simple_service.js
+++ b/mods/simple_service.js
@@ -57,7 +57,7 @@ SimpleService.prototype.processSpec = function(spec) {
                         return restbase.put({
                             uri: storageUriTemplate.expand(req.params),
                             headers: res.headers,
-                            body: res.body
+                            body: res.body,
                         })
                         .then(function(storeRes) {
                             res.headers.etag = storeRes.headers.etag;
@@ -94,7 +94,7 @@ SimpleService.prototype.processSpec = function(spec) {
     return {
         spec: spec,
         operations: operations,
-        resources: resources
+        resources: resources,
     };
 };
 

--- a/mods/simple_service.js
+++ b/mods/simple_service.js
@@ -13,7 +13,7 @@ var Template = require('../lib/reqTemplate');
 function SimpleService(options) {
     options = options || {};
     this.spec = {
-        paths: options.paths,
+        paths: options.paths
     };
 
     this.exports = this.processSpec(this.spec);
@@ -57,7 +57,7 @@ SimpleService.prototype.processSpec = function(spec) {
                         return restbase.put({
                             uri: storageUriTemplate.expand(req.params),
                             headers: res.headers,
-                            body: res.body,
+                            body: res.body
                         })
                         .then(function(storeRes) {
                             res.headers.etag = storeRes.headers.etag;
@@ -73,7 +73,7 @@ SimpleService.prototype.processSpec = function(spec) {
                     } else {
                         // Try storage first
                         return restbase.get({
-                            uri: storageUriTemplate.expand(req.params),
+                            uri: storageUriTemplate.expand(req.params)
                         })
                         .catch(function(e) {
                             if (e.status === 404) {
@@ -94,7 +94,7 @@ SimpleService.prototype.processSpec = function(spec) {
     return {
         spec: spec,
         operations: operations,
-        resources: resources,
+        resources: resources
     };
 };
 

--- a/mods/simple_service.js
+++ b/mods/simple_service.js
@@ -46,7 +46,7 @@ SimpleService.prototype.processSpec = function(spec) {
                 }
 
                 function backendRequest() {
-                    return restbase.request(backendRequestTemplate.eval({request: req}));
+                    return restbase.request(backendRequestTemplate.eval({ request: req }));
                 }
 
                 function regenerateAndSave() {

--- a/mods/simple_service.js
+++ b/mods/simple_service.js
@@ -13,7 +13,7 @@ var Template = require('../lib/reqTemplate');
 function SimpleService(options) {
     options = options || {};
     this.spec = {
-        paths: options.paths
+        paths: options.paths,
     };
 
     this.exports = this.processSpec(this.spec);
@@ -32,7 +32,8 @@ SimpleService.prototype.processSpec = function(spec) {
             var storageUriTemplate;
             if (conf.storage) {
                 if (!conf.storage.bucket_request.uri) {
-                    throw new Error('Broken config: expected storage.bucket_request.uri for ' + path);
+                    throw new Error('Broken config: ' +
+                        'expected storage.bucket_request.uri for ' + path);
                 }
                 storageUriTemplate = new URI(conf.storage.item_request.uri, {}, true);
                 resources.push(conf.storage.bucket_request);
@@ -45,14 +46,14 @@ SimpleService.prototype.processSpec = function(spec) {
                 }
 
                 function backendRequest() {
-                    return restbase.request(backendRequestTemplate.eval({request:req}));
+                    return restbase.request(backendRequestTemplate.eval({request: req}));
                 }
 
                 function regenerateAndSave() {
                     // Fall back to the backend service
                     return backendRequest()
                     .then(function(res) {
-                        // store the result
+                        // Store the result
                         return restbase.put({
                             uri: storageUriTemplate.expand(req.params),
                             headers: res.headers,
@@ -72,7 +73,7 @@ SimpleService.prototype.processSpec = function(spec) {
                     } else {
                         // Try storage first
                         return restbase.get({
-                            uri: storageUriTemplate.expand(req.params)
+                            uri: storageUriTemplate.expand(req.params),
                         })
                         .catch(function(e) {
                             if (e.status === 404) {
@@ -98,6 +99,6 @@ SimpleService.prototype.processSpec = function(spec) {
 };
 
 
-module.exports = function (options) {
+module.exports = function(options) {
     return new SimpleService(options).exports;
 };

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "swagger-test": "0.2.0",
     "url-template": "^2.0.6",
     "nock": "^2.6.0",
-    "restbase-mod-table-sqlite": "^0.1.0"
+    "restbase-mod-table-sqlite": "^0.1.0",
+    "mocha-jscs": "^1.2.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -3,4 +3,5 @@
 
 // Run jshint as part of normal testing
 require('mocha-jshint')();
-
+// Run jscs as part of normal testing
+require('mocha-jscs')();


### PR DESCRIPTION
Most of the stuff fixed automatically, then I've looked over the changes and all seems to be fine.
The jscs config is the same as in parsoid, but we don't verify that comments are starting with an upper-case letter, because we have several places with commented-out code that could be useful for debugging.

Bug: https://phabricator.wikimedia.org/T107950