### PR TITLE
Added support for default values in templates

### DIFF
--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -92,12 +92,15 @@ function compileTemplate(templateSpec, setValue, reqPart) {
             res += '' + bit;
         }
     };
+    var errorHandler = function() { return undefined; };
+
     var resolveTemplate = TAssembly.compile(template, {
         nestedTemplate: true,
-        cb: callback
+        cb: callback,
+        errorHandler: errorHandler
     });
     var options = {
-        errorHandler: function() { return undefined; },
+        errorHandler: errorHandler,
         cb: callback,
         globals: {
             default: function(val, defVal) {

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -52,10 +52,6 @@ function _setAtPath(path, spec) {
  * @returns {string} validated and
  */
 function prepareTemplateString(template, defaultLookupPath) {
-    if (!/^(\$\.)?([a-zA-Z][a-zA-Z0-9-_]*)(\.[a-zA-Z][a-zA-Z0-9-_]*)*$/.test(template)) {
-        throw new Error('Invalid template ' + template);
-    }
-
     if (template[0] === '$') {
         template = 'rm' + template.slice(1);
     } else {
@@ -75,12 +71,32 @@ function prepareTemplateString(template, defaultLookupPath) {
  * @returns {Function} a template resolver for the provided template
  */
 function compileTemplate(templateSpec, setValue, reqPart) {
+    function createTAssemblyTemplate(template) {
+        if (/^(?:\$\.)?(?:[a-zA-Z][\w-]*)(?:\.[a-zA-Z][\w-]*)*$/.test(template)) {
+            // It's an ordinary template without default value
+            return [['raw', prepareTemplateString(template, reqPart)]];
+        }
+        var condTemplate = new RegExp('^((?:\\$\.)?(?:[a-zA-Z][\\w-]*)(?:\\.[a-zA-Z][\\w-]*)*)' +
+                '\\s?\\|\\|\\s?[\'"]([^\'"]+)[\'"]$').exec(template);
+        if (Array.isArray(condTemplate)) {
+            var paramTemplate = condTemplate[1];
+            var defaultVal = condTemplate[2];
+            var templateString = prepareTemplateString(paramTemplate, reqPart);
+            return [
+                ['if', { data: templateString, tpl: [['raw', templateString]] }],
+                ['ifnot', { data: templateString,  tpl: defaultVal }]
+            ];
+        }
+        throw new Error('Invalid template ' + template);
+    }
+
     var template;
     var prevIndex = 0;
     var completeTemplate = /^\{([^}]+)}$/.exec(templateSpec);
     if (completeTemplate && completeTemplate.length > 0) {
-        template = [['raw', prepareTemplateString(completeTemplate[1], reqPart)]];
+        template = createTAssemblyTemplate(completeTemplate[1]);
     } else {
+        // Only substring is templated
         var re = /\{([^}]+)}/g;
         template = [];
         var match;
@@ -90,7 +106,7 @@ function compileTemplate(templateSpec, setValue, reqPart) {
                 if (match.index !== prevIndex) {
                     template.push(templateSpec.substring(prevIndex, match.index));
                 }
-                template.push(['raw', prepareTemplateString(match[1], reqPart)]);
+                Array.prototype.push.apply(template, createTAssemblyTemplate(match[1]));
                 prevIndex = match.index + match[0].length;
             } else if (prevIndex !== templateSpec.length) {
                 template.push(templateSpec.substring(prevIndex, templateSpec.length));

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -1,9 +1,9 @@
 "use strict";
 
 var URI = require('swagger-router').URI;
-var rbUtil = require('./rbUtil');
 var TAssembly = require('tassembly');
 var url = require('url');
+var expressionCompiler = require('template-expression-compiler');
 
 /**
  * Creates a function that sets a value at the path
@@ -42,24 +42,36 @@ function _setAtPath(path, spec) {
     return new Function('obj', 'value', code);
 }
 
-/**
- * Validates and prepares the template string - resolves local references
- * and wraps property access to ["..."]
- *
- * @param {string} template an original template string
- * @param {string} defaultLookupPath a default path withing the context which
- *                 to look if template is local
- * @returns {string} validated and
- */
-function prepareTemplateString(template, defaultLookupPath) {
-    if (template[0] === '$') {
-        template = 'rm' + template.slice(1);
-    } else {
-        template = 'm.request.' + defaultLookupPath + '.' + template;
+function splitAndPrepareTAsseblyTemplate(templateSpec) {
+    var result = [];
+    var templateNest = 0;
+    var startIndex = 0;
+    var currentTemplate;
+    for (var index = 0; index < templateSpec.length; index++) {
+        if (templateSpec[index] === '{') {
+            if (templateNest === 0) { // We are either entering a new template
+                if (startIndex !== index) {
+                    result.push(templateSpec.substring(startIndex, index));
+                }
+                startIndex = index + 1;
+            } // Or entering an object literal
+            templateNest++;
+        } else if (templateSpec[index] === '}') {
+            if (templateNest === 1) { // The current template is finished
+                currentTemplate = templateSpec.substring(startIndex, index);
+                result.push(['raw', expressionCompiler.parse(currentTemplate)]);
+                startIndex = index + 1;
+            } // Or and object literal finished
+            templateNest--;
+        }
     }
-    return template.replace(/\.([^.]*(?:-[^.]*)+)/g, function(all, paren) {
-        return "['" + paren.replace(/'/g, "\\'") + "']";
-    });
+    if (startIndex !== index) {
+        result.push(templateSpec.substring(startIndex));
+    }
+    if (templateNest > 0) {
+        throw new Error('Illegal template, unbalanced curly braces');
+    }
+    return result;
 }
 
 /**
@@ -71,62 +83,58 @@ function prepareTemplateString(template, defaultLookupPath) {
  * @returns {Function} a template resolver for the provided template
  */
 function compileTemplate(templateSpec, setValue, reqPart) {
-    function createTAssemblyTemplate(template) {
-        if (/^(?:\$\.)?(?:[a-zA-Z][\w-]*)(?:\.[a-zA-Z][\w-]*)*$/.test(template)) {
-            // It's an ordinary template without default value
-            return [['raw', prepareTemplateString(template, reqPart)]];
-        }
-        var condTemplate = new RegExp('^((?:\\$\.)?(?:[a-zA-Z][\\w-]*)(?:\\.[a-zA-Z][\\w-]*)*)' +
-                '\\s?\\|\\|\\s?[\'"]([^\'"]+)[\'"]$').exec(template);
-        if (Array.isArray(condTemplate)) {
-            var paramTemplate = condTemplate[1];
-            var defaultVal = condTemplate[2];
-            var templateString = prepareTemplateString(paramTemplate, reqPart);
-            return [
-                ['if', { data: templateString, tpl: [['raw', templateString]] }],
-                ['ifnot', { data: templateString,  tpl: defaultVal }]
-            ];
-        }
-        throw new Error('Invalid template ' + template);
-    }
-
-    var template;
-    var prevIndex = 0;
-    var completeTemplate = /^\{([^}]+)}$/.exec(templateSpec);
-    if (completeTemplate && completeTemplate.length > 0) {
-        template = createTAssemblyTemplate(completeTemplate[1]);
-    } else {
-        // Only substring is templated
-        var re = /\{([^}]+)}/g;
-        template = [];
-        var match;
-        do {
-            match = re.exec(templateSpec);
-            if (match) {
-                if (match.index !== prevIndex) {
-                    template.push(templateSpec.substring(prevIndex, match.index));
-                }
-                Array.prototype.push.apply(template, createTAssemblyTemplate(match[1]));
-                prevIndex = match.index + match[0].length;
-            } else if (prevIndex !== templateSpec.length) {
-                template.push(templateSpec.substring(prevIndex, templateSpec.length));
-            }
-        } while (match);
-    }
-
     var res;
+    var template = splitAndPrepareTAsseblyTemplate(templateSpec);
+    var callback = function(bit) {
+        if (res === undefined) {
+            res = bit;
+        } else {
+            res += '' + bit;
+        }
+    };
     var resolveTemplate = TAssembly.compile(template, {
+        nestedTemplate: true,
+        cb: callback
+    });
+    var options = {
         errorHandler: function() { return undefined; },
-        cb: function(bit) {
-            if (res === undefined) {
-                res = bit;
-            } else {
-                res += '' + bit;
+        cb: callback,
+        globals: {
+            default: function(val, defVal) {
+                return val || defVal;
+            },
+            merge: function(destination, source) {
+                destination = destination || {};
+                source = source || {};
+
+                if (typeof destination !== 'object' || typeof source !== 'object') {
+                    throw new Error('Illegal spec. Merge source and destination must be objects');
+                }
+
+                var result = Object.assign({}, destination);
+                Object.keys(source).forEach(function(keyName) {
+                    if (result[keyName] === undefined) {
+                        result[keyName] = source[keyName];
+                    }
+                });
+                return result;
             }
         }
-    });
+    };
+
     return function(newReq, context) {
-        resolveTemplate(context);
+        var extendedContext = {
+            rc: null,
+            rm: context,
+            m: context.request[reqPart],
+            pms: [ context.request[reqPart] ],
+            g: options.globals,
+            options: options,
+            cb: options.cb
+        };
+        extendedContext.rc = extendedContext;
+
+        resolveTemplate(extendedContext);
         var value = res;
         res = undefined; // Unitialize res to prepare to the next request
         setValue(newReq, value);
@@ -182,7 +190,7 @@ function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
  */
 function createURIResolver(spec) {
     var setter = _setAtPath('uri', spec);
-    if (/^\{[^\{}]+}$/.test(spec.uri) || /\{\$\..+}/.test(spec.uri)) {
+    if (/^\{[^\{}]+}$/.test(spec.uri) || /\{\$\$?\..+}/.test(spec.uri)) {
         var setValue = function(newReq, value) {
             if (value.constructor !== URI) {
                 value = new URI(value, {}, false);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "swagger-router": "^0.1.1",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "tassembly": "^0.1.4",
-    "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master"
+    "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
+    "template-expression-compiler": "^0.1.0"
   },
   "devDependencies": {
     "bunyan": "^1.4.0",

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -284,4 +284,33 @@ describe('router - misc', function() {
         assert.deepEqual(template.eval({request:request}).uri, '/path/test/a');
     });
 
+    it('supports default values in req templates', function() {
+        var template = new Template({
+            uri: '/path/{$.request.body.test || "default"}',
+            body: {
+                complete: '{$.request.body.test || "default"}',
+                partial: '/test/{$.request.body.test || "default"}'
+            }
+        });
+        var evaluatedNoDefaults = template.eval({
+            request: {
+                method: 'get',
+                body: {
+                    test: 'value'
+                }
+            }
+        });
+        assert.deepEqual(evaluatedNoDefaults.uri, '/path/value');
+        assert.deepEqual(evaluatedNoDefaults.body.complete, 'value');
+        assert.deepEqual(evaluatedNoDefaults.body.partial, '/test/value');
+        var evaluatedDefaults = template.eval({
+            request: {
+                method: 'get',
+                body: {}
+            }
+        });
+        assert.deepEqual(evaluatedDefaults.uri, '/path/default');
+        assert.deepEqual(evaluatedDefaults.body.complete, 'default');
+        assert.deepEqual(evaluatedDefaults.body.partial, '/test/default');
+    });
 });


### PR DESCRIPTION
Added support for `{$.request.body.xxx || "defaultVal"}` in request templates.

But please be aware, that although it's a handy feature, it's quite slow. Template evaluation benchmarks shows ~5-7 times performance impact comparing to plain template without a default. But we can live with it, as impact on a endpoint latency is close to 0.