### PR TITLE
Quote the profile in content-type headers

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -263,9 +263,9 @@ services:
 
 test:
   content_types:
-    html: text/html;profile=mediawiki.org/specs/html/1.1.0;charset=utf-8
-    data-parsoid: application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1;charset=utf-8
-    wikitext: text/plain;profile=mediawiki.org/specs/wikitext/1.0.0;charset=utf-8
+    html: text/html;profile="mediawiki.org/specs/html/1.1.0";charset=utf-8
+    data-parsoid: application/json;profile="mediawiki.org/specs/data-parsoid/0.0.1"
+    wikitext: text/plain;profile="mediawiki.org/specs/wikitext/1.0.0";charset=utf-8
 
 logging:
   name: restbase

--- a/doc/HandlerConfiguration.md
+++ b/doc/HandlerConfiguration.md
@@ -18,7 +18,7 @@ Example for a bucket handler:
       default:
         description: Unexpected error
         schema: { $ref: Error }
-    produces: text/html;profile=mw.org/specs/html/1.0
+    produces: text/html;profile="mw.org/specs/html/1.0"
 
     request_handler:
     - if:
@@ -63,8 +63,8 @@ Example for a bucket handler:
         schema: { $ref: Error }
     consumes:
       - text/html
-      - text/html;profile=mediawiki.org/specs/html/1.0
-      - application/json;profile=mediawiki.org/specs/pagebundle/1.0
+      - text/html;profile="mediawiki.org/specs/html/1.0"
+      - application/json;profile="mediawiki.org/specs/pagebundle/1.0"
 
     request_handler:
     - send_request: 
@@ -80,7 +80,7 @@ Example for a bucket handler:
       - if:
           response.status: 200
           response.headers:
-            content-type: application/json;profile=mw.org/spec/requests
+            content-type: application/json;profile="mw.org/spec/requests"
           # The backend service returned a JSON structure containing a request
           # structure (a HTTP transaction). Execute it & return the response.
         then:

