### PR TITLE
Use nock for some of the save_api tests

### DIFF
--- a/mods/action.js
+++ b/mods/action.js
@@ -187,7 +187,7 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     apiRequest.body.action = defBody.action;
     apiRequest.body.format = apiRequest.body.format || defBody.format || 'json';
     apiRequest.body.formatversion = apiRequest.body.formatversion || defBody.formatversion || 1;
-    if (!apiRequest.body.hasOwnProperty('continue')) {
+    if (!apiRequest.body.hasOwnProperty('continue') && apiRequest.action === 'query') {
         apiRequest.body.continue = '';
     }
     return restbase.request(apiRequest).then(cont);

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -118,7 +118,7 @@ describe('page save api', function() {
 
         nock.enableNetConnect();
         var api = nock(apiURI)
-            // The first request should return a page so that we store it.
+        // Mock MW API badtoken response
         .post('')
         .reply(200, {
             "servedby": "nock",
@@ -294,7 +294,7 @@ describe('page save api', function() {
 
         nock.enableNetConnect();
         var api = nock(apiURI)
-            // The first request should return a page so that we store it.
+        // Mock MW API editconflict response
         .post('')
         .reply(200, {
             "servedby": "nock",
@@ -355,7 +355,7 @@ describe('page save api', function() {
 
         nock.enableNetConnect();
         var api = nock(apiURI)
-            // The first request should return a page so that we store it.
+        // Mock MW API editconflict response
         .post('')
         .reply(200, {
             "servedby": "nock",


### PR DESCRIPTION
429 errors on save tests are very annoying, and even setting a 90 second delay between running tests on different backends doesn't help, so we switch some of the tests to nock.