### PR TITLE
Implemented prototype of varnish purge for testing and benchmarking.

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -95,6 +95,11 @@ templates:
             type: file
             options:
               parsoidHost: http://parsoid-lb.eqiad.wikimedia.org
+              # To enable mobileApps purging - add these to the config.
+              # (TODO: remove after actual purging is implemented
+              #purge:
+              #  host: '239.128.0.112'
+              #  port: 4827
               # For local testing, use:
               # parsoidHost: http://localhost:8000
 

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -292,20 +292,62 @@ function createHandler(spec) {
     }
 }
 
-/**
- * Processes an x-setup-handler config and returns all resources
- *
- * @param {object} setupConf an endpoint configuration object
- */
-function parseSetupConfig(setupConf) {
-    var result = [];
-    if (Array.isArray(setupConf)) {
-        setupConf.forEach(function(resourceSpec) {
-            Object.keys(resourceSpec).forEach(function(requestName) {
-                var requestSpec = resourceSpec[requestName];
-                requestSpec.method = requestSpec.method || 'put';
-                result.push(requestSpec);
-            });
+    Object.keys(spec.paths).forEach(function(path) {
+        var pathObj = spec.paths[path];
+        Object.keys(pathObj).forEach(function(method) {
+            var conf = pathObj[method];
+            var requestChain = prepareRequestChain(conf.on_request);
+            conf.operationId = method + '_' + path;
+
+            resources = resources.concat(processResources(conf));
+
+            function generatePromiseChain(restbase, context, requestChain) {
+                var promise;
+                var currentRequestSpec = requestChain[0];
+                if (currentRequestSpec.length > 1) {
+                    promise = P.all(currentRequestSpec.map(function(spec) {
+                        return spec.request(restbase, context);
+                    }));
+                } else if (currentRequestSpec[0].request) {
+                    promise = currentRequestSpec[0].request(restbase, context);
+                }
+
+                if (currentRequestSpec[0].return) {
+                    promise = promise || P.resolve();
+                    promise = promise.then(currentRequestSpec[0].return(context));
+                }
+
+                if (currentRequestSpec[0].catch) {
+                    promise = promise.catch(function(err) {
+                        if (!currentRequestSpec[0].catch(err)) {
+                            throw err;
+                        }
+                    });
+                }
+                promise = promise || P.resolve();
+                if (requestChain.length === 1) {
+                    return promise;
+                } else if (currentRequestSpec[0].return_if) {
+                    return promise.then(function(res) {
+                        if (res && currentRequestSpec[0].return_if(res)) {
+                            return res;
+                        } else {
+                            return generatePromiseChain(restbase, context, requestChain.slice(1));
+                        }
+                    });
+                } else {
+                    return promise.then(function() {
+                        return generatePromiseChain(restbase, context, requestChain.slice(1));
+                    });
+                }
+            }
+
+            operations[conf.operationId] = function(restbase, req) {
+                var context = {
+                    request: req
+                };
+                return generatePromiseChain(restbase, context, requestChain);
+            };
         });
     } else {
         throw new Error('Invalid config. x-setup-handler must be an array');

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -292,62 +292,20 @@ function createHandler(spec) {
     }
 }
 
-    Object.keys(spec.paths).forEach(function(path) {
-        var pathObj = spec.paths[path];
-        Object.keys(pathObj).forEach(function(method) {
-            var conf = pathObj[method];
-            var requestChain = prepareRequestChain(conf.on_request);
-            conf.operationId = method + '_' + path;
-
-            resources = resources.concat(processResources(conf));
-
-            function generatePromiseChain(restbase, context, requestChain) {
-                var promise;
-                var currentRequestSpec = requestChain[0];
-                if (currentRequestSpec.length > 1) {
-                    promise = P.all(currentRequestSpec.map(function(spec) {
-                        return spec.request(restbase, context);
-                    }));
-                } else if (currentRequestSpec[0].request) {
-                    promise = currentRequestSpec[0].request(restbase, context);
-                }
-
-                if (currentRequestSpec[0].return) {
-                    promise = promise || P.resolve();
-                    promise = promise.then(currentRequestSpec[0].return(context));
-                }
-
-                if (currentRequestSpec[0].catch) {
-                    promise = promise.catch(function(err) {
-                        if (!currentRequestSpec[0].catch(err)) {
-                            throw err;
-                        }
-                    });
-                }
-                promise = promise || P.resolve();
-                if (requestChain.length === 1) {
-                    return promise;
-                } else if (currentRequestSpec[0].return_if) {
-                    return promise.then(function(res) {
-                        if (res && currentRequestSpec[0].return_if(res)) {
-                            return res;
-                        } else {
-                            return generatePromiseChain(restbase, context, requestChain.slice(1));
-                        }
-                    });
-                } else {
-                    return promise.then(function() {
-                        return generatePromiseChain(restbase, context, requestChain.slice(1));
-                    });
-                }
-            }
-
-            operations[conf.operationId] = function(restbase, req) {
-                var context = {
-                    request: req
-                };
-                return generatePromiseChain(restbase, context, requestChain);
-            };
+/**
+ * Processes an x-setup-handler config and returns all resources
+ *
+ * @param {object} setupConf an endpoint configuration object
+ */
+function parseSetupConfig(setupConf) {
+    var result = [];
+    if (Array.isArray(setupConf)) {
+        setupConf.forEach(function(resourceSpec) {
+            Object.keys(resourceSpec).forEach(function(requestName) {
+                var requestSpec = resourceSpec[requestName];
+                requestSpec.method = requestSpec.method || 'put';
+                result.push(requestSpec);
+            });
         });
     } else {
         throw new Error('Invalid config. x-setup-handler must be an array');

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -51,13 +51,13 @@ function ParsoidService(options) {
 
     // THIS IS EXPERIMENTAL AND ADDED FOR TESTING PURPOSE!
     // SHOULD BE REWRITTEN WHEN DEPENDENCY TRACKING SYSTEM IS IMPLEMENTED!
-    self.purgeOnUpdate = options.purge_on_update;
+    self.purgeOnUpdate = !!options.purge;
     if (self.purgeOnUpdate) {
         self.purger = new Purger({
             routes: [
                 {
-                    host: '239.128.0.112',
-                    port: 4827
+                    host: options.purge.host || '239.128.0.112',
+                    port: options.purge.port || 4827
                 }
             ]
         });

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -21,36 +21,21 @@ var Template = require('../lib/reqTemplate');
 var cacheURIs = [
     // /page/mobile-html/{title}
     new Template({
-        uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html/{title}'
-    }),
-    new Template({
         uri: 'https://{domain}/api/rest_v1/page/mobile-html/{title}'
     }),
     // /page/mobile-html-sections/{title}
-    new Template({
-        uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html-sections/{title}'
-    }),
     new Template({
         uri: 'https://{domain}/api/rest_v1/page/mobile-html-sections/{title}'
     }),
     // /page/mobile-html-sections-lead/{title}
     new Template({
-        uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html-sections-lead/{title}'
-    }),
-    new Template({
         uri: 'https://{domain}/api/rest_v1/page/mobile-html-sections-lead/{title}'
     }),
     // /page/mobile-html-sections-remaining/{title}
     new Template({
-        uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html-sections-remaining/{title}'
-    }),
-    new Template({
         uri: 'https://{domain}/api/rest_v1/page/mobile-html-sections-remaining/{title}'
     }),
     // /page/mobile-text/{title}
-    new Template({
-        uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-text/{title}'
-    }),
     new Template({
         uri: 'https://{domain}/api/rest_v1/page/mobile-text/{title}'
     })

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -91,7 +91,6 @@ var PSP = ParsoidService.prototype;
  * @param title updated page title
  */
 PSP.purgeCaches = function(domain, title) {
-    console.log('PURGE!', domain, title);
     this.purger.purge(cacheURIs.map(function(template) {
         return template.eval({
             request: {

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -20,42 +20,65 @@ var Purger = require('htcp-purge');
 var Template = require('../lib/reqTemplate');
 var cacheURIs = [
     // /page/mobile-html/{title}
-    new Template({uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html/{title}'}),
-    new Template({uri: 'https://{domain}/api/rest_v1/page/mobile-html/{title}'}),
+    new Template({
+        uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html/{title}'
+    }),
+    new Template({
+        uri: 'https://{domain}/api/rest_v1/page/mobile-html/{title}'
+    }),
     // /page/mobile-html-sections/{title}
-    new Template({uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html-sections/{title}'}),
-    new Template({uri: 'https://{domain}/api/rest_v1/page/mobile-html-sections/{title}'}),
+    new Template({
+        uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html-sections/{title}'
+    }),
+    new Template({
+        uri: 'https://{domain}/api/rest_v1/page/mobile-html-sections/{title}'
+    }),
     // /page/mobile-html-sections-lead/{title}
-    new Template({uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html-sections-lead/{title}'}),
-    new Template({uri: 'https://{domain}/api/rest_v1/page/mobile-html-sections-lead/{title}'}),
+    new Template({
+        uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html-sections-lead/{title}'
+    }),
+    new Template({
+        uri: 'https://{domain}/api/rest_v1/page/mobile-html-sections-lead/{title}'
+    }),
     // /page/mobile-html-sections-remaining/{title}
-    new Template({uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html-sections-remaining/{title}'}),
-    new Template({uri: 'https://{domain}/api/rest_v1/page/mobile-html-sections-remaining/{title}'}),
+    new Template({
+        uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-html-sections-remaining/{title}'
+    }),
+    new Template({
+        uri: 'https://{domain}/api/rest_v1/page/mobile-html-sections-remaining/{title}'
+    }),
     // /page/mobile-text/{title}
-    new Template({uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-text/{title}'}),
-    new Template({uri: 'https://{domain}/api/rest_v1/page/mobile-text/{title}'})
+    new Template({
+        uri: 'https://rest.wikimedia.org/{domain}/v1/page/mobile-text/{title}'
+    }),
+    new Template({
+        uri: 'https://{domain}/api/rest_v1/page/mobile-text/{title}'
+    })
 
 ];
 
 function ParsoidService(options) {
+    var self = this;
     options = options || {};
     this.log = options.log || function() {};
     this.parsoidHost = options.parsoidHost
         || 'http://parsoid-lb.eqiad.wikimedia.org';
-    // Set up operations
-    var self = this;
 
     // THIS IS EXPERIMENTAL AND ADDED FOR TESTING PURPOSE!
     // SHOULD BE REWRITTEN WHEN DEPENDENCY TRACKING SYSTEM IS IMPLEMENTED!
-    self.purger = new Purger({
-        routes: [
-            {
-                host: '239.128.0.112',
-                port: 4827
-            }
-        ]
-    });
+    self.purgeOnUpdate = options.purge_on_update;
+    if (self.purgeOnUpdate) {
+        self.purger = new Purger({
+            routes: [
+                {
+                    host: '239.128.0.112',
+                    port: 4827
+                }
+            ]
+        });
+    }
 
+    // Set up operations
     this.operations = {
         getPageBundle: function(restbase, req) {
             return self.wrapContentReq(restbase, req,
@@ -367,7 +390,9 @@ PSP.getFormat = function(format, restbase, req) {
                 }
             })
             .then(function(res) {
-                self.purgeCaches(rp.domain, rp.title);
+                if (self.purgeOnUpdate) {
+                    self.purgeCaches(rp.domain, rp.title);
+                }
                 return res;
             });
         } else {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "tassembly": "^0.1.4",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "template-expression-compiler": "^0.1.0"
+    "template-expression-compiler": "^0.1.0",
+    "htcp-purge": "^0.1.0"
   },
   "devDependencies": {
     "bunyan": "^1.4.0",


### PR DESCRIPTION
NOTE: This is an experimental PR, added only for testing and running benchmarks of mobile-apps endpoints. This code should not get to production and this PR should be reverted when testing/benchmarks are done, because without a proper dependency tracking system we can't create a real solution for this issue.

Here we enable varnish caches for mobile apps endpoints and set up background HTCP purges when the page is updated. Ideally, nothing should be hard-coded, and dependencies between endpoints should be stored in the dependency tracking system. 

This PR is only for testing, so I think making the code better is worthless as it will be removed soon. Correct me if I'm wrong, and I'll make this completely spec-driven without hard-coded endpoints and varnish IPs

Bug: https://phabricator.wikimedia.org/T109742