### PR TITLE
Support $.request.hash template

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -83,7 +83,17 @@ function compileTemplate(templateSpec, setValue, reqPart) {
     // Special case - lazy-evaluation of a request hash property
     if (templateSpec === '{$.request.hash}') {
         return function(newReq, context) {
+            // Need to remove x-request-id header if it's present
+            var reqId = context.request.headers && context.request.headers['x-request-id'];
+            if (reqId) {
+                delete context.request.headers['x-request-id'];
+            }
+
             setValue(newReq, sha1(stringify(context.request)));
+
+            if (reqId) {
+                context.request.headers['x-request-id'] = reqId;
+            }
         };
     }
 

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -4,6 +4,8 @@ var URI = require('swagger-router').URI;
 var rbUtil = require('./rbUtil');
 var TAssembly = require('tassembly');
 var url = require('url');
+var sha1 = require('sha1');
+var stringify = require('json-stable-stringify');
 
 /**
  * Creates a function that sets a value at the path
@@ -77,6 +79,14 @@ function prepareTemplateString(template, defaultLookupPath) {
 function compileTemplate(templateSpec, setValue, reqPart) {
     var template;
     var prevIndex = 0;
+
+    // Special case - lazy-evaluation of a request hash property
+    if (templateSpec === '{$.request.hash}') {
+        return function(newReq, context) {
+            setValue(newReq, sha1(stringify(context.request)));
+        };
+    }
+
     var completeTemplate = /^\{([^}]+)}$/.exec(templateSpec);
     if (completeTemplate && completeTemplate.length > 0) {
         template = [['raw', prepareTemplateString(completeTemplate[1], reqPart)]];

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -80,23 +80,6 @@ function compileTemplate(templateSpec, setValue, reqPart) {
     var template;
     var prevIndex = 0;
 
-    // Special case - lazy-evaluation of a request hash property
-    if (templateSpec === '{$.request.hash}') {
-        return function(newReq, context) {
-            // Need to remove x-request-id header if it's present
-            var reqId = context.request.headers && context.request.headers['x-request-id'];
-            if (reqId) {
-                delete context.request.headers['x-request-id'];
-            }
-
-            setValue(newReq, sha1(stringify(context.request)));
-
-            if (reqId) {
-                context.request.headers['x-request-id'] = reqId;
-            }
-        };
-    }
-
     var completeTemplate = /^\{([^}]+)}$/.exec(templateSpec);
     if (completeTemplate && completeTemplate.length > 0) {
         template = [['raw', prepareTemplateString(completeTemplate[1], reqPart)]];
@@ -179,6 +162,21 @@ function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
     }
 }
 
+function calculateHash(context) {
+    // Need to remove x-request-id header if it's present
+    var reqId = context.request.headers && context.request.headers['x-request-id'];
+    if (reqId) {
+        delete context.request.headers['x-request-id'];
+    }
+
+    var result = sha1(stringify(context.request));
+
+    if (reqId) {
+        context.request.headers['x-request-id'] = reqId;
+    }
+    return result;
+}
+
 /**
  * Creates a template resolver functuons for URI part of the spec
  * @param {object} spec a root request spec object
@@ -186,7 +184,10 @@ function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
  */
 function createURIResolver(spec) {
     var setter = _setAtPath('uri', spec);
-    if (/^\{[^\{}]+}$/.test(spec.uri)) {
+    if (/^\{[^\{}]+}$/.test(spec.uri)
+            || /\{\$\..+}/.test(spec.uri)) {
+        // Complete URI is templated or absolute reference is used in URI
+        // Switch to a complete URI pass
         var setValue = function(newReq, value) {
             if (value.constructor !== URI) {
                 value = new URI(value, {}, false);
@@ -238,6 +239,7 @@ function Template(spec) {
             return result.val;
         };
     } else {
+        var hashNeeded = false;
         Object.keys(spec).forEach(function(reqPart) {
             var setValue;
             if (reqPart === 'uri') {
@@ -251,7 +253,17 @@ function Template(spec) {
                 self.resolvers = self.resolvers.concat(
                     _createTemplateResolvers(spec, spec[reqPart], reqPart));
             }
+            if (/\{\$\.request\.hash}/.test(JSON.stringify(spec[reqPart]))) {
+                hashNeeded = true;
+            }
         });
+
+        if (hashNeeded) {
+            // Precalculate the hash and put it to request
+            self.resolvers = [function(newReq, context) {
+                context.request.hash = calculateHash(context);
+            }].concat(self.resolvers);
+        }
 
         self._eval = function(context) {
             var newReq = { method: context.request.method };

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -163,16 +163,23 @@ function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
 }
 
 function calculateHash(context) {
+    var req = context.request;
+    // Ensure consistent hashing
+    req.headers = req.headers || {};
+    req.body = req.body || {};
+    req.query = req.query || {};
+    req.params = req.params || {};
+
     // Need to remove x-request-id header if it's present
-    var reqId = context.request.headers && context.request.headers['x-request-id'];
+    var reqId = req.headers && req.headers['x-request-id'];
     if (reqId) {
-        delete context.request.headers['x-request-id'];
+        delete req.headers['x-request-id'];
     }
 
-    var result = sha1(stringify(context.request));
+    var result = sha1(stringify(req));
 
     if (reqId) {
-        context.request.headers['x-request-id'] = reqId;
+        req.headers['x-request-id'] = reqId;
     }
     return result;
 }

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -171,7 +171,7 @@ function calculateHash(context) {
     req.params = req.params || {};
 
     // Need to remove x-request-id header if it's present
-    var reqId = req.headers && req.headers['x-request-id'];
+    var reqId = req.headers['x-request-id'];
     if (reqId) {
         delete req.headers['x-request-id'];
     }

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -226,6 +226,16 @@ function createURIResolver(spec) {
 function Template(spec) {
     var self = this;
     self.resolvers = [];
+
+    // Could have done smarter lookup, but this is run only on startup,
+    // so performance doesn't matter.
+    if (/\{\$\.request\.hash}/.test(stringify(spec))) {
+        // Precalculate the hash and put it to request
+        self.resolvers = [function(newReq, context) {
+            context.request.hash = calculateHash(context);
+        }];
+    }
+
     if (typeof spec === 'string') {
         self.resolvers.push(compileTemplate(spec, function(newReq, val) {
             newReq.val = val;
@@ -239,7 +249,6 @@ function Template(spec) {
             return result.val;
         };
     } else {
-        var hashNeeded = false;
         Object.keys(spec).forEach(function(reqPart) {
             var setValue;
             if (reqPart === 'uri') {
@@ -253,17 +262,7 @@ function Template(spec) {
                 self.resolvers = self.resolvers.concat(
                     _createTemplateResolvers(spec, spec[reqPart], reqPart));
             }
-            if (/\{\$\.request\.hash}/.test(JSON.stringify(spec[reqPart]))) {
-                hashNeeded = true;
-            }
         });
-
-        if (hashNeeded) {
-            // Precalculate the hash and put it to request
-            self.resolvers = [function(newReq, context) {
-                context.request.hash = calculateHash(context);
-            }].concat(self.resolvers);
-        }
 
         self._eval = function(context) {
             var newReq = { method: context.request.method };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "service-runner": "^0.2.0",
     "swagger-router": "^0.1.0",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
-    "tassembly": "^0.1.4"
+    "tassembly": "^0.1.4",
+    "sha1": "^1.1.1",
+    "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master"
   },
   "devDependencies": {
     "bunyan": "^1.4.0",

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -298,6 +298,20 @@ describe('router - misc', function() {
         assert.deepEqual(result2.body, '19a5337cc49833b0923ac4b6d72744bf8e915de9');
     });
 
+    it('should support hash and absolute templates in URI', function() {
+        var template = new Template({
+            uri: '/test/{$.request.hash}/{$.request.headers.host}'
+        });
+        var request = {
+            method: 'post',
+            headers: {
+                'host': 'test'
+            },
+            body: 'a'
+        };
+        assert.deepEqual(template.eval({request:request}).uri,
+            '/test/912e1d7e5cc235315fe41776a0806fbeaed0a582/test');
+    });
     it('should truncate body upon HEAD request', function() {
         return preq.head({
             uri: server.config.bucketURL + '/html/1912'

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -269,7 +269,7 @@ describe('router - misc', function() {
                 body: 'a'
             }
         });
-        assert.deepEqual(result.body, '575bd4981fc14132c40646e6a115e80e8fcb9618');
+        assert.deepEqual(result.body, '5d177fa925d730c6c0f1d776065193c878d976e0');
     });
 
     it('should remove x-request-id header from hash', function() {
@@ -285,7 +285,6 @@ describe('router - misc', function() {
                 body: 'a'
             }
         });
-        assert.deepEqual(result1.body, '19a5337cc49833b0923ac4b6d72744bf8e915de9');
         var result2 = requestTemplate.eval({
             request: {
                 method: 'post',
@@ -295,7 +294,7 @@ describe('router - misc', function() {
                 body: 'a'
             }
         });
-        assert.deepEqual(result2.body, '19a5337cc49833b0923ac4b6d72744bf8e915de9');
+        assert.deepEqual(result2.body, result1.body);
     });
 
     it('should support hash and absolute templates in URI', function() {
@@ -310,7 +309,7 @@ describe('router - misc', function() {
             body: 'a'
         };
         assert.deepEqual(template.eval({request:request}).uri,
-            '/test/912e1d7e5cc235315fe41776a0806fbeaed0a582/test');
+            '/test/31ffc8b0fd1f3f4da9f7cb338b513c5f5168fcea/test');
     });
 
     it('supports hash in string templates', function() {
@@ -323,7 +322,7 @@ describe('router - misc', function() {
             body: 'a'
         };
         assert.deepEqual(template.eval({request:request}),
-            '912e1d7e5cc235315fe41776a0806fbeaed0a582');
+            '31ffc8b0fd1f3f4da9f7cb338b513c5f5168fcea');
     });
 
     it('should truncate body upon HEAD request', function() {

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -265,11 +265,37 @@ describe('router - misc', function() {
         });
         var result = requestTemplate.eval({
             request: {
-                method: 'get',
+                method: 'post',
                 body: 'a'
             }
         });
-        assert.deepEqual(result.body, '9637f2a22955c1371a7eec2582e7a3e2f2361076');
+        assert.deepEqual(result.body, '575bd4981fc14132c40646e6a115e80e8fcb9618');
+    });
+
+    it('should remove x-request-id header from hash', function() {
+        var requestTemplate = new Template({
+            body: '{$.request.hash}'
+        });
+        var result1 = requestTemplate.eval({
+            request: {
+                method: 'post',
+                headers: {
+                    'x-request-id': '10'
+                },
+                body: 'a'
+            }
+        });
+        assert.deepEqual(result1.body, '19a5337cc49833b0923ac4b6d72744bf8e915de9');
+        var result2 = requestTemplate.eval({
+            request: {
+                method: 'post',
+                headers: {
+                    'x-request-id': '11'
+                },
+                body: 'a'
+            }
+        });
+        assert.deepEqual(result2.body, '19a5337cc49833b0923ac4b6d72744bf8e915de9');
     });
 
     it('should truncate body upon HEAD request', function() {

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -312,6 +312,20 @@ describe('router - misc', function() {
         assert.deepEqual(template.eval({request:request}).uri,
             '/test/912e1d7e5cc235315fe41776a0806fbeaed0a582/test');
     });
+
+    it('supports hash in string templates', function() {
+        var template = new Template('{$.request.hash}');
+        var request = {
+            method: 'post',
+            headers: {
+                'host': 'test'
+            },
+            body: 'a'
+        };
+        assert.deepEqual(template.eval({request:request}),
+            '912e1d7e5cc235315fe41776a0806fbeaed0a582');
+    });
+
     it('should truncate body upon HEAD request', function() {
         return preq.head({
             uri: server.config.bucketURL + '/html/1912'

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -259,6 +259,19 @@ describe('router - misc', function() {
         assert.deepEqual(result.uri, new URI('en.wikipedia.org/path1/test1/test2/test3', {}, false));
     });
 
+    it('should support calculating a hash in template', function() {
+        var requestTemplate = new Template({
+            body: '{$.request.hash}'
+        });
+        var result = requestTemplate.eval({
+            request: {
+                method: 'get',
+                body: 'a'
+            }
+        });
+        assert.deepEqual(result.body, '9637f2a22955c1371a7eec2582e7a3e2f2361076');
+    });
+
     it('should truncate body upon HEAD request', function() {
         return preq.head({
             uri: server.config.bucketURL + '/html/1912'
@@ -268,5 +281,5 @@ describe('router - misc', function() {
             assert.deepEqual(res.headers['content-length'], undefined);
             assert.deepEqual(res.body, '');
         })
-    })
+    });
 });


### PR DESCRIPTION
A simple fix to support calculation of `'{$.request.hash}'`  templates to calculate hashes of the request.