### PR TITLE
Document Cassandra datacenter configuration

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -65,10 +65,10 @@ templates:
           - name: restbase-mod-table-cassandra
             version: 1.0.0
             type: npm
+            # See: https://github.com/wikimedia/restbase-mod-table-cassandra/blob/master/Readme.md#configuration
             options: # Passed to the module constructor
               conf:
                 hosts: [localhost]
-                keyspace: system
                 username: cassandra
                 password: cassandra
                 defaultConsistency: one # or 'one' for single-node testing

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -65,10 +65,10 @@ templates:
           - name: restbase-mod-table-cassandra
             version: 1.0.0
             type: npm
+            # See: https://github.com/wikimedia/restbase-mod-table-cassandra/blob/master/Readme.md#configuration
             options: # Passed to the module constructor
               conf:
                 hosts: [localhost]
-                keyspace: system
                 username: cassandra
                 password: cassandra
                 defaultConsistency: one # or 'one' for single-node testing

--- a/debian/config.yaml.example
+++ b/debian/config.yaml.example
@@ -6,7 +6,6 @@ storage:
     hosts:
       - localhost
     id: <uuid>
-    keyspace: system
     username: test
     password: test
     poolSize: 70


### PR DESCRIPTION
This links to the documentation added in https://github.com/wikimedia/restbase-mod-table-cassandra/pull/147, and so ought to be merged after it.

References to the `keyspace` directive were also removed here.  There isn't likely to be any legit reason that a user would need to configure this themselves (and it defaults to `system` if unset).

Bug: https://phabricator.wikimedia.org/T76494