### PR TITLE
Pass x-forwarded-for header to backend services

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -45,7 +45,7 @@ var securityDefinitionCreators = {
         return {
             prepareRequest: function(restbase, req) {
                 if (isInternalRequest(req)) {
-                    rbUtil.copyForwardedHeaders(restbase, req, ['cookie']);
+                    rbUtil.copyForwardedHeaders(restbase, req, ['cookie', 'x-forwarded-for']);
                 }
             },
             checkPermissions: function(restbase, req, permDefinitions) {
@@ -59,7 +59,7 @@ var securityDefinitionCreators = {
 
                 // If nothing is applicable to the current method - skip the check
                 if (permissions.length === 0) {
-                    return;
+                    return P.resolve();
                 }
 
                 var checkReq = {
@@ -202,7 +202,7 @@ AuthService.prototype.addRequirements = function(requirements) {
                 };
             }));
         } else {
-            permObj[name].forEach(function(perm) {
+            permObj.value[name].forEach(function(perm) {
                 self.securityRequirements[name].add({
                     value: perm,
                     method: permObj.method

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -45,7 +45,7 @@ var securityDefinitionCreators = {
         return {
             prepareRequest: function(restbase, req) {
                 if (isInternalRequest(req)) {
-                    rbUtil.copyForwardedCookies(restbase, req);
+                    rbUtil.copyForwardedHeaders(restbase, req, ['cookie']);
                 }
             },
             checkPermissions: function(restbase, req, permDefinitions) {

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -275,13 +275,19 @@ rbUtil.parseETag = function(etag) {
  * Copies forwarded headers from restbase to request.
  * If the same header was already set it takes precedence over
  * the forwarded header.
+ *
+ * @param restbase a restbase instance to take the forwarded headers from
+ * @param req a request where to copy the headers
+ * @param headers array of header names to copy
  */
-rbUtil.copyForwardedCookies = function(restbase, req) {
-    if (restbase._rootReq
-            && restbase._forwardedCookies
-            && !req.headers.cookie) {
+rbUtil.copyForwardedHeaders = function(restbase, req, headers) {
+    if (restbase._rootReq && restbase._forwardedHeaders) {
         req.headers = req.headers || {};
-        req.headers.cookie = restbase._forwardedCookies;
+        headers.filter(function(header) {
+            return !req.headers[header] && restbase._forwardedHeaders[header];
+        }).forEach(function(header) {
+            req.headers[header] = restbase._forwardedHeaders[header];
+        });
     }
     return req;
 };

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -283,10 +283,10 @@ rbUtil.parseETag = function(etag) {
 rbUtil.copyForwardedHeaders = function(restbase, req, headers) {
     if (restbase._rootReq && restbase._forwardedHeaders) {
         req.headers = req.headers || {};
-        headers.filter(function(header) {
-            return !req.headers[header] && restbase._forwardedHeaders[header];
-        }).forEach(function(header) {
-            req.headers[header] = restbase._forwardedHeaders[header];
+        headers.forEach(function(header) {
+            if (!req.headers[header] && restbase._forwardedHeaders[header]) {
+                req.headers[header] = restbase._forwardedHeaders[header];
+            }
         });
     }
     return req;

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -30,8 +30,7 @@ function RESTBase(options, req) {
         this._priv = par._priv;
         this.rb_config = this._priv.options.conf;
         this._rootReq = par._rootReq || req;
-        this._forwardedCookies = par._forwardedCookies
-            || this._rootReq.headers && this._rootReq.headers.cookie;
+        this._forwardedHeaders = par._forwardedHeaders || this._rootReq.headers;
         this._authService = par._authService ? new AuthService(par._authService) : null;
     } else {
         // Brand new instance
@@ -60,7 +59,7 @@ function RESTBase(options, req) {
         this.rb_config = options.conf;
         this.rb_config.user_agent = this.rb_config.user_agent || 'RESTBase';
         this._rootReq = null;
-        this._forwardedCookies = null;
+        this._forwardedHeaders = null;
         this._authService = null;
     }
 }
@@ -160,6 +159,7 @@ RESTBase.prototype.defaultWebRequestHandler = function(req) {
     // Enforce the usage of UA
     req.headers = req.headers || {};
     req.headers['User-Agent'] = req.headers['User-Agent'] || this.rb_config.user_agent;
+    rbUtil.copyForwardedHeaders(this, req, ['x-forwarded-for']);
     if (this._authService) {
         this._authService.prepareRequest(this, req);
     }

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -159,7 +159,6 @@ RESTBase.prototype.defaultWebRequestHandler = function(req) {
     // Enforce the usage of UA
     req.headers = req.headers || {};
     req.headers['User-Agent'] = req.headers['User-Agent'] || this.rb_config.user_agent;
-    rbUtil.copyForwardedHeaders(this, req, ['x-forwarded-for']);
     if (this._authService) {
         this._authService.prepareRequest(this, req);
     }

--- a/mods/action.js
+++ b/mods/action.js
@@ -201,8 +201,6 @@ ActionService.prototype.query = function(restbase, req) {
 };
 
 ActionService.prototype.edit = function(restbase, req) {
-    // For edit need to copy-over cookies for unrestricted domains too.
-    rbUtil.copyForwardedHeaders(restbase, req, ['cookie']);
     return this._doRequest(restbase, req, {
         action: 'edit',
         format: 'json',

--- a/mods/action.js
+++ b/mods/action.js
@@ -202,7 +202,7 @@ ActionService.prototype.query = function(restbase, req) {
 
 ActionService.prototype.edit = function(restbase, req) {
     // For edit need to copy-over cookies for unrestricted domains too.
-    rbUtil.copyForwardedCookies(restbase, req);
+    rbUtil.copyForwardedHeaders(restbase, req, ['cookie']);
     return this._doRequest(restbase, req, {
         action: 'edit',
         format: 'json',

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -374,6 +374,9 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+      # RB doesn't check for permissions, just prepares a request correctly
+      security:
+        - mediawiki_auth: []
       x-request-handler:
         - post_to_backend:
             request:
@@ -863,6 +866,9 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+      # RB doesn't check for permissions, just prepares a request correctly
+      security:
+        - mediawiki_auth: []
       x-request-handler:
         - post_to_backend:
             request:

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -348,7 +348,11 @@ describe('page save api', function() {
 
     it('save HTML', function() {
         nock.enableNetConnect();
-        var api = nock(prodApiURI)
+        var api = nock(prodApiURI, {
+            reqheaders: {
+                'x-forwarded-for': '123.123.123.123'
+            }
+        })
         // Mock MW API success response
         .post('')
         .reply(200, {
@@ -369,6 +373,9 @@ describe('page save api', function() {
             assert.deepEqual(res.status, 200, 'Could not retrieve test page!');
             return preq.post({
                 uri: htmlUri,
+                headers: {
+                    'x-forwarded-for': '123.123.123.123'
+                },
                 body: {
                     html: res.body.replace(/\<\/body\>/,
                         '<p>Generated via direct HTML save! Random ' + Math.floor(Math.random() * 32768) + ' </p></body>'),
@@ -407,13 +414,13 @@ describe('page save api', function() {
             assert.deepEqual(res.status, 200, 'Could not retrieve test page!');
             return preq.post({
                 uri: htmlUri,
+                headers: {
+                    'if-match': lastHTMLETag
+                },
                 body: {
                     html: res.body.replace(/\<\/body\>/, '<p>Old revision edit that should detect conflict!</p></body>'),
                     csrf_token: htmlToken,
                     base_etag: oldHTMLEtag
-                },
-                headers: {
-                    'if-match': lastHTMLETag
                 }
             });
         }).then(function(res) {

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -350,7 +350,8 @@ describe('page save api', function() {
         nock.enableNetConnect();
         var api = nock(prodApiURI, {
             reqheaders: {
-                'x-forwarded-for': '123.123.123.123'
+                'x-forwarded-for': '123.123.123.123',
+                cookie: 'test'
             }
         })
         // Mock MW API success response
@@ -374,7 +375,8 @@ describe('page save api', function() {
             return preq.post({
                 uri: htmlUri,
                 headers: {
-                    'x-forwarded-for': '123.123.123.123'
+                    'x-forwarded-for': '123.123.123.123',
+                    cookie: 'test'
                 },
                 body: {
                     html: res.body.replace(/\<\/body\>/,


### PR DESCRIPTION
We need to pass `x-forwarded-for` header to backend services as RB works like a proxy for them.

Bugs:
https://phabricator.wikimedia.org/T112536