### PR TITLE
Add example config for local wikis

### DIFF
--- a/config.example.localhost.yaml
+++ b/config.example.localhost.yaml
@@ -1,0 +1,116 @@
+# RESTBase config for small wiki installs
+#
+# - sqlite backend
+# - parsoid at http://localhost:8142
+# - wiki at http://localhost/w/api.php
+# 
+# Quick setup:
+# - npm install
+#   If you see errors about sqlite, you might have to `apt-get install
+#   libsqlite3-dev`.
+# - cp config.example.localhost.yaml config.yaml
+# - double-check and possibly modify lines marked with XXX, then start restbase with
+#
+#   node server
+#
+# - If all went well, http://localhost:7231/localhost/v1/page/html/Main_Page
+# should show your wiki's [[Main Page]].
+
+
+info:
+  name: restbase
+
+templates:
+  # The public API is defined here.
+  wmf-content-1.0.0: &wp/content/1.0.0
+    swagger: '2.0'
+    info:
+      version: 1.0.0-beta
+      title: Wikimedia REST API
+      description: Welcome to your RESTBase API.
+    x-subspecs:
+      # Pull in the default REST content API spec.
+      - mediawiki/v1/content
+
+  # The internal storage modules and services under /sys/ are defined here.
+  wmf-sys-1.0.0: &wp/sys/1.0.0
+    info:
+      title: Default MediaWiki sys API module
+    paths:
+      /{module:table}:
+        x-modules:
+          # There can be multiple modules too per stanza, as long as the
+          # exported symbols don't conflict. The operationIds from the spec
+          # will be resolved against all of the modules.
+          - name: restbase-mod-table-sqlite
+            type: npm
+            options:
+              conf:
+                dbname: db.sqlite3
+                pool_idle_timeout: 20000
+                retry_delay: 250
+                retry_limit: 10
+                show_sql: false
+
+      /{module:page_revisions}:
+        x-modules:
+            - name: page_revisions
+              version: 1.0.0
+              type: file
+
+      /{module:key_rev_value}:
+        x-modules:
+          - name: key_rev_value
+            version: 1.0.0
+            type: file
+
+      /{module:parsoid}:
+        x-modules:
+          - name: parsoid
+            version: 1.0.0
+            type: file
+            options:
+              # Default for Parsoid installed from the Debian package:
+              parsoidHost: http://localhost:8142
+              # XXX: For local testing using the git checkout, use:
+              # parsoidHost: http://localhost:8000
+
+      /{module:action}:
+        x-modules:
+          - name: action
+            type: file
+            options:
+              apiRequest:
+                method: post
+                # XXX: double-check the API URI:
+                uri: 'http://localhost/w/api.php'
+                body: '{$.request.body}'
+
+spec: &spec
+  title: "The RESTBase root"
+  # Some more general RESTBase info
+  paths:
+    /{domain:localhost}:
+      x-subspecs:
+        - paths:
+            # Mount the content API at /localhost/v1/
+            /{api:v1}:
+              x-subspec: *wp/content/1.0.0
+        - paths:
+            # Mount the internal modules at /localhost/sys/
+            /{api:sys}:
+              x-subspec: *wp/sys/1.0.0
+
+services:
+  - name: restbase
+    module: ./lib/server
+    conf: 
+      port: 7231
+      spec: *spec
+      salt: secret
+      default_page_size: 250
+      user_agent: RESTBase
+
+logging:
+  name: restbase
+  level: info


### PR DESCRIPTION
Add an example config for typical local RESTBase installs:

- use `http://localhost/w/api.php` as the API URI
- use `localhost` as the domain
- use `http://localhost:8142/` as the parsoid url (matching the Debian
  package, plus a comment about using port 8000 if using a git checkout)
- configure the sqlite backend

Task: https://phabricator.wikimedia.org/T109669