### PR TITLE
Don't perform expensive no-cache instance tests

### DIFF
--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -104,23 +104,23 @@ paths:
           if-unmodified-since: '{if-unmodified-since}'
       x-monitor: true
       x-amples:
-        - title: Get rev of by title from MW
-          request:
-            params:
-              title: Foobar
-            headers:
-              cache-control: no-cache
-          response:
-            status: 200
-            headers:
-              etag: /.+/
-              content-type: application/json
-            body:
-              items:
-                - title: 'Foobar'
-                  rev: /\d+/
-                  tid: /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
-                  comment: /.*/
+        #- title: Get rev of by title from MW
+        #  request:
+        #    params:
+        #      title: Foobar
+        #    headers:
+        #      cache-control: no-cache
+        #  response:
+        #    status: 200
+        #    headers:
+        #      etag: /.+/
+        #      content-type: application/json
+        #    body:
+        #      items:
+        #        - title: 'Foobar'
+        #          rev: /\d+/
+        #          tid: /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+        #          comment: /.*/
         - title: Get rev by title from storage
           request:
             params:
@@ -263,18 +263,22 @@ paths:
           sections: '{sections}'
       x-monitor: true
       x-amples:
-        - title: Get html by title from Parsoid
-          request:
-            params:
-              title: Foobar
-            headers:
-              cache-control: no-cache
-          response:
-            status: 200
-            headers:
-              etag: /.+/
-              content-type: /^text\/html.+/
-            body: /^<!DOCTYPE html>.*/
+        # FIXME: This depends on our 'no change' detection optimization to
+        # avoid filling up storage with re-renders. We have plenty of data on
+        # Parsoid backend requests, so there shouldn't be a need to test this
+        # per-instance.
+        #- title: Get html by title from Parsoid
+        #  request:
+        #    params:
+        #      title: Foobar
+        #    headers:
+        #      cache-control: no-cache
+        #  response:
+        #    status: 200
+        #    headers:
+        #      etag: /.+/
+        #      content-type: /^text\/html.+/
+        #    body: /^<!DOCTYPE html>.*/
         - title: Get html by title from storage
           request:
             params:


### PR DESCRIPTION
While doing some latency testing I noticed that the title Foobar was really
slow to load (500ms). I eventually traced this down to many thousands of
revision entries (possibly hundreds of thousands), which are caused by x-ample
tests forcing revision refreshes with no-cache.

Looking at the config, I found another x-ample that continuously re-renders
Foobar's HTML. This only avoided filling up revision storage as the content of
Foobar does not change much between renders, and we have implemented an
optimization that avoids storing unchanged revisions.

In both cases, there is really not much of a point in testing re-renders
separately for each instance. We have plenty of data on backend connections
that we can set alerts on. Having RESTBase alerts go off when the Action API
is in trouble is confusing, which is the last thing we need when things aren't
working so well.