### PR TITLE
Removed test.local domains

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -73,10 +73,6 @@ templates:
                 password: cassandra
                 defaultConsistency: one # or 'one' for single-node testing
                 storage_groups:
-                  - name: test.group.local
-                    domains:
-                      - /test\..*\.org$/
-                      - /test\.local$/
                   - name: default.group.local
                     domains: /./
 
@@ -217,9 +213,6 @@ spec: &spec
 #   /{domain:de.wikipedia.org}: *wp/default/1.0.0
 #   /{domain:es.wikipedia.org}: *wp/default/1.0.0
 #   /{domain:nl.wikipedia.org}: *wp/default/1.0.0
-#
-    # test domain
-    /{domain:en.wikipedia.test.local}: *wp/default/1.0.0
 
 
 services:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -297,7 +297,7 @@ spec: &spec
   paths:
     # test domain
     /{domain:en.wikipedia.org}: *wp/default/1.0.0
-    # For security testing we deny on mocks, so it's OK to use French wiki.
+    # For security testing we rely on mocks, so it's OK to use French wiki.
     /{domain:fr.wikipedia.org}: *wp/secure/1.0.0
 
 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -48,6 +48,7 @@ templates:
         name: cookie
         x-internal-request-whitelist:
           - http://en.wikipedia.org/w/api.php
+          - http://fr.wikipedia.org/w/api.php
           # Left as a regex for test purpose
           - /http:\/\/parsoid\-lb\.eqiad\.wikimedia\.org/
 
@@ -73,10 +74,6 @@ templates:
                 defaultConsistency: one # or 'one' for single-node testing
                 storage_groups:
                   - name: test.group.local
-                    domains:
-                      - /test\..*\.org$/
-                      - /test\.local$/
-                  - name: default.group.local
                     domains: /./
 
       /{module:page_revisions}:
@@ -126,7 +123,7 @@ templates:
                     on_request:
                       - get_from_graphoid:
                           request:
-                            uri: http://graphoid.wikimedia.org/en.wikipedia.org/v1/png/{title}/{revision}/{graph_id}
+                            uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
 
       /{module:post_data_service}:
         x-modules:
@@ -167,31 +164,31 @@ templates:
                     on_request:
                       - get_from_backend:
                           request:
-                            uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html/{title}
+                            uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html/{title}
                 /v1/sections/{title}:
                   get:
                     on_request:
                       - get_from_backend:
                           request:
-                            uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections/{title}
+                            uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections/{title}
                 /v1/sections-lead/{title}:
                   get:
                     on_request:
                       - get_from_backend:
                           request:
-                            uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections-lead/{title}
+                            uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections-lead/{title}
                 /v1/sections-remaining/{title}:
                   get:
                     on_request:
                       - get_from_backend:
                           request:
-                            uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-html-sections-remaining/{title}
+                            uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections-remaining/{title}
                 /v1/text/{title}:
                   get:
                     on_request:
                       - get_from_backend:
                           request:
-                            uri: http://appservice.wmflabs.org/en.wikipedia.org/v1/page/mobile-text/{title}
+                            uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-text/{title}
 
       /{module:action}:
         x-modules:
@@ -200,10 +197,9 @@ templates:
             options:
               apiRequest:
                 method: post
-                uri: http://en.wikipedia.org/w/api.php
+                uri: http://{domain}/w/api.php
                 headers:
-                  # the domain is en.wikipedia.test.local, so we can't use it. use en.wikipedia.org instead
-                  host: 'en.wikipedia.org'
+                  host: '{$.request.params.domain}'
                 body: '{$.request.body}'
 
       /{module:testservice}:
@@ -230,7 +226,7 @@ templates:
                             status: 404
                       - get_from_api:
                           request:
-                            uri: http://en.wikipedia.org/wiki/{+key}
+                            uri: http://{domain}/wiki/{+key}
                             body: '{$.request.body}'
                       - store:
                           request:
@@ -258,10 +254,10 @@ templates:
                     on_request:
                       - get_from_api1:
                           request:
-                            uri: http://en.wikipedia.org/wiki/{+key1}
+                            uri: http://{domain}/wiki/{+key1}
                         get_from_api2:
                           request:
-                            uri: http://en.wikipedia.org/wiki/{+key2}
+                            uri: http://{domain}/wiki/{+key2}
                       - return_response:
                           return:
                             status: 200
@@ -300,8 +296,9 @@ spec: &spec
   # Some more general RESTBase info
   paths:
     # test domain
