### PR TITLE
Tighten down CSP headers

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -63,7 +63,7 @@ var cspHeaderVariants = [
     'content-security-policy',
     // For IE 10 & 11
     'x-content-security-policy',
-    // For Chrome <= v25 (seems to be <1% traffic; should we still care?)
+    // For Chrome <= v25 (<<1% traffic; todo: revisit support)
     'x-webkit-csp',
 ];
 
@@ -82,23 +82,29 @@ rbUtil.addCSPHeaders = function(res, options) {
     var rh = res.headers;
     var csp;
     if (isHtmlSvgContent(res)) {
-        // Our main production clients will ignore CSP anyway (by loading via
-        // XHR or fetch), so we need to sanitize our HTML assuming that no
-        // CSP is enforced on the client. This means that we might actually
-        // gain some security by convincing some users to load HTML in frames,
-        // and thus actually enforce CSP. It is also useful to preview content
-        // in the browser.
-        var styleSource;
-        if (options.domain) {
-            styleSource = this.wildcardSubdomain(options.domain);
-            styleSource = 'http://' + styleSource + ' https://' + styleSource;
+        // Let backend services override CSP headers for HTML / SVG
+        // XXX: Re-consider this policy
+        if (rh['content-security-policy']) {
+            csp = rh['content-security-policy'];
         } else {
-            styleSource = '*';
+            // Our main production clients will ignore CSP anyway (by loading via
+            // XHR or fetch), so we need to sanitize our HTML assuming that no
+            // CSP is enforced on the client. This means that we might actually
+            // gain some security by convincing some users to load HTML in frames,
+            // and thus actually enforce CSP. It is also useful to preview content
+            // in the browser.
+            var styleSource;
+            if (options.domain) {
+                styleSource = this.wildcardSubdomain(options.domain);
+                styleSource = 'http://' + styleSource + ' https://' + styleSource;
+            } else {
+                styleSource = '*';
+            }
+            csp = "default-src 'none'; media-src *; img-src *; style-src "
+                + styleSource
+                + (options && options.allowInline ? " 'unsafe-inline'" : "")
+                + "; frame-ancestors 'self'";
         }
-        csp = "default-src 'none'; media-src *; img-src *; style-src "
-            + styleSource
-            + (options && options.allowInline ? " 'unsafe-inline'" : "")
-            + "; frame-ancestors 'self'";
     } else {
         // Other content: Disallow everything, especially framing to avoid
         // re-dressing attacks.
@@ -106,13 +112,10 @@ rbUtil.addCSPHeaders = function(res, options) {
     }
     rh['x-xss-protection'] = '1; mode=block';
 
-    // Let backend services override CSP headers
-    // XXX: Re-consider this policy
-    if (!rh['content-security-policy']) {
-        cspHeaderVariants.forEach(function(name) {
-            rh[name] = csp;
-        });
-    }
+    // Finally, assign the csp header variants
+    cspHeaderVariants.forEach(function(name) {
+        rh[name] = csp;
+    });
 };
 
 // Parse a POST request into request.body with BusBoy

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -54,24 +54,65 @@ rbUtil.wildcardSubdomain = function(domain) {
     }
 };
 
+function isHtmlSvgContent(res) {
+    return res.headers
+        && /^(?:text\/html|image\/svg)/i.test(res.headers['content-type']);
+}
+
+var cspHeaderVariants = [
+    'content-security-policy',
+    // For IE 10 & 11
+    'x-content-security-policy',
+    // For Chrome <= v25 (seems to be <1% traffic; should we still care?)
+    'x-webkit-csp',
+];
+
 /**
- * Constructs Content-Security-Policy header to send in response
+ * Adds Content-Security-Policy & related headers to send in response
  *
- * @param domain the domain to allow. If undefined, '*' is allowed
+ * @param res response object
  * @param options options containing the following fields:
- *                - allowInline - if true 'unsafe-inline' is added to style-src
- * @returns {string} CSP header value
+ *                - domain: the domain to allow. If undefined, '*' is allowed
+ *                - allowInline: if true 'unsafe-inline' is added to style-src
  */
-rbUtil.constructCSP = function(domain, options) {
-    var styleSource;
-    if (domain) {
-        styleSource = this.wildcardSubdomain(domain);
-        styleSource = 'http://' + styleSource + ' https://' + styleSource;
-    } else {
-        styleSource = '*';
+rbUtil.addCSPHeaders = function(res, options) {
+    if (!res.headers) {
+        res.headers = {};
     }
-    return "default-src 'none'; media-src *; img-src *; style-src " + styleSource
-        + (options && options.allowInline ? " 'unsafe-inline'" : "") + "; frame-ancestors 'self'";
+    var rh = res.headers;
+    var csp;
+    if (isHtmlSvgContent(res)) {
+        // Our main production clients will ignore CSP anyway (by loading via
+        // XHR or fetch), so we need to sanitize our HTML assuming that no
+        // CSP is enforced on the client. This means that we might actually
+        // gain some security by convincing some users to load HTML in frames,
+        // and thus actually enforce CSP. It is also useful to preview content
+        // in the browser.
+        var styleSource;
+        if (options.domain) {
+            styleSource = this.wildcardSubdomain(options.domain);
+            styleSource = 'http://' + styleSource + ' https://' + styleSource;
+        } else {
+            styleSource = '*';
+        }
+        csp = "default-src 'none'; media-src *; img-src *; style-src "
+            + styleSource
+            + (options && options.allowInline ? " 'unsafe-inline'" : "")
+            + "; frame-ancestors 'self'";
+    } else {
+        // Other content: Disallow everything, especially framing to avoid
+        // re-dressing attacks.
+        csp = "default-src 'none'; frame-ancestors 'none'";
+    }
+    rh['x-xss-protection'] = '1; mode=block';
+
+    // Let backend services override CSP headers
+    // XXX: Re-consider this policy
+    if (!rh['content-security-policy']) {
+        cspHeaderVariants.forEach(function(name) {
+            rh[name] = csp;
+        });
+    }
 };
 
 // Parse a POST request into request.body with BusBoy

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,29 +31,19 @@ function handleResponse(opts, req, resp, response) {
         }
 
         // Set up CORS
-        rh['Access-Control-Allow-Origin'] = '*';
-        rh['Access-Control-Allow-Methods'] = 'GET';
-        rh['Access-Control-Allow-Headers'] = 'accept, content-type';
+        rh['access-control-allow-origin'] = '*';
+        rh['access-control-allow-methods'] = 'GET';
+        rh['access-control-allow-headers'] = 'accept, content-type';
 
         // Set up security headers
         // https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-        rh['X-Content-Type-Options'] = 'nosniff';
-        rh['X-Frame-Options'] = 'SAMEORIGIN';
+        rh['x-content-type-options'] = 'nosniff';
+        rh['x-frame-options'] = 'SAMEORIGIN';
 
-        if (!/^application\/json/.test(rh['content-type'])) {
-            rh['X-XSS-Protection'] = '1; mode=block';
-            if (!rh['Content-Security-Policy']) {
-                rh['Content-Security-Policy'] =
-                    rbUtil.constructCSP(req.params ? req.params.domain : undefined);
-            }
-            // For IE 10 & 11
-            rh['X-Content-Security-Policy'] = rh['Content-Security-Policy'];
-            // For Chrome <= v25 (seems to be <1% traffic; should we still care?)
-            rh['X-WebKit-CSP'] = rh['Content-Security-Policy'];
-        }
+        rbUtil.addCSPHeaders(response, { domain: req.params && req.params.domain });
 
         // Propagate the request id header
-        rh['X-Request-Id'] = opts.reqId;
+        rh['x-request-id'] = opts.reqId;
 
         var logLevel = 'trace/request';
         if (response.status >= 500) {

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -351,10 +351,10 @@ PSP.getFormat = function(format, restbase, req) {
     }
     return contentReq
     .then(function(res) {
-        if (res && res.headers && !/^application\/json/.test(res.headers['content-type'])) {
-            res.headers['Content-Security-Policy'] =
-                rbUtil.constructCSP(rp.domain, { allowInline: true });
-        }
+        rbUtil.addCSPHeaders(res, {
+            domain: rp.domain,
+            allowInline: true,
+        });
         return res;
     });
 };


### PR DESCRIPTION
- Create a single method to encapsulate all CSP header logic in one place.
- Set really strict CSP headers on anything but text/html and image/svg.
- Consistently lowercase header names to avoid confusion and subtle bugs.

Task: https://phabricator.wikimedia.org/T112586