### PR TITLE
Added tests agains MW API agains test & test2 wikis

### DIFF
--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -11,7 +11,7 @@ var pagingToken = '';
 function generateTests(options) {
 
     var apiRequestTemplate = server.config.conf.templates['wmf-sys-1.0.0']
-                .paths['/{module:action}']['x-modules'][0]['options']['apiRequest'];
+                ['paths']['/{module:action}']['x-modules'][0]['options']['apiRequest'];
     var prevUri = apiRequestTemplate.uri;
     var prevHost = apiRequestTemplate.headers.host;
 

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -11,13 +11,12 @@ var pagingToken = '';
 function generateTests(options) {
 
     var apiRequestTemplate = server.config.conf.templates['wmf-sys-1.0.0']
-                .paths['/{module:action}']['x-modules'][0]
-                .options.apiRequest;
+                .paths['/{module:action}']['x-modules'][0]['options']['apiRequest'];
     var prevUri = apiRequestTemplate.uri;
     var prevHost = apiRequestTemplate.headers.host;
 
     before(function () {
-        apiRequestTemplate.uri = 'http://' + options.apiDomain + '/w/api.php';
+        apiRequestTemplate.uri = 'https://' + options.apiDomain + '/w/api.php';
         apiRequestTemplate.headers.host = options.apiDomain;
         return server.start();
     });

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -44,13 +44,14 @@ config.conf.logging = {
 };
 
 var stop    = function () {};
+var isRunning;
 var options = null;
 var runner = new ServiceRunner();
 
 function start(_options) {
     _options = _options || {};
 
-    if (!assert.isDeepEqual(options, _options)) {
+    if (!assert.isDeepEqual(options, _options) || !isRunning) {
         console.log('server options changed; restarting');
         stop();
         options = _options;
@@ -61,9 +62,11 @@ function start(_options) {
         return runner.run(config.conf)
         .then(function(servers){
             var server = servers[0];
+            isRunning = true;
             stop =
                 function () {
                     console.log('stopping restbase');
+                    isRunning = false;
                     server.close();
                     stop = function () {};
                 };
@@ -76,4 +79,5 @@ function start(_options) {
 
 module.exports.config = config;
 module.exports.start  = start;
+module.exports.stop   = function() { stop() };
 module.exports.loadConfig = loadConfig;


### PR DESCRIPTION
We need to perform tests related to MW API against test.wikipedia.org & test2.wikipedia.org too, as they contain newer versions of the API. 

I've chosen revisions tests and page_save tests and the work with MW API the most. Ideas which other tests to include are very welcome. 

2 tests in page_save are excluded, because they fail against test.wikipedia.org which is returning 'This action has been automatically identified as harmful.' Need to resolve it, but better do it separately.

Bug: https://phabricator.wikimedia.org/T103104