-    /{domain:en.wikipedia.test.local}: *wp/default/1.0.0
-    /{domain:secure.wikipedia.test.local}: *wp/secure/1.0.0
+    /{domain:en.wikipedia.org}: *wp/default/1.0.0
+    # For security testing we deny on mocks, so it's OK to use French wiki.
+    /{domain:fr.wikipedia.org}: *wp/secure/1.0.0
 
 
 services:

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -137,7 +137,6 @@ PSP.getBucketURI = function(rp, format, tid) {
 PSP.pagebundle = function(restbase, req) {
     var rp = req.params;
     var domain = rp.domain;
-    if (domain === 'en.wikipedia.test.local') { domain = 'en.wikipedia.org'; }
     // TODO: Pass in current or predecessor version data if available
     var newReq = Object.assign({}, req);
     if (!newReq.method) { newReq.method = 'get'; }
@@ -546,7 +545,6 @@ PSP.callParsoidTransform = function callParsoidTransform(restbase, req, from, to
 
     var domain = rp.domain;
     // Re-map test domain
-    if (domain === 'en.wikipedia.test.local') { domain = 'en.wikipedia.org'; }
     var parsoidReq = {
         uri: this.parsoidHost + '/v2/' + domain + '/'
             + parsoidTo + parsoidExtraPath,

--- a/test/features/errors/notfound.js
+++ b/test/features/errors/notfound.js
@@ -84,6 +84,7 @@ describe('404 handling', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
             .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+        apiURI = apiURI.replace('{domain}', 'en.wikipedia.org');
         var title = 'TestingTitle';
         var revision = 12345;
         var emptyResponse = {'batchcomplete':'','query':{'badrevids':{'12345' :{'revid':'12345'}}}};

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -135,7 +135,7 @@ describe('item requests', function() {
 
     it('should list APIs using the generic listing handler', function() {
         return preq.get({
-            uri: server.config.hostPort + '/en.wikipedia.test.local/'
+            uri: server.config.hostPort + '/en.wikipedia.org/'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -207,7 +207,7 @@ describe('on-demand generation of html and data-parsoid', function() {
         .then(function (res) {
             assert.deepEqual(!!res.headers['content-security-policy'], true);
             assert.deepEqual(res.headers['content-security-policy']
-                .indexOf("style-src http://*.wikipedia.test.local https://*.wikipedia.test.local 'unsafe-inline'") > 0, true);
+                .indexOf("style-src http://*.wikipedia.org https://*.wikipedia.org 'unsafe-inline'") > 0, true);
         });
     });
 });

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -10,7 +10,7 @@ var server = require('../../utils/server');
 
 var rootSpec = {
     paths: {
-        '/{domain:en.wikipedia.test.local}/v1': {
+        '/{domain:en.wikipedia.org}/v1': {
             'x-subspecs': [
                 {
                     paths: {
@@ -30,7 +30,7 @@ var rootSpec = {
 
 var faultySpec = {
     paths: {
-        '/{domain:en.wikipedia.test.local}': {
+        '/{domain:en.wikipedia.org}': {
             'x-subspecs': ['some/non/existing/spec']
         }
     }
@@ -38,7 +38,7 @@ var faultySpec = {
 
 var additionalMethodSpec = {
     paths: {
-        '/{domain:en.wikipedia.test.local}/v1': {
+        '/{domain:en.wikipedia.org}/v1': {
             'x-subspecs': [
                 {
                     paths: {
@@ -69,7 +69,7 @@ var additionalMethodSpec = {
 
 var overlappingMethodSpec = {
     paths: {
-        '/{domain:en.wikipedia.test.local}/v1': {
+        '/{domain:en.wikipedia.org}/v1': {
             'x-subspecs': [
                 {
                     paths: {
@@ -100,7 +100,7 @@ var overlappingMethodSpec = {
 
 var nestedSecuritySpec = {
     paths: {
-        '/{domain:en.wikipedia.test.local}/v1': {
+        '/{domain:en.wikipedia.org}/v1': {
             'x-subspecs': [
                 {
                     paths: {
@@ -137,10 +137,10 @@ describe('tree building', function() {
         return router.loadSpec(rootSpec)
         .then(function() {
             //console.log(JSON.stringify(router.tree, null, 2));
-            var handler = router.route('/en.wikipedia.test.local/v1/page/Foo/html');
+            var handler = router.route('/en.wikipedia.org/v1/page/Foo/html');
             //console.log(handler);
             assert.equal(!!handler.value.methods.get, true);
-            assert.equal(handler.params.domain, 'en.wikipedia.test.local');
+            assert.equal(handler.params.domain, 'en.wikipedia.org');
             assert.equal(handler.params.title, 'Foo');
         });
     });
@@ -165,10 +165,10 @@ describe('tree building', function() {
             }
         })
         .then(function() {
-            var handler = router.route('/en.wikipedia.test.local/v1/page/html/Foo');
+            var handler = router.route('/en.wikipedia.org/v1/page/html/Foo');
             assert.equal(resourceRequests.length > 0, true);
             assert.equal(!!handler.value.methods.get, true);
-            assert.equal(handler.params.domain, 'en.wikipedia.test.local');
+            assert.equal(handler.params.domain, 'en.wikipedia.org');
             assert.equal(handler.params.title, 'Foo');
         });
     });
@@ -177,7 +177,7 @@ describe('tree building', function() {
         var router = new Router();
         return router.loadSpec(additionalMethodSpec)
         .then(function() {
-            var handler = router.route('/en.wikipedia.test.local/v1/page/Foo/html');
+            var handler = router.route('/en.wikipedia.org/v1/page/Foo/html');
             assert.equal(!!handler.value.methods.get, true);
             assert.equal(!!handler.value.methods.post, true);
         });
@@ -198,7 +198,7 @@ describe('tree building', function() {
         var router = new Router();
         return router.loadSpec(nestedSecuritySpec)
         .then(function() {
-            var handler = router.route('/en.wikipedia.test.local/v1/page/secure');
+            var handler = router.route('/en.wikipedia.org/v1/page/secure');
             assert.deepEqual(handler.permissions, ['first', 'second', 'third']);
         });
     });

--- a/test/features/security/security.js
+++ b/test/features/security/security.js
@@ -42,6 +42,7 @@ describe('router - security', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
             .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+        apiURI = apiURI.replace('{domain}', 'fr.wikipedia.org');
         var api = nock(apiURI, {
             reqheaders: {
                 cookie: 'test=test_cookie'
@@ -67,14 +68,14 @@ describe('router - security', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
             .paths['/{module:parsoid}']['x-modules'][0].options.parsoidHost;
-        var title = 'User%3APchelolo%2Fsections_test';
-        var revision = 669458404;
+        var title = 'Test';
+        var revision = 117795883;
         var api = nock(apiURI, {
             reqheaders: {
                 cookie: 'test=test_cookie'
             }
         })
-        .get('/v2/secure.wikipedia.test.local/pagebundle/' + title + '/' + revision)
+        .get('/v2/fr.wikipedia.org/pagebundle/' + title + '/' + revision)
         .reply(200, function() {
             return {
                 'html': {
@@ -111,6 +112,7 @@ describe('router - security', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
             .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+        apiURI = apiURI.replace('{domain}', 'en.wikipedia.org');
         var api = nock(apiURI, {
             badheaders: ['cookie']
         })
@@ -132,6 +134,7 @@ describe('router - security', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
             .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+        apiURI = apiURI.replace('{domain}', 'fr.wikipedia.org');
         var title = 'TestingTitle';
         var revision = 12345;
 

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -50,7 +50,7 @@ paths:
       x-amples:
         - request:
             params:
-                domain: en.wikipedia.test.local
+                domain: en.wikipedia.org
                 title: Foobar
           response:
             status: 200
@@ -91,7 +91,7 @@ paths:
       x-amples:
         - request:
             params:
-                domain: en.wikipedia.test.local
+                domain: en.wikipedia.org
                 title: Foobar
           response:
             status: 200
@@ -141,7 +141,7 @@ paths:
       x-amples:
         - request:
             params:
-                domain: en.wikipedia.test.local
+                domain: en.wikipedia.org
                 title: Foobar
                 revision: 624484477
           response:
@@ -192,7 +192,7 @@ paths:
       x-amples:
         - request:
             params:
-                domain: en.wikipedia.test.local
+                domain: en.wikipedia.org
                 title: Foobar
                 revision: 624484477
           response:

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -11,9 +11,9 @@ var assert    = require('./assert');
 var yaml      = require('js-yaml');
 
 var hostPort  = 'http://localhost:7231';
-var baseURL   = hostPort + '/en.wikipedia.test.local/v1';
+var baseURL   = hostPort + '/en.wikipedia.org/v1';
 var bucketURL = baseURL + '/page';
-var secureURL = hostPort + '/secure.wikipedia.test.local/v1/page';
+var secureURL = hostPort + '/fr.wikipedia.org/v1/page';
 
 function loadConfig(path) {
     var confString = fs.readFileSync(path).toString();


### PR DESCRIPTION
We have more and more hacks, connected to `test.local` domains. In this fix we start testing RB agains real en.wiki domains, but set up cassandra storage so that all test data get to test storage group. By this we still have the same protection of the prod data, but can remove all hacks from the code.