### PR TITLE
Check client IP on requests to POST storage

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -57,7 +57,7 @@ templates:
       title: Default MediaWiki sys API module
       version: 1.0.0
     securityDefinitions:
-      header_match:
+      header_match: 
         description: Checks client ip against one of the predefined whitelists
         x-error-message: This client is not allowed to use the endpoint
         x-whitelists:
@@ -100,11 +100,6 @@ templates:
           - name: post_data
             version: 1.0.0
             type: file
-        security:
-          - header_match:
-              - header: 'x-rb-client-ip'
-                patterns:
-                  - internal
 
       /{module:key_rev_value}:
         x-modules:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -57,9 +57,10 @@ templates:
       title: Default MediaWiki sys API module
       version: 1.0.0
     securityDefinitions:
-      client_ip:
+      header_match:
         description: Checks client ip against one of the predefined whitelists
-        x-client-whitelists:
+        x-error-message: This client is not allowed to use the endpoint
+        x-whitelists:
           internal:
             - /^(?:::ffff:)?(?:10|127)\./
     paths:
@@ -100,8 +101,10 @@ templates:
             version: 1.0.0
             type: file
         security:
-          - client_ip:
-              - internal
+          - header_match:
+              - header: 'x-rb-client-ip'
+                patterns:
+                  - internal
 
       /{module:key_rev_value}:
         x-modules:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -56,6 +56,12 @@ templates:
     info:
       title: Default MediaWiki sys API module
       version: 1.0.0
+    securityDefinitions:
+      client_ip:
+        description: Checks client ip against one of the predefined whitelists
+        x-client-whitelists:
+          internal:
+            - /^(?:::ffff:)?(?:10|127)\./
     paths:
       /{module:table}: &wp/sys/table # Can use this anchor to share the table
         x-modules:
@@ -93,7 +99,9 @@ templates:
           - name: post_data
             version: 1.0.0
             type: file
-
+        security:
+          - client_ip:
+              - internal
 
       /{module:key_rev_value}:
         x-modules:

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -85,11 +85,13 @@ var securityDefinitionCreators = {
             }
         };
     },
