### PR TITLE
Enabled tests with node 4.0 and removed io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
-    - "iojs-v2.5.0"
+    - "4.0"
 
 sudo: false
 


### PR DESCRIPTION
node.js 4.0 is now available, making io.js fork stale, so we need to use that for testing.