### PR TITLE
Deprecate bodyOnly and replace it with body_only

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -617,8 +617,9 @@ PSP.makeTransform = function(from, to) {
             // Unwrap to the flat response format
             var innerRes = res.body[to];
             innerRes.status = 200;
-            // Handle bodyOnly flag
-            if (to === 'html' && req.body.bodyOnly) {
+            // Handle body_only flag.
+            // bodyOnly is deprecated and will be removed at some point
+            if (to === 'html' && (req.body.body_only || req.body.bodyOnly)) {
                 innerRes.body = cheapBodyInnerHTML(innerRes.body);
             }
             return innerRes;

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -887,6 +887,11 @@ paths:
           required: true
         - name: bodyOnly
           in: formData
+          description: Deprecated. Use `body_only`
+          type: boolean
+          required: false
+        - name: body_only
+          in: formData
           description: Return only `body.innerHTML`
           type: boolean
           required: false
@@ -910,6 +915,7 @@ paths:
         body:
           wikitext: '{wikitext}'
           bodyOnly: '{bodyOnly}'
+          body_only: '{body_only}'
       x-monitor: true
       x-amples:
         - title: Transform wikitext to html
@@ -918,7 +924,7 @@ paths:
               title: Foobar
             body:
               wikitext: == Heading ==
-              bodyOnly: true
+              body_only: true
           response:
             status: 200
             headers:
@@ -955,6 +961,11 @@ paths:
           required: true
         - name: bodyOnly
           in: formData
+          description: Deprecated. Use `body_only`.
+          type: boolean
+          required: false
+        - name: body_only
+          in: formData
           description: Return only `body.innerHTML`
           type: boolean
           required: false
@@ -978,6 +989,7 @@ paths:
         body:
           html: '{html}'
           bodyOnly: '{bodyOnly}'
+          body_only: '{body_only}'
       x-monitor: false
 
   /{module:transform}/sections/to/wikitext/{title}/{revision}:

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -53,14 +53,14 @@ describe('transform api', function() {
         });
     });
 
-    it('html2html with bodyOnly', function () {
+    it('html2html with body_only', function () {
         return preq.post({
             uri: server.config.baseURL
                 + '/transform/html/to/html/' + testPage.title
                 + '/' + testPage.revision,
             body: {
                 html: testPage.html,
-                bodyOnly: true
+                body_only: true
             }
         })
         .then(function (res) {
@@ -93,13 +93,13 @@ describe('transform api', function() {
         });
     });
 
-    it('wt2html with bodyOnly', function () {
+    it('wt2html with body_only', function () {
         return preq.post({
             uri: server.config.baseURL
                 + '/transform/wikitext/to/html/User:GWicke%2F_restbase_test',
             body: {
                 wikitext: '== Heading ==',
-                bodyOnly: true
+                body_only: true
             }
         })
         .then(function (res) {


### PR DESCRIPTION
After some discussion it's been decided that we need to use snake_case in POST request parameters. The only one that wasn't following this rule is `bodyOnly`. This PR deprecated the `bodyOnly` parameter and replaces it with `body_only`.