### PR TITLE
Updated spec to be supported in newer swagger-ui

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -21,9 +21,9 @@ function staticServe(restbase, req) {
                         '<title>RESTBase docs</title>')
                 // Replace the default url with ours, switch off validation &
                 // limit the size of documents to apply syntax highlighting to
-                .replace(/sorter *: "alpha"/, 'sorter: "alpha", ' +
-                    'url: "?spec", validatorUrl: null, ' +
-                    'highlightSizeThreshold: 10000, docExpansion: "list",');
+                .replace(/Sorter: "alpha"/, 'Sorter: "alpha", ' + 'validatorUrl: null, ' +
+                    'highlightSizeThreshold: 10000, docExpansion: "list"')
+                .replace(/ url: url,/, 'url: "?spec",');
         }
 
         var contentType = 'text/html';

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -213,8 +213,8 @@ paths:
       tags:
         - Page content
       description: >
-        Retrieve the latest html for a page title. 
-        
+        Retrieve the latest html for a page title.
+
         If you know the revision as well, then please use the
         `{title}/{revision}` end point instead for better performance.
 
@@ -837,8 +837,7 @@ paths:
           required: true
       responses:
         '200':
-          description: The transformed wikitext
-          schema: 'text/plain'
+          description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec
         '403':
           description: Access to the specific revision is restricted
           schema:
@@ -893,7 +892,7 @@ paths:
           required: false
       responses:
         '200':
-          schema: 'https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec'
+          description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec
         '403':
           description: access to the specific revision is restricted
           schema:
@@ -961,7 +960,7 @@ paths:
           required: false
       responses:
         '200':
-          schema: 'https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec'
+          description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec
         '403':
           description: access to the specific revision is restricted
           schema:
@@ -1011,7 +1010,7 @@ paths:
           required: true
       responses:
         '200':
-          schema: 'https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec'
+          description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec
         '400':
           description: Illegal JSON provided or section id does not exist
           schema:
@@ -1056,7 +1055,7 @@ definitions:
     properties:
       items:
         type: array
-        properties:
+        items:
           revision:
             type: integer
             format: int32
@@ -1101,7 +1100,7 @@ definitions:
             type: string
           page_id:
             type: integer
-            format: int32            
+            format: int32
           rev:
             type: integer
             format: int32
@@ -1136,5 +1135,4 @@ definitions:
           timestamp:
             type: timestamp
           redirect:
-            type: boolean  
-
+            type: boolean


### PR DESCRIPTION
Mobileapps routes has been added recently, we've hit a swagger bug there, so it was decided to upgrade our swagger-ui fork from upstream. 

Now a complete mess of forks and branches begin:
1. A branch with an upgraded swagger-ui is [here](https://github.com/wikimedia/swagger-ui/tree/us) but it's not mergeable with master, because it was made by reset to forks `HEAD~4` (undo all stuff in fork, because it's not needed any more), pull upstream up to [the latest commit](https://github.com/swagger-api/swagger-ui/commit/8e72906c911a02853b87f5241d157e83e2bf7377) to the latest 2.1.1 release, and a new commit, that uses our [new fork for swagger-js](https://github.com/wikimedia/swagger-js), because the functionality we need to patch is now in that lib. This PR is not mergable, I could either make mergable by adding reverse patches, or just rewrite master with -F, alternatively we could point to the newer brunch.
2. Restbase docs spec was a little bit wrong and wasn't parable by newer version, so a couple of simple fixes added, also our dynamic overrides needed to be patched a little bit
3. The desired functionality, that was added to [the fork](https://github.com/wikimedia/swagger-ui/pull/1), now moved [here](https://github.com/wikimedia/swagger-js/pull/1)

Sorry, it's a complete mess of PRs, repos and forks, but swagger guys moved the functionality we need to patch deeper, so now we have 2 levels of forks, but all works really well now. 

Bug: https://phabricator.wikimedia.org/T109311