### PR TITLE
Added support for http HEAD method

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -39,6 +39,7 @@ function RESTBase(options, req) {
         this._recursionDepth = par._recursionDepth + 1;
         this._priv = par._priv;
         this.rb_config = this._priv.options.conf;
+        this._rootReq = par._rootReq || req;
     } else {
         // Brand new instance
         this.log = options.log; // Logging method
@@ -65,6 +66,7 @@ function RESTBase(options, req) {
 
         this.rb_config = options.conf;
         this.rb_config.user_agent = this.rb_config.user_agent || 'RESTBase';
+        this._rootReq = null;
     }
 
 }
@@ -242,10 +244,14 @@ RESTBase.prototype._request = function(req) {
 
     var match = priv.router.route(childReq.uri);
     var methods = match && match.value && match.value.methods;
-    var handler = methods && (methods[childReq.method] || methods.all);
-    if (childReq.method === 'head' && !handler) {
+    var handler = methods && (
+            (self._rootReq && self._rootReq.method === 'head' && methods.head)
+            || methods[childReq.method]
+            || methods.all);
+    if (!handler &&
+            (req.method === 'head'
+            || self._rootReq && self._rootReq.method === 'head')) {
         handler = methods && methods.get;
-        childReq.method = 'get';
     }
 
     if (match && !handler

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -243,6 +243,10 @@ RESTBase.prototype._request = function(req) {
     var match = priv.router.route(childReq.uri);
     var methods = match && match.value && match.value.methods;
     var handler = methods && (methods[childReq.method] || methods.all);
+    if (childReq.method === 'head' && !handler) {
+        handler = methods && methods.get;
+        childReq.method = 'get';
+    }
 
     if (match && !handler
             && childReq.method === 'get'

--- a/lib/server.js
+++ b/lib/server.js
@@ -108,6 +108,11 @@ function handleResponse(opts, req, resp, response) {
             response.body = body;
         }
 
+        if (req.method === 'head') {
+            delete response.headers['content-length'];
+            delete response.body;
+        }
+
         if (response.body) {
             body = response.body;
             // Convert to a buffer
@@ -161,7 +166,7 @@ function handleResponse(opts, req, resp, response) {
 
         response.headers['content-type'] = 'application/problem+json';
         resp.writeHead(response.status || 500, '', response.headers);
-        resp.end(JSON.stringify({
+        resp.end(req.method === 'head' ? undefined : JSON.stringify({
             type: 'https://restbase.org/errors/no_content',
             title: 'RESTBase error: No content returned by backend.',
             uri: req.url,

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -258,4 +258,15 @@ describe('router - misc', function() {
         });
         assert.deepEqual(result.uri, new URI('en.wikipedia.org/path1/test1/test2/test3', {}, false));
     });
+
+    it('should truncate body upon HEAD request', function() {
+        return preq.head({
+            uri: server.config.bucketURL + '/html/1912'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-length'], undefined);
+            assert.deepEqual(res.body, '');
+        })
+    })
 });


### PR DESCRIPTION
If the HEAD request comes, we check for a handler, and if it's not found, check for a GET handler and run a request. Upon response - remove the body and content-length headers.