### PR TITLE
Fill the latest_rev field

### DIFF
--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -239,7 +239,6 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
 
         if (!rp.revision) {
             storeAttributes.latest_rev = apiRev.revid;
-            storeAttributes.latest_tid = currentTid;
         }
 
         return restbase.put({ // Save / update the revision entry

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -125,7 +125,7 @@ function generateTests(options) {
         });
     });
 
-    it('should fill latest rev and tid properties', function() {
+    it('should fill latest_rev property', function() {
         return preq.get({
             uri: server.config.bucketURL + '/title/' + options.pageName,
             headers: {
@@ -136,8 +136,6 @@ function generateTests(options) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body.items.length, 1);
             assert.deepEqual(res.body.items[0].latest_rev, options.pageLastRev);
-            assert.deepEqual(!!res.body.items[0].latest_tid, true);
-            assert.deepEqual(res.body.items[0].latest_tid, res.body.items[0].tid)
         });
     });
 

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -125,6 +125,22 @@ function generateTests(options) {
         });
     });
 
+    it('should fill latest rev and tid properties', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/title/' + options.pageName,
+            headers: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].latest_rev, options.pageLastRev);
+            assert.deepEqual(!!res.body.items[0].latest_tid, true);
+            assert.deepEqual(res.body.items[0].latest_tid, res.body.items[0].tid)
+        });
+    });
+
     after(function() {
         server.stop();
         apiRequestTemplate.uri = prevUri;


### PR DESCRIPTION
In page_revisions spec and table we have a `latest_rev` field, which might be useful. However now it's never set. This patch sets it when we get a new revision for a title, so for historic revisions it will still be `null`, but at least it will be set for newer ones. 

This is a (little) part of the work under https://phabricator.wikimedia.org/T106455