### PR TITLE
Removed unused and inefficient by_ns secondary index

### DIFF
--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -37,7 +37,7 @@ PRS.prototype.tableURI = function(domain) {
 PRS.prototype.getTableSchema = function() {
     return {
         table: this.tableName,
-        version: 2,
+        version: 3,
         attributes: {
             // Listing: /titles.rev/Barack_Obama/master/
             // @specific time: /titles.rev/Barack_Obama?ts=20140312T20:22:33.3Z
@@ -77,12 +77,6 @@ PRS.prototype.getTableSchema = function() {
                 { attribute: 'tid', type: 'range', order: 'desc' },
                 { attribute: 'title', type: 'range', order: 'asc' },
                 { attribute: 'restrictions', type: 'proj' }
-            ],
-            by_ns: [
-                { attribute: 'namespace', type: 'hash' },
-                { attribute: 'title', type: 'range', order: 'asc' },
-                { attribute: 'rev', type: 'range', order: 'desc' },
-                { attribute: 'tid', type: 'range', order: 'desc' }
             ]
         }
     };

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jsonwebtoken": "^5.0.1",
     "cassandra-uuid": "^0.0.2",
     "preq": "^0.4.3",
-    "restbase-mod-table-cassandra": "^0.7.11",
+    "restbase-mod-table-cassandra": "^0.7.14",
     "service-runner": "^0.2.0",
     "swagger-router": "^0.1.1",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
@@ -57,7 +57,7 @@
     "swagger-test": "0.2.0",
     "url-template": "^2.0.6",
     "nock": "^2.10.0",
-    "restbase-mod-table-sqlite": "^0.1.6",
+    "restbase-mod-table-sqlite": "^0.1.8",
     "mocha-jscs": "^1.2.0"
   }
 }


### PR DESCRIPTION
The by_ns index in the revisions table is not used and inefficient. This PR removes it until we have a better solution and need for such index.

Bug: https://phabricator.wikimedia.org/T111959