### PR TITLE
Require a tid iff a revision is supplied in html2wt

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -441,6 +441,16 @@ PSP.transformRevision = function(restbase, req, from, to) {
                                 .exec(req.body.html);
             tid = tidMatch && tidMatch[1];
         }
+        if (!tid) {
+            throw new rbUtil.HTTPError({
+                status: 400,
+                body: {
+                    type: 'invalid_request',
+                    description: 'No or invalid If-Match header supplied, '
+                        + 'or missing mw:TimeUuid meta element in the supplied HTML.',
+                }
+            });
+        }
     }
 
     return this._getOriginalContent(restbase, req, rp.revision, tid)


### PR DESCRIPTION
Parsoid uses both the original HTML and data-parsoid in the html2wt
conversion. Each entry in data-parsoid is associated with a DOM node via a
unique ID. These IDs can change randomly between renders, which means that it
is critical for correctness to supply both original HTML and data-parsoid from
the exact same render. This means that we need to require a tid to be supplied
iff the revision is specified.

This patch adds a simple check for the tid, and throws a 400 if it is missing.

Bug: T111491