### PR TITLE
Use the travis 'services' support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,8 @@ node_js:
     - "0.12"
     - "iojs-v2.5.0"
 
-before_install:
-  - sudo sh -c "echo 'JVM_OPTS=\"\${JVM_OPTS} -Djava.net.preferIPv4Stack=false\"' >> /usr/local/cassandra/conf/cassandra-env.sh"
-  - sudo service cassandra start
-
-before_script:
-  - while [ `nc localhost 9042 < /dev/null; echo $?` != 0 ] ; do
-      echo 'waiting for cassandra...' ;
-      sleep 1 ;
-    done
+services:
+    - cassandra
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
     - "0.12"
     - "iojs-v2.5.0"
 
+sudo: false
+
 services:
     - cassandra
 


### PR DESCRIPTION
Travis now supports starting up services with the 'services' stanza. This lets
us avoid using sudo & thus use the container infrastructure. As a result, our
tests should run faster. It also simplifies our .travis.yml slightly.