### PR TITLE
Added delay between running Cassandra and SQLite tests

### DIFF
--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -37,6 +37,8 @@ elif [ "$2" = "cassandra" ]; then
     runTest "cassandra" $1
 elif [ "$2" = "all" ]; then
     runTest "sqlite" $1
+    # sleep 1 minute to avoid MW edit endpoint rate limiting
+    sleep 60s
     runTest "cassandra" $1
 else
     echo "Invalid testing mode"

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -38,8 +38,7 @@ elif [ "$2" = "cassandra" ]; then
 elif [ "$2" = "all" ]; then
     runTest "sqlite" $1
     # Sleep a delay to avoid 429.
-    # It's random to avoid different jobs running at save_api tests simultaniously
-    sleep $[ ( $RANDOM % 30 ) + 60 ]s
+    sleep 90s
     runTest "cassandra" $1
 else
     echo "Invalid testing mode"

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -37,8 +37,9 @@ elif [ "$2" = "cassandra" ]; then
     runTest "cassandra" $1
 elif [ "$2" = "all" ]; then
     runTest "sqlite" $1
-    # sleep 1 minute to avoid MW edit endpoint rate limiting
-    sleep 60s
+    # Sleep a delay to avoid 429.
+    # It's random to avoid different jobs running at save_api tests simultaniously
+    sleep $[ ( $RANDOM % 30 ) + 60 ]s
     runTest "cassandra" $1
 else
     echo "Invalid testing mode"


### PR DESCRIPTION
429 errors in travis became extremely annoying, so we need to add a 1 minute delay between running SQLite and Cassandra tests.