### PR TITLE
Modify MobileApps routes

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -130,23 +130,23 @@ templates:
                 /v1/html/{title}:
                   get:
                     backend_request:
-                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html/{title}
+                      uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html/{title}
                 /v1/sections/{title}:
                   get:
                     backend_request:
-                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections/{title}
+                      uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections/{title}
                 /v1/sections-lead/{title}:
                   get:
                     backend_request:
-                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections-lead/{title}
+                      uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections-lead/{title}
                 /v1/sections-remaining/{title}:
                   get:
                     backend_request:
-                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections-remaining/{title}
+                      uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections-remaining/{title}
                 /v1/text/{title}:
                   get:
                     backend_request:
-                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-text/{title}
+                      uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-text/{title}
 
       /{module:page_save}:
         x-modules:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -119,7 +119,6 @@ templates:
                   get:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
-                      body: '{$.request.body}'
 
       /{module:mobileapps}:
         x-modules:
@@ -128,14 +127,26 @@ templates:
             type: file
             options:
               paths:
-                /v1/std/html/{title}:
+                /v1/html/{title}:
                   get:
                     backend_request:
-                      uri: http://appservice.wmflabs.org/{domain}/v1/mobile/app/page/html/{title}
-                /v1/lite/{title}:
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html/{title}
+                /v1/sections/{title}:
                   get:
                     backend_request:
-                      uri: http://appservice.wmflabs.org/{domain}/v1/mobile/app/page/lite/{title}
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections/{title}
+                /v1/sections-lead/{title}:
+                  get:
+                    backend_request:
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections-lead/{title}
+                /v1/sections-remaining/{title}:
+                  get:
+                    backend_request:
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections-remaining/{title}
+                /v1/text/{title}:
+                  get:
+                    backend_request:
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-text/{title}
 
       /{module:page_save}:
         x-modules:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -112,7 +112,6 @@ templates:
                   get:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/en.wikipedia.org/v1/png/{title}/{revision}/{graph_id}
-                      body: '{$.request.body}'
 
       /{module:mobileapps}:
         x-modules:
@@ -121,14 +120,26 @@ templates:
             type: file
             options:
               paths:
-                /v1/std/html/{title}:
+                /v1/html/{title}:
                   get:
                     backend_request:
-                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/mobile/app/page/html/{title}
-                /v1/lite/{title}:
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html/{title}
+                /v1/sections/{title}:
                   get:
                     backend_request:
-                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/mobile/app/page/lite/{title}
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections/{title}
+                /v1/sections-lead/{title}:
+                  get:
+                    backend_request:
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections-lead/{title}
+                /v1/sections-remaining/{title}:
+                  get:
+                    backend_request:
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections-remaining/{title}
+                /v1/text/{title}:
+                  get:
+                    backend_request:
+                      uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-text/{title}
 
       /{module:action}:
         x-modules:

--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -3,7 +3,7 @@
 swagger: 2.0
 
 paths:
-  /{module:page}/mobile-html-full/{title}:
+  /{module:page}/mobile-html/{title}:
     get:
       tags:
         - Page content
@@ -33,7 +33,7 @@ paths:
           schema:
             $ref: '#/definitions/problem'
       x-backend-request:
-        uri: /{domain}/sys/mobileapps/v1/std/html/{title}
+        uri: /{domain}/sys/mobileapps/v1/html/{title}
       x-monitor: true
       x-amples:
         - title: Get MobileApps Main Page
@@ -45,7 +45,104 @@ paths:
             headers:
               content-type: /text\/html/
             body: /body/
-  /{module:page}/mobile-json-lite/{title}:
+  /{module:page}/mobile-html-sections/{title}:
+    get:
+      tags:
+        - Page content
+        - Mobile
+      description: >
+        Retrieve the latest HTML for a page title optimised for viewing with
+        native mobile applications. Note that the output is split by sections.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
+      produces:
+        - application/json
+      parameters:
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The HTML for the given page title.
+        '404':
+          description: Unknown page title
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/mobileapps/v1/sections/{title}
+      x-monitor: false
+  /{module:page}/mobile-html-sections-lead/{title}:
+    get:
+      tags:
+        - Page content
+        - Mobile
+      description: >
+        Retrieve the lead section of the latest HTML for a page title optimised
+        for viewing with native mobile applications.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
+      produces:
+        - application/json
+      parameters:
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The HTML for the given page title.
+        '404':
+          description: Unknown page title
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/mobileapps/v1/sections-lead/{title}
+      x-monitor: false
+  /{module:page}/mobile-html-sections-remaining/{title}:
+    get:
+      tags:
+        - Page content
+        - Mobile
+      description: >
+        Retrieve the remainder of the latest HTML (without the lead section) for
+        a page title optimised for viewing with native mobile applications,
+        provided as a JSON object containing the sections.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
+      produces:
+        - application/json
+      parameters:
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The HTML for the given page title.
+        '404':
+          description: Unknown page title
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/mobileapps/v1/sections-remaining/{title}
+      x-monitor: false
+  /{module:page}/mobile-text/{title}:
     get:
       tags:
         - Page content
@@ -75,17 +172,5 @@ paths:
           schema:
             $ref: '#/definitions/problem'
       x-backend-request:
-        uri: /{domain}/sys/mobileapps/v1/lite/{title}
+        uri: /{domain}/sys/mobileapps/v1/text/{title}
       x-monitor: false
-#      x-amples:
-#        - title: Get MobileApps Lite Main Page
-#          request:
-#            params:
-#              title: Main_Page
-#          response:
-#            status: 200
-#            headers:
-#              content-type: /application\/json/
-#            body:
-#              revision: /.+/
-#              displaytitle: /.+/


### PR DESCRIPTION
We have settled on the following routes for the MobileApps service:
- `/page/mobile-html`
- `/page/mobile-html-sections`
- `/page/mobile-html-sections-lead`
- `/page/mobile-html-sections-remaining`
- `/page/mobile-text`

The content specification and configuration files have been changed accordingly.

Bug: [T102130](https://phabricator.wikimedia.org/T102130)
Bug: [T102270](https://phabricator.wikimedia.org/T102270)
Bug: [T104719](https://phabricator.wikimedia.org/T104719)