### PR TITLE
Hook up Mathoid in RESTBase

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,6 +44,7 @@ templates:
       - mediawiki/v1/content
       - mediawiki_v1_graphoid
       - mediawiki/v1/mobileapps
+      - mediawiki/v1/mathoid
     # - mediawiki/v1/revision-scoring
 
   wmf-sys-1.0.0: &wp/sys/1.0.0
@@ -119,6 +120,22 @@ templates:
                   get:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
+
+      /{module:mathoid}:
+        x-modules:
+          - name: simple_service
+            version: 1.0.0
+            type: file
+            options:
+              paths:
+                /v1/{format}/{formula}/{type}:
+                  get:
+                    backend_request:
+                      method: post
+                      uri: http://mathoid-tester.wmflabs.org/{format}
+                      body:
+                        q: '{$.request.params.formula}'
+                        type: '{$.request.params.type}'
 
       /{module:mobileapps}:
         x-modules:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -43,6 +43,7 @@ templates:
       - mediawiki/v1/content
       - mediawiki_v1_graphoid
       - mediawiki/v1/mobileapps
+      - mediawiki/v1/mathoid
       - test
 
   wmf-sys-1.0.0: &wp/sys/1.0.0
@@ -112,6 +113,22 @@ templates:
                   get:
                     backend_request:
                       uri: http://graphoid.wikimedia.org/en.wikipedia.org/v1/png/{title}/{revision}/{graph_id}
+
+      /{module:mathoid}:
+        x-modules:
+          - name: simple_service
+            version: 1.0.0
+            type: file
+            options:
+              paths:
+                /v1/{format}/{formula}/{type}:
+                  get:
+                    backend_request:
+                      method: post
+                      uri: http://mathoid-tester.wmflabs.org/{format}
+                      body:
+                        q: '{$.request.params.formula}'
+                        type: '{$.request.params.type}'
 
       /{module:mobileapps}:
         x-modules:

--- a/specs/mediawiki/v1/mathoid.yaml
+++ b/specs/mediawiki/v1/mathoid.yaml
@@ -1,0 +1,105 @@
+# Mathoid - math formula rendering service
+
+swagger: 2.0
+
+paths:
+  /{module:media}/math/{format}/{formula}:
+    get:
+      tags:
+        - Media
+        - Math
+      description: >
+        Renders a TeX formula into its mathematic representation in the given format.
+        Available formats are svg, json and mml.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
+      produces:
+        - image/svg+xml
+        - application/mathml+xml
+        - application/json
+      parameters:
+        - name: format
+          in: path
+          description: The output format; can be svg, json or mml
+          type: string
+          required: true
+        - name: formula
+          in: path
+          description: The URI-encoded formula to render
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The rendered formula
+        '400':
+          description: Invalid format or type
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/mathoid/v1/{format}/{formula}/tex
+      x-monitor: true
+      x-amples:
+        - title: Mathoid - test formula
+          request:
+            params:
+              format: json
+              formula: E=mc^2
+          response:
+            status: 200
+            headers:
+              content-type: /^application\/json/
+            body:
+              svg: /.+/
+              mml: /.+/
+              success: true
+  /{module:media}/math/{format}/{formula}/{type}:
+    get:
+      tags:
+        - Media
+        - Math
+      description: >
+        Renders a formula into its mathematic representation in the given format.
+        Available formats are svg, json and mml. Accepted values for type include
+        inline-tex, mml and ascii.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
+      produces:
+        - image/svg+xml
+        - application/mathml+xml
+        - application/json
+      parameters:
+        - name: format
+          in: path
+          description: The output format; can be svg, json or mml
+          type: string
+          required: true
+        - name: formula
+          in: path
+          description: The URI-encoded formula to render
+          type: string
+          required: true
+        - name: type
+          in: path
+          description: >
+            The type to use to interpret the formula;
+            can be tex, inline-tex, mml and ascii
+          type: string
+          required: false
+      responses:
+        '200':
+          description: The rendered formula
+        '400':
+          description: Invalid format or type
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/mathoid/v1/{format}/{formula}/{type}
+      x-monitor: false


### PR DESCRIPTION
This PR adds the public API end-points and the back-end module definition for proxying calls to Mathoid - the math rendering service.

Two public routes are added:
- `/media/math/{format}/{formula}`
- `/media/math/{format}/{formula}/{type}`

The first renders a formula given in TeX format into the specified format, while the latter allows a client to specify the input type as well.

Note: depends on #302 since they modify the same files.

Bug: [T102030](https://phabricator.wikimedia.org/T102030)