### PR TITLE
Minor templating improvements

### DIFF
--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -59,17 +59,19 @@ function generatePromiseChain(restbase, context, requestChain) {
  */
 function compileCatchFunction(catchDefinition) {
     function createCondition(catchCond, option) {
+        var opt = option.toString();
         if (catchCond === 'status') {
-            if (/^[0-9]+$/.test(option.toString())) {
-                return '(res["' + catchCond + '"] === ' + option + ')';
-            } else if (/^[0-9x]$/.test(option.toString())) {
-                return '(/^' + option.replace('x', '.') +
-                '$/.test(res["' + catchCond + '"].toString())';
+            if (/^[0-9]+$/.test(opt)) {
+                return '(res["' + catchCond + '"] === ' + opt + ')';
+            } else if (/^[0-9x]+$/.test(opt)) {
+                return 'Array.isArray(res["' + catchCond
+                    + '"].toString().match(/^' + opt.replace(/x/g, '.')
+                    + '$/))';
             } else {
-                throw new Error('Invalid condition ' + option);
+                throw new Error('Invalid condition ' + opt);
             }
         } else {
-            return '(res["' + catchCond + '"] === ' + option + ')';
+            return '(res["' + catchCond + '"] === ' + opt + ')';
         }
     }
 

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -65,7 +65,7 @@ function compileCatchFunction(catchDefinition) {
                 return '(res["' + catchCond + '"] === ' + opt + ')';
             } else if (/^[0-9x]+$/.test(opt)) {
                 return 'Array.isArray(res["' + catchCond
-                    + '"].toString().match(/^' + opt.replace(/x/g, '.')
+                    + '"].toString().match(/^' + opt.replace(/x/g, "\\d")
                     + '$/))';
             } else {
                 throw new Error('Invalid condition ' + opt);

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -166,7 +166,7 @@ function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
  */
 function createURIResolver(spec) {
     var setter = _setAtPath('uri', spec);
-    if (/^\{[^\{}]+}$/.test(spec.uri)) {
+    if (/^\{[^\{}]+}$/.test(spec.uri) || /\{\$\..+}/.test(spec.uri)) {
         var setValue = function(newReq, value) {
             if (value.constructor !== URI) {
                 value = new URI(value, {}, false);

--- a/test/features/router/handlerTemplate.js
+++ b/test/features/router/handlerTemplate.js
@@ -124,7 +124,7 @@ describe('handler template', function () {
                 return_if: {
                     status: '5xx'
                 },
-                return: '$.request'
+                return: '{$.request}'
             }
         }]);
     });

--- a/test/features/router/handlerTemplate.js
+++ b/test/features/router/handlerTemplate.js
@@ -115,6 +115,20 @@ describe('handler template', function () {
         }, /^Invalid spec\. Either request or return must be specified\..*/);
     });
 
+    it('validates config: compiles a valid condition function', function() {
+        handlerTemplate.createHandler([{
+            get_one: {
+                request: {
+                    uri: '/my/path'
+                },
+                return_if: {
+                    status: '5xx'
+                },
+                return: '$.request'
+            }
+        }]);
+    });
+
     it('validates config: requires request for return_if', function() {
         testValidation(function() {
             handlerTemplate.createHandler([{

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -269,4 +269,19 @@ describe('router - misc', function() {
             assert.deepEqual(res.body, '');
         })
     })
+
+    it('absolute templates in URI', function() {
+        var template = new Template({
+            uri: '/path/{$.request.headers.host}/{$.request.body}'
+        });
+        var request = {
+            method: 'post',
+            headers: {
+                'host': 'test'
+            },
+            body: 'a'
+        };
+        assert.deepEqual(template.eval({request:request}).uri, '/path/test/a');
+    });
+
 });


### PR DESCRIPTION
This PR makes some small improvements to the handler-templating engine:

- **Handle `xxx` conditions properly**. Previously, only one `x` was replaced by a `.` and the construct `/^.$/.test(a_string)` does not seem to pass the syntax check when used inside `new Function(code)`. Both of these bugs have been corrected.
- **Allow URIs to have absolute templates**. Absolute URI templating is needed for cases where one wants to use the POST request's hash string as the primary key for a *key_value* bucket storing responses from back-end services. The PR adds the capability without hurting performance in cases where this is not needed.