--- a/doc/Transactions.md
+++ b/doc/Transactions.md
@@ -18,7 +18,7 @@ The collection of requests is encoded as JSON, reusing the request spec above:
     uri: '/v1/en.wikipedia.org/transactions/<timeuuid>',
     headers: {
         'Content-type':
-            'application/json;profile=https://mediawiki.org/schema/transaction',
+            'application/json;profile="https://mediawiki.org/schema/transaction"',
         // Precondition for the entire transaction for idempotency
         // tids older than the normal transaction entry lifetime are rejected
         'If-None-Match': '*'
@@ -41,7 +41,7 @@ The collection of requests is encoded as JSON, reusing the request spec above:
                 headers: {
                     'if-match': '<uuid>',
                     'content-type':
-                      'application/json;profile=https://mediawiki.org/specs/foo'
+                      'application/json;profile="https://mediawiki.org/specs/foo"'
                 },
                 // Objects implicitly serialized to JSON
                 body: {..}
@@ -70,7 +70,7 @@ The response mirrors the structure of the request object:
     status: 200, -- status of primary request
     headers: {
         'Content-Type':
-            'application/json;profile=http://mediawiki.org/schema/transaction_response'
+            'application/json;profile="http://mediawiki.org/schema/transaction_response"'
     },
     body: {
         status: 200,

--- a/doc/development/README.md
+++ b/doc/development/README.md
@@ -37,13 +37,13 @@ First, let's identify a feature to be developed.  For this example, we'll choose
 >         revid: 12345, // The original revision ID
 >         html: {
 >             headers: {
->                 'content-type': 'text/html;profile=mediawiki.org/specs/html/1.0.0'
+>                 'content-type': 'text/html;profile="mediawiki.org/specs/html/1.0.0"'
 >             },
 >             body: "the original HTML"
 >         }
 >         'data-parsoid': {
 >             headers: {
->                 'content-type': 'application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1'
+>                 'content-type': 'application/json;profile="mediawiki.org/specs/data-parsoid/0.0.1"'
 >             },
 >             body: {}
 >         }
@@ -70,7 +70,7 @@ The user should then expect a response as described above.  Let's [verify the re
 assert.deepEqual(res.status, 200);
 assert.deepEqual(localRequestsOnly(slice), false);
 assert.deepEqual(wentToParsoid(slice), true);
-assert.deepEqual(res.headers['content-type'], 'text/html;profile=mediawiki.org/specs/html/1.0.0');
+assert.deepEqual(res.headers['content-type'], 'text/html;profile="mediawiki.org/specs/html/1.0.0"');
 assert.deepEqual(/^<!DOCTYPE html>/.test(res.body), true);
 assert.deepEqual(/<\/html>$/.test(res.body), true);
 ```

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -234,7 +234,7 @@ paths:
           description: Comma-separated list of section IDs
           type: string
       produces:
-        - text/html; profile=mediawiki.org/specs/html/1.1.0
+        - text/html; profile="mediawiki.org/specs/html/1.1.0"
       responses:
         '200':
           description: >
@@ -414,7 +414,7 @@ paths:
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       operationId: getFormatRevision
       produces:
-        - text/html; profile=mediawiki.org/specs/html/1.1.0
+        - text/html; profile="mediawiki.org/specs/html/1.1.0"
       parameters:
         - name: title
           in: path
@@ -818,7 +818,7 @@ paths:
       consumes:
         - multipart/form-data
       produces:
-        - text/plain; profile=mediawiki.org/specs/wikitext/1.0.0
+        - text/plain; profile="mediawiki.org/specs/wikitext/1.0.0"
       parameters:
         - name: title
           in: path
@@ -868,7 +868,7 @@ paths:
       consumes:
         - multipart/form-data
       produces:
-        - text/html; profile=mediawiki.org/specs/html/1.1.0
+        - text/html; profile="mediawiki.org/specs/html/1.1.0"
       parameters:
         - name: title
           in: path
@@ -936,7 +936,7 @@ paths:
       consumes:
         - multipart/form-data
       produces:
-        - text/html; profile=mediawiki.org/specs/html/1.1.0
+        - text/html; profile="mediawiki.org/specs/html/1.1.0"
       parameters:
         - name: title
           in: path
@@ -991,7 +991,7 @@ paths:
       consumes:
         - multipart/form-data
       produces:
-        - text/html; profile=mediawiki.org/specs/html/1.1.0
+        - text/html; profile="mediawiki.org/specs/html/1.1.0"
       parameters:
         - name: title
           in: path

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -245,7 +245,7 @@ describe('storage-backed transform api', function() {
             headers: { 'content-type': 'application/json' },
             body: {
                 headers: {
-                  'content-type': 'text/html;profile=mediawiki.org/specs/html/1.0.0'
+                  'content-type': 'text/html;profile="mediawiki.org/specs/html/1.0.0"'
                 },
                 body: '<html>The modified HTML</html>'
             }
@@ -255,7 +255,7 @@ describe('storage-backed transform api', function() {
             assert.deepEqual(res.body, {
                 wikitext: {
                     headers: {
-                        'content-type': 'text/plain;profile=mediawiki.org/specs/wikitext/1.0.0'
+                        'content-type': 'text/plain;profile="mediawiki.org/specs/wikitext/1.0.0"'
                     },
                     body: 'The modified HTML'
                 }

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -96,7 +96,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: text/html;profile=mediawiki.org/specs/html/1.1.0
+                content-type: text/html;profile="mediawiki.org/specs/html/1.1.0"
 
   /{domain}/v1/page/html/{title}/{revision}:
     get:
@@ -147,7 +147,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: text/html;profile=mediawiki.org/specs/html/1.1.0
+                content-type: text/html;profile="mediawiki.org/specs/html/1.1.0"
 
   /{domain}/v1/page/data-parsoid/{title}/{revision}:
     get:
@@ -198,7 +198,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: application/json;profile=mediawiki.org/specs/data-parsoid/0.0.1
+                content-type: application/json;profile="mediawiki.org/specs/data-parsoid/0.0.1"
 definitions:
   defaultError:
     required:


### PR DESCRIPTION
According to RFC 7231 section 3.1.1, parameter values are either tokens or quoted strings.  The forward-slash character ("/") is not allowed in a token (defined in RFC 7230, section 3.2.6).  We need to make the parameter value a quoted string.

This parsing restriction is actually enforced by the npm `content-type` module (version 1.0.1) which is used by Express 4.x to manipulate content type headers.  The unmodified content-type causes an exception to be thrown.

See also: https://gerrit.wikimedia.org/r/233188