### PR TITLE
Made swagger spec more valid

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -223,7 +223,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
     // Process HTTP method stanzas ('get', 'put' etc)
     .then(function() {
         // Register the path in the specRoot
-        if (specRoot && !specRoot.paths[prefixPath]) {
+        if (specRoot && !specRoot.paths[prefixPath] && prefixPath) {
             specRoot.paths[prefixPath] = {};
         }
 

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -14,7 +14,6 @@ info:
 x-default-params:
   domain: en.wikipedia.org
 paths:
-
   /{module:page}/:
     get:
       tags:
@@ -1055,12 +1054,7 @@ definitions:
     properties:
       items:
         type: array
-        items:
-          revision:
-            type: integer
-            format: int32
-          tid:
-            type: string
+        $ref: revisionIdentifier
 
   listing:
     description: The result format for listings
@@ -1095,44 +1089,56 @@ definitions:
         format: int32
       items:
         type: array
+        $ref: revisionInfo
+
+  revisionInfo:
+    properties:
+      title:
+        type: string
+      page_id:
+        type: integer
+        format: int32
+      rev:
+        type: integer
+        format: int32
+      tid:
+        type: string
+      latest_rev:
+        type: integer
+        format: int32
+      latest_tid:
+        type: string
+      nextrev_tid:
+        type: string
+      comment:
+        type: string
+      renames:
+        type: array
         items:
-          title:
-            type: string
-          page_id:
-            type: integer
-            format: int32
-          rev:
-            type: integer
-            format: int32
-          tid:
-            type: string
-          latest_rev:
-            type: integer
-            format: int32
-          latest_tid:
-            type: string
-          nextrev_tid:
-            type: string
-          comment:
-            type: string
-          renames:
-            type: array
-            items:
-              type: string
-          restrictions:
-            type: array
-            items:
-              type: string
-          tags:
-            type: array
-            items:
-              type: string
-          user_id:
-            type: integer
-            format: int32
-          user_text:
-            type: string
-          timestamp:
-            type: timestamp
-          redirect:
-            type: boolean
+          type: string
+      restrictions:
+        type: array
+        items:
+          type: string
+      tags:
+        type: array
+        items:
+          type: string
+      user_id:
+        type: integer
+        format: int32
+      user_text:
+        type: string
+      timestamp:
+        type: string
+        format: date-time
+      redirect:
+        type: boolean
+
+  revisionIdentifier:
+    properties:
+      revision:
+        type: integer
+        format: int32
+      tid:
+        type: string

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -14,6 +14,7 @@ info:
 x-default-params:
   domain: en.wikipedia.org
 paths:
+
   /{module:page}/:
     get:
       tags:
@@ -1092,6 +1093,7 @@ definitions:
         $ref: revisionInfo
 
   revisionInfo:
+    description: Complete information about the revision
     properties:
       title:
         type: string
@@ -1136,6 +1138,7 @@ definitions:
         type: boolean
 
   revisionIdentifier:
+    description: Unique revision identifier
     properties:
       revision:
         type: integer

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -3,13 +3,10 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, it, before, beforeEach, after, afterEach */
 
-var fs = require('fs');
-var yaml = require('js-yaml');
-
 var assert = require('assert');
+var preq   = require('preq');
 var Router = require('../../../lib/router');
-var loadConfig = require('../../utils/server').loadConfig;
-var router = new Router();
+var server = require('../../utils/server');
 
 var rootSpec = {
     paths: {
@@ -166,12 +163,14 @@ var sameModuleAtDifferentPathsSpec = {
     }
 };
 
-var fullSpec = loadConfig('config.example.yaml');
-var fullSpec = loadConfig('config.test.yaml');
+var fullSpec = server.loadConfig('config.example.wikimedia.yaml');
 
 describe('tree building', function() {
 
+    before(function() { server.start(); });
+
     it('should build a simple spec tree', function() {
+        var router = new Router();
         return router.loadSpec(rootSpec)
         .then(function() {
             //console.log(JSON.stringify(router.tree, null, 2));
@@ -184,17 +183,18 @@ describe('tree building', function() {
     });
 
     it('should fail loading a faulty spec', function() {
+        var router = new Router();
         return router.loadSpec(faultySpec)
         .then(function() {
             throw new Error("Should throw an exception!");
         },
-        function(e) {
+        function() {
             // exception thrown as expected
-            return;
         });
     });
 
     it('should build the example config spec tree', function() {
+        var router = new Router();
         var resourceRequests = [];
         return router.loadSpec(fullSpec.spec, {
             request: function(req) {
@@ -202,9 +202,7 @@ describe('tree building', function() {
             }
         })
         .then(function() {
-            //console.log(JSON.stringify(router.tree, null, 2));
             var handler = router.route('/en.wikipedia.test.local/v1/page/html/Foo');
-            //console.log(handler);
             assert.equal(resourceRequests.length > 0, true);
             assert.equal(!!handler.value.methods.get, true);
             assert.equal(handler.params.domain, 'en.wikipedia.test.local');
@@ -213,6 +211,7 @@ describe('tree building', function() {
     });
 
     it('should allow adding methods to existing paths', function() {
+        var router = new Router();
         return router.loadSpec(additionalMethodSpec)
         .then(function() {
             var handler = router.route('/en.wikipedia.test.local/v1/page/Foo/html');
@@ -221,12 +220,13 @@ describe('tree building', function() {
         });
     });
 
-    it('should on overlapping methods on the same path', function() {
-        return router.loadSpec(additionalMethodSpec)
+    it('should error on overlapping methods on the same path', function() {
+        var router = new Router();
+        return router.loadSpec(overlappingMethodSpec)
         .then(function() {
             throw new Error("Should throw an exception!");
         },
-        function(e) {
+        function() {
             // exception thrown as expected
             return;
         });
@@ -238,5 +238,14 @@ describe('tree building', function() {
             var handler = router.route('/en.wikipedia.test.local/v1/page/secure');
             assert.deepEqual(handler.permissions, ['first', 'second', 'third']);
         });
+    });
+
+    it('should not load root-spec params', function() {
+        return preq.get({
+            uri: server.config.baseURL + '/?spec'
+        })
+        .then(function(res) {
+            assert.equal(res.body.paths[''], undefined);
+        })
     });
 });

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -126,43 +126,6 @@ var nestedSecuritySpec = {
     }
 };
 
-var parsoidSpec = {
-    'x-modules': [
-        {
-            name: 'parsoid',
-            version: '1.0.0',
-            type: 'file',
-            options: {
-                parsoidHost: 'http://parsoid-lb.eqiad.wikimedia.org'
-            }
-        }
-    ]
-};
-
-var sameModuleAtDifferentPathsSpec = {
-    paths: {
-        '/{domain:en.wikipedia.org}/v1': {
-            'x-subspecs': [
-                {
-                    paths: {
-                        '/parsoid': parsoidSpec
-                    }
-                }
-            ]
-        },
-        '/{domain:secure.wikipedia.org}/v1': {
-            'x-subspecs': [
-                {
-                    paths: {
-                        '/parsoid': parsoidSpec
-                    }
-                }
-            ],
-            'additions_property': 'test'
-        }
-    }
-};
-
 var fullSpec = server.loadConfig('config.example.wikimedia.yaml');
 
 describe('tree building', function() {
@@ -228,11 +191,11 @@ describe('tree building', function() {
         },
         function() {
             // exception thrown as expected
-            return;
         });
     });
 
     it('should parse permission along the path to endpoint', function() {
+        var router = new Router();
         return router.loadSpec(nestedSecuritySpec)
         .then(function() {
             var handler = router.route('/en.wikipedia.test.local/v1/page/secure');


### PR DESCRIPTION
There is an [online tool](https://github.com/swagger-api/validator-badge) for swagger spec validation. I shows errors on our spec, so in this PR it's made more valid. One of the visible consequences: now the [/page/revision/{revision}](https://rest.wikimedia.org/en.wikipedia.org/v1/?doc#!/Page_content/get_page_revision_revision) endpoint docs correctly show the result items spec. 

Additionally, fixed a small issue in router - it didn't verify, that the 'prefixPath' exist, so all the contents of the spec `info` field ended up in the paths object under `""` key. 

Unfortunately, the spec validator doesn't support optional path elements (e.g. `{/tid}`), so our spec is still invalid even after this fix, so we can't put a nice valid badge on the spec page. We could fork the validator and add support for that, but it's too low-priority task to do it. 