-    client_ip: function(definition) {
+    header_match: function(definition) {
+        var errorMessage = definition['x-error-message']
+            || 'This client is not allowed to use the endpoint';
         var whitelistMap = {};
-        Object.keys(definition['x-client-whitelists']).forEach(function(whitelistName) {
+        Object.keys(definition['x-whitelists']).forEach(function(whitelistName) {
             whitelistMap[whitelistName]
-            = constructInternalRequestRegex(definition['x-client-whitelists'][whitelistName]);
+            = constructInternalRequestRegex(definition['x-whitelists'][whitelistName]);
         });
 
         return {
@@ -101,27 +103,28 @@ var securityDefinitionCreators = {
                     return;
                 }
 
-                permissions.forEach(function(permission) {
-                    if (!whitelistMap[permission]) {
-                        throw new Error('Invalid spec. ' +
+                permissions.forEach(function(headerMatchRequirement) {
+                    var headerName = headerMatchRequirement.header;
+                    var headerValue = req.headers && req.headers[headerName]
+                            || restbase._rootReq.headers && restbase._rootReq.headers[headerName];
+
+                    headerMatchRequirement.patterns.forEach(function(permission) {
+                        if (!whitelistMap[permission]) {
+                            throw new Error('Invalid spec. ' +
                             'Unknown client ip whitelist name: ' + permission);
-                    }
+                        }
 
-                    var xff = req.headers && req.headers['x-forwarded-for']
-                                || restbase._rootReq.headers
-                                    && restbase._rootReq.headers['x-forwarded-for'];
-                    var remoteAddr = xff && xff.split(',')[0].trim();
-
-                    if (!whitelistMap[permission].test(remoteAddr)) {
-                        throw new rbUtil.HTTPError({
-                            status: 403,
-                            body: {
-                                type: 'forbidden',
-                                title: 'Access to resource denied',
-                                description: 'This client is not allowed to use the endpoint'
-                            }
-                        });
-                    }
+                        if (!whitelistMap[permission].test(headerValue)) {
+                            throw new rbUtil.HTTPError({
+                                status: 403,
+                                body: {
+                                    type: 'forbidden',
+                                    title: 'Access to resource denied',
+                                    description: errorMessage
+                                }
+                            });
+                        }
+                    });
                 });
             }
         };

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -96,14 +96,20 @@ var securityDefinitionCreators = {
             prepareRequest: function() {
             },
             checkPermissions: function(restbase, req, permissions) {
+                if (restbase._rootReq.uri === '#internal-startup') {
+                    // Skip a check on requests made by RESTBase during startup
+                    return;
+                }
+
                 permissions.forEach(function(permission) {
                     if (!whitelistMap[permission]) {
                         throw new Error('Invalid spec. ' +
                             'Unknown client ip whitelist name: ' + permission);
                     }
 
-                    var xff = req.headers['x-forwarded-for']
-                                || restbase._rootReq.headers['x-forwarded-for'];
+                    var xff = req.headers && req.headers['x-forwarded-for']
+                                || restbase._rootReq.headers
+                                    && restbase._rootReq.headers['x-forwarded-for'];
                     var remoteAddr = xff && xff.split(',')[0].trim();
 
                     if (!whitelistMap[permission].test(remoteAddr)) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -48,7 +48,20 @@ var securityDefinitionCreators = {
                     rbUtil.copyForwardedCookies(restbase, req);
                 }
             },
-            checkPermissions: function(restbase, req, permissions) {
+            checkPermissions: function(restbase, req, permDefinitions) {
+                // First filter permissions applicable to the current method
+                var permissions = [];
+                permDefinitions.forEach(function(perm) {
+                    if (!perm.method || perm.method === req.method) {
+                        permissions.push(perm.value);
+                    }
+                });
+
+                // If nothing is applicable to the current method - skip the check
+                if (permissions.length === 0) {
+                    return;
+                }
+
                 var checkReq = {
                     uri: new URI([req.params.domain, 'sys', 'action', 'query']),
                     method: 'post',
@@ -91,7 +104,7 @@ var securityDefinitionCreators = {
         var whitelistMap = {};
         Object.keys(definition['x-whitelists']).forEach(function(whitelistName) {
             whitelistMap[whitelistName]
-            = constructInternalRequestRegex(definition['x-whitelists'][whitelistName]);
+                = constructInternalRequestRegex(definition['x-whitelists'][whitelistName]);
         });
 
         return {
@@ -103,7 +116,14 @@ var securityDefinitionCreators = {
                     return;
                 }
 
-                permissions.forEach(function(headerMatchRequirement) {
+                permissions.forEach(function(requirementDefinition) {
+                    // Check if requirement is limited to some method
+                    if (requirementDefinition.method
+                            && requirementDefinition.method !== req.method) {
+                        return;
+                    }
+
+                    var headerMatchRequirement = requirementDefinition.value;
                     var headerName = headerMatchRequirement.header;
                     var headerValue = req.headers && req.headers[headerName]
                             || restbase._rootReq.headers && restbase._rootReq.headers[headerName];
@@ -169,16 +189,24 @@ function AuthService(spec) {
 AuthService.prototype.addRequirements = function(requirements) {
     var self = this;
     requirements.forEach(function(permObj) {
-        var names = Object.keys(permObj);
+        var names = Object.keys(permObj.value);
         if (names.length !== 1) {
             throw new Error('Invalid security requirement object: ' + JSON.stringify(permObj));
         }
         var name = names[0];
         if (!self.securityRequirements[name]) {
-            self.securityRequirements[name] = new Set(permObj[name]);
+            self.securityRequirements[name] = new Set(permObj.value[name].map(function(perm) {
+                return {
+                    value: perm,
+                    method: permObj.method
+                };
+            }));
         } else {
             permObj[name].forEach(function(perm) {
-                self.securityRequirements[name].add(perm);
+                self.securityRequirements[name].add({
+                    value: perm,
+                    method: permObj.method
+                });
             });
         }
     });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -128,13 +128,13 @@ var securityDefinitionCreators = {
                     var headerValue = req.headers && req.headers[headerName]
                             || restbase._rootReq.headers && restbase._rootReq.headers[headerName];
 
-                    headerMatchRequirement.patterns.forEach(function(permission) {
-                        if (!whitelistMap[permission]) {
+                    headerMatchRequirement.patterns.forEach(function(patternName) {
+                        if (!whitelistMap[patternName]) {
                             throw new Error('Invalid spec. ' +
-                            'Unknown client ip whitelist name: ' + permission);
+                            'Unknown client ip whitelist name: ' + patternName);
                         }
 
-                        if (!whitelistMap[permission].test(headerValue)) {
+                        if (!whitelistMap[patternName].test(headerValue)) {
                             throw new rbUtil.HTTPError({
                                 status: 403,
                                 body: {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -84,6 +84,41 @@ var securityDefinitionCreators = {
                 });
             }
         };
+    },
+    client_ip: function(definition) {
+        var whitelistMap = {};
+        Object.keys(definition['x-client-whitelists']).forEach(function(whitelistName) {
+            whitelistMap[whitelistName]
+            = constructInternalRequestRegex(definition['x-client-whitelists'][whitelistName]);
+        });
+
+        return {
+            prepareRequest: function() {
+            },
+            checkPermissions: function(restbase, req, permissions) {
+                permissions.forEach(function(permission) {
+                    if (!whitelistMap[permission]) {
+                        throw new Error('Invalid spec. ' +
+                            'Unknown client ip whitelist name: ' + permission);
+                    }
+
+                    var xff = req.headers['x-forwarded-for']
+                                || restbase._rootReq.headers['x-forwarded-for'];
+                    var remoteAddr = xff && xff.split(',')[0].trim();
+
+                    if (!whitelistMap[permission].test(remoteAddr)) {
+                        throw new rbUtil.HTTPError({
+                            status: 403,
+                            body: {
+                                type: 'forbidden',
+                                title: 'Access to resource denied',
+                                description: 'This client is not allowed to use the endpoint'
+                            }
+                        });
+                    }
+                });
+            }
+        };
     }
 };
 

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -325,13 +325,20 @@ RESTBase.prototype._request = function(req) {
         });
 
         if (accessRestricted) {
-            return P.all([
-                reqHandlerPromise,
-                childRESTBase._authService.checkPermissions(childRESTBase, childReq)
-            ])
-            .then(function(res) {
-                return res[0];
-            });
+            if (req.method === 'get' || req.method === 'head') {
+                return P.all([
+                    reqHandlerPromise,
+                    childRESTBase._authService.checkPermissions(childRESTBase, childReq)
+                ])
+                .then(function(res) {
+                    return res[0];
+                });
+            } else {
+                return childRESTBase._authService.checkPermissions(childRESTBase, childReq)
+                .then(function() {
+                    return reqHandlerPromise;
+                });
+            }
         } else {
             return reqHandlerPromise;
         }

--- a/lib/router.js
+++ b/lib/router.js
@@ -208,9 +208,9 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
 
     var security = pathspec.security;
     if (Array.isArray(security)) {
-        loaderPromise = loaderPromise.then(function() {
-            node.value.security = security.concat(node.value.security || []);
-        });
+        node.value.security = security.map(function(item) {
+            return { value: item };
+        }).concat(node.value.security || []);
     }
 
     return loaderPromise
@@ -234,6 +234,16 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
             if (node.value.methods[methodName]) {
                 throw new Error('Trying to re-define existing method '
                     + node.value.path + ':' + methodName);
+            }
+
+            // Check and add method-level security specs
+            if (Array.isArray(method.security)) {
+                node.value.security = method.security.map(function(item) {
+                    return {
+                        value: item,
+                        method: methodName
+                    };
+                }).concat(node.value.security || []);
             }
 
             var backendSetup = method && method['x-setup-handler'];

--- a/lib/server.js
+++ b/lib/server.js
@@ -169,6 +169,8 @@ function handleRequest(opts, req, resp) {
     // Set the request ID early on for external requests
     req.headers = req.headers || {};
     req.headers['x-request-id'] = req.headers['x-request-id'] || rbUtil.generateRequestId();
+    req.headers['x-forwarded-for'] = req.headers['x-forwarded-for']
+        || req.socket && req.socket.remoteAddress;
 
     var reqOpts = {
         conf: opts.conf,
@@ -187,8 +189,7 @@ function handleRequest(opts, req, resp) {
 
     // Simplistic count of requests from public & private networks
     var xff = req.headers['x-forwarded-for'];
-    var remoteAddr = xff && xff.split(',')[0].trim()
-        || req.socket.remoteAddress;
+    var remoteAddr = xff && xff.split(',')[0].trim();
     if (/^(?:::ffff:)?(?:10|127)\./.test(remoteAddr)) {
         reqOpts.metrics.increment('requests.private');
     } else {
@@ -291,7 +292,12 @@ function main(options) {
     opts.restbase = new Restbase(opts);
     // Use a child restbase instance to sidestep the security protection for
     // direct requests to /sys
-    var childRestBase = opts.restbase.makeChild({ uri: '#internal-startup' });
+    var childRestBase = opts.restbase.makeChild({
+        uri: '#internal-startup',
+        headers: {
+            'x-forwarded-for': '127.0.0.1'
+        }
+    });
     // Main app startup happens during async spec loading:
     return opts.router.loadSpec(conf.spec, childRestBase)
     .then(function(router) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -169,8 +169,14 @@ function handleRequest(opts, req, resp) {
     // Set the request ID early on for external requests
     req.headers = req.headers || {};
     req.headers['x-request-id'] = req.headers['x-request-id'] || rbUtil.generateRequestId();
-    req.headers['x-forwarded-for'] = req.headers['x-forwarded-for']
-        || req.socket && req.socket.remoteAddress;
+    if (req.socket) {
+        if (req.headers['x-forwarded-for']) {
+            req.headers['x-forwarded-for'] =
+                req.headers['x-forwarded-for'] + ', ' + req.socket.remoteAddress;
+        } else {
+            req.headers['x-forwarded-for'] = req.socket.remoteAddress;
+        }
+    }
 
     var reqOpts = {
         conf: opts.conf,
@@ -293,10 +299,7 @@ function main(options) {
     // Use a child restbase instance to sidestep the security protection for
     // direct requests to /sys
     var childRestBase = opts.restbase.makeChild({
-        uri: '#internal-startup',
-        headers: {
-            'x-forwarded-for': '127.0.0.1'
-        }
+        uri: '#internal-startup'
     });
     // Main app startup happens during async spec loading:
     return opts.router.loadSpec(conf.spec, childRestBase)

--- a/lib/server.js
+++ b/lib/server.js
@@ -169,14 +169,6 @@ function handleRequest(opts, req, resp) {
     // Set the request ID early on for external requests
     req.headers = req.headers || {};
     req.headers['x-request-id'] = req.headers['x-request-id'] || rbUtil.generateRequestId();
-    if (req.socket) {
-        if (req.headers['x-forwarded-for']) {
-            req.headers['x-forwarded-for'] =
-                req.headers['x-forwarded-for'] + ', ' + req.socket.remoteAddress;
-        } else {
-            req.headers['x-forwarded-for'] = req.socket.remoteAddress;
-        }
-    }
 
     var reqOpts = {
         conf: opts.conf,
@@ -195,7 +187,10 @@ function handleRequest(opts, req, resp) {
 
     // Simplistic count of requests from public & private networks
     var xff = req.headers['x-forwarded-for'];
-    var remoteAddr = xff && xff.split(',')[0].trim();
+    var remoteAddr = xff && xff.split(',')[0].trim()
+            || req.socket.remoteAddress;
+    req.headers['x-rb-client-ip'] = remoteAddr;
+
     if (/^(?:::ffff:)?(?:10|127)\./.test(remoteAddr)) {
         reqOpts.metrics.increment('requests.private');
     } else {
@@ -298,9 +293,7 @@ function main(options) {
     opts.restbase = new Restbase(opts);
     // Use a child restbase instance to sidestep the security protection for
     // direct requests to /sys
-    var childRestBase = opts.restbase.makeChild({
-        uri: '#internal-startup'
-    });
+    var childRestBase = opts.restbase.makeChild({ uri: '#internal-startup' });
     // Main app startup happens during async spec loading:
     return opts.router.loadSpec(conf.spec, childRestBase)
     .then(function(router) {

--- a/mods/post_data.yaml
+++ b/mods/post_data.yaml
@@ -21,3 +21,8 @@ paths:
   /{bucket}/:
     put:
       operationId: putRevision
+      security:
+        - header_match:
+            - header: 'x-rb-client-ip'
+              patterns:
+                - internal

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "preq": "^0.4.4",
     "restbase-mod-table-cassandra": "^0.8.0",
     "service-runner": "^0.2.5",
-    "swagger-router": "^0.1.1",
+    "swagger-router": "^0.1.2",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "tassembly": "^0.1.4",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",

--- a/test/features/post_data.js
+++ b/test/features/post_data.js
@@ -48,4 +48,21 @@ describe('post_data', function () {
             assert.deepEqual(res.body, hash);
         });
     });
+
+    it('should deny access on remote requests', function() {
+        return preq.post({
+            uri: server.config.baseURL + '/post_data/',
+            headers: {
+                'x-forwarded-for': '123.123.123.123'
+            },
+            body: {
+                key: 'value2'
+            }
+        })
+        .then(function() {
+            throw new Error('Error should be thrown');
+        }, function(e) {
+            assert.deepEqual(e.status, 403);
+        });
+    });
 });

--- a/test/features/post_data.js
+++ b/test/features/post_data.js
@@ -49,7 +49,17 @@ describe('post_data', function () {
         });
     });
 
-    it('should deny access on remote requests', function() {
+    it('should allow read on remote request', function() {
+        return preq.get({
+            uri: server.config.baseURL + '/post_data/' + hash
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body, { key: 'value' });
+        })
+    });
+
+    it('should deny write on remote requests', function() {
         return preq.post({
             uri: server.config.baseURL + '/post_data/',
             headers: {

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -149,7 +149,8 @@ var nestedSecuritySpec = {
                                                         }
                                                     }
                                                 }
-                                            ]
+                                            ],
+                                            security: [ 'forth' ]
                                         }
                                     }
                                 }
@@ -237,7 +238,12 @@ describe('tree building', function() {
         return router.loadSpec(nestedSecuritySpec)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/secure');
-            assert.deepEqual(handler.permissions, ['first', 'second', 'third']);
+            assert.deepEqual(handler.permissions, [
+                { value: 'first' },
+                { value: 'second'},
+                { value: 'third' },
+                { value: 'forth', method: 'get' }
+            ]);
         });
     });
 


### PR DESCRIPTION
This PR is very tightly coupled with https://github.com/wikimedia/restbase/pull/332. 

It's more a prototype to start the discussion, than a final implementation. A couple of notes:
1. The `client_ip` securityDefinition is set on the `/sys` subspec, so it doesn't get to the publicly exposed spec, leaving it valid (this securityDefinition is invalid from swagger perspective) while we can still use it on the /sys level. When we need to add such a feature on /api level we can move it (and rename to x-securityDefinitions).
2. If we state, that RB works as a proxy, the correct way to work with an `x-forwarded-for` header would be to add request's `remoteAddress` to the incoming header's proxy list, or set it as a client ip if no header was passed. 
3. RB can make requests upon startup and these shouldn't be checked.
4. Parallel access checks are only valid for GET and HEAD, other methods should use sequential checks.