### PR TITLE
Mathoid: Add public and back-end endpoints

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -41,7 +41,7 @@ templates:
       - mediawiki/v1/mobileapps
       - media/v1/mathoid
     # - mediawiki/v1/revision-scoring
-    securityDefinitions:
+    securityDefinitions: &wp/content-security/1.0.0
       mediawiki_auth:
         description: Checks permissions using MW api
         type: apiKey
@@ -201,6 +201,7 @@ templates:
   global-content: &gb/content/1.0.0
     swagger: '2.0'
     info: *wp/content-info/1.0.0
+    securityDefinitions: *wp/content-security/1.0.0
     x-subspecs:
       - media/v1/mathoid
 

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -112,7 +112,7 @@ templates:
             options:
               apiRequest:
                 method: post
-                uri: 'http://{domain}/w/api.php'
+                uri: http://{domain}/w/api.php
                 headers:
                   host: '{$.request.params.domain}'
                 body: '{$.request.body}'
@@ -204,7 +204,7 @@ templates:
       /{module:table}: *wp/sys/table
       /{module:key_value}: *wp/sys/key_value
       /{module:post_data}: *wp/sys/post_data
-      /{module:mathoid}/v1/request:
+      /{module:mathoid}/v1/request/{format}:
         post:
           x-request-handler:
             - store:
@@ -214,19 +214,17 @@ templates:
                   body:
                     q: '{$.request.body.q}'
                     type: '{$$.default($.request.body.type, "tex")}'
-                    format: '{$$.default($.request.body.format, "json")}'
             - handle_req:
                 request:
                   method: post
-                  uri: /{domain}/sys/mathoid/v1/handler
+                  uri: /{domain}/sys/mathoid/v1/handler/{format}
                   headers:
                     cache-control: '{cache-control}'
                     x-resource-location: '{$.store.body}'
                   body:
                     q: '{$.request.body.q}'
                     type: '{$$.default($.request.body.type, "tex")}'
-                    format: '{$$.default($.request.body.format, "json")}'
-      /{module:mathoid}/v1/request/{hash}:
+      /{module:mathoid}/v1/request/{format}/{hash}:
         get:
           x-setup-handler:
             - init:
@@ -239,12 +237,12 @@ templates:
             - handle_req:
                 request:
                   method: post
-                  uri: /{domain}/sys/mathoid/v1/handler
+                  uri: /{domain}/sys/mathoid/v1/handler/{format}
                   headers:
                     cache-control: '{cache-control}'
                     x-resource-location: '{$.request.params.hash}'
                   body: '{$.get_from_storage.body}'
-      /{module:mathoid}/v1/handler:
+      /{module:mathoid}/v1/handler/{format}:
         post:
           x-setup-handler:
             - init:
@@ -263,17 +261,14 @@ templates:
                   status: '2xx'
                 return:
                   status: 200
-                  headers: '{$.check_storage.body.headers}'
-                  body: '{$.check_storage.body.data}'
+                  headers: '{$$.merge($.check_storage.body.data[$.request.params.format].headers,$.check_storage.body.headers)}'
+                  body: '{$.check_storage.body.data[$.request.params.format].body}'
                 catch:
                   status: 404
             - mathoid:
                 request:
                   method: post
-                  uri: http://mathoid-tester.wmflabs.org/{$.request.body.format}
-                  # force preq to convert the response into a string
-                  # so that it can be stored properly as a JSON
-                  encoding: utf8
+                  uri: http://mathoid-tester.wmflabs.org/complete
                   body:
                     q: '{$.request.body.q}'
                     type: '{$.request.body.type}'
@@ -288,8 +283,8 @@ templates:
                     data: '{$.mathoid.body}'
                 return:
                   status: 200
-                  headers: '{$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location})}'
-                  body: '{$.mathoid.body}'
+                  headers: '{$$.merge($.mathoid.body[$.request.params.format].headers,$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location}))}'
+                  body: '{$.mathoid.body[$.request.params.format].body}'
 
 
   wp-default-1.0.0: &wp/default/1.0.0

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -332,7 +332,7 @@ spec: &spec
 #   /{domain:nl.wikipedia.org}: *wp/default/1.0.0
 
     # global domain
-    /{domain:window.wikimedia.org}: *gb/default/1.0.0
+    /{domain:wikimedia.org}: *gb/default/1.0.0
 
 
 services:

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -13,7 +13,7 @@ templates:
       version: 1.0.0-beta
       title: Wikimedia REST API
       description: >
-          This API aims to provide straightforward and low-latency access to
+          This API aims to provide coherent and low-latency access to
           Wikimedia content and services. It is currently in beta testing, so
           things aren't completely locked down yet. Each entry point has
           explicit stability markers to inform you about development status
@@ -21,8 +21,7 @@ templates:
           policy](https://www.mediawiki.org/wiki/API_versioning).
 
           ### High-volume access
-            - As a general rule, don't perform more than 200 requests/s to
-              this API.
+            - Don't perform more than 500 requests/s to this API.
             - Set a unique `User-Agent` header that allows us to contact you
               quickly. Email addresses or URLs of contact pages work well.
             - Consider using our [HTML
@@ -40,6 +39,7 @@ templates:
       - mediawiki/v1/content
       - mediawiki/v1/graphoid
       - mediawiki/v1/mobileapps
+      - media/v1/mathoid
     # - mediawiki/v1/revision-scoring
     securityDefinitions:
       mediawiki_auth:
@@ -62,7 +62,7 @@ templates:
       title: Default MediaWiki sys API module
       version: 1.0.0
     paths:
-      /{module:table}:
+      /{module:table}: &wp/sys/table
         x-modules:
           # There can be multiple modules too per stanza, as long as the
           # exported symbols don't conflict. The operationIds from the spec
@@ -81,19 +81,48 @@ templates:
                   - name: default.group.local
                     domains: /./
 
-      /{module:page_revisions}:
+      /{module:page_revisions}: &wp/sys/page_revisions
         x-modules:
             - name: page_revisions
               version: 1.0.0
               type: file
 
-      /{module:key_rev_value}:
+      /{module:key_value}: &wp/sys/key_value
+        x-modules:
+          - name: key_value
+            version: 1.0.0
+            type: file
+
+      /{module:key_rev_value}: &wp/sys/key_rev_value
         x-modules:
           - name: key_rev_value
             version: 1.0.0
             type: file
 
-      /{module:parsoid}:
+      /{module:post_data}: &wp/sys/post_data
+        x-modules:
+          - name: post_data
+            version: 1.0.0
+            type: file
+
+      /{module:action}: &wp/sys/action
+        x-modules:
+          - name: action
+            type: file
+            options:
+              apiRequest:
+                method: post
+                uri: 'http://{domain}/w/api.php'
+                headers:
+                  host: '{$.request.params.domain}'
+                body: '{$.request.body}'
+
+      /{module:page_save}: &wp/sys/page_save
+        x-modules:
+          - name: page_save
+            type: file
+
+      /{module:parsoid}: &wp/sys/parsoid
         x-modules:
           - name: parsoid
             version: 1.0.0
@@ -107,18 +136,6 @@ templates:
               #  port: 4827
               # For local testing, use:
               # parsoidHost: http://localhost:8000
-
-      /{module:action}:
-        x-modules:
-          - name: action
-            type: file
-            options:
-              apiRequest:
-                method: post
-                uri: 'http://{domain}/w/api.php'
-                headers:
-                  host: '{$.request.params.domain}'
-                body: '{$.request.body}'
 
       /{module:graphoid}/v1/png/{title}/{revision}/{graph_id}:
         get:
@@ -163,11 +180,6 @@ templates:
                       request:
                         uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-text/{title}
 
-      /{module:page_save}:
-        x-modules:
-          - name: page_save
-            type: file
-
 #      /{module:revscore}:
 #        title: Simple revscore service wrapper
 #        x-modules:
@@ -183,6 +195,102 @@ templates:
 #                uri: /{domain}/sys/key_rev_value/revscore.scores/{title}/{revision}
 #              service: 
 #                uri: http://revscore.wikimedia.org/{domain}/{title}/{revision}
+
+  global-sys: &gb/sys/1.0.0
+    info:
+      title: global domain sys API module
+      version: 1.0.0
+    paths:
+      /{module:table}: *wp/sys/table
+      /{module:key_value}: *wp/sys/key_value
+      /{module:post_data}: *wp/sys/post_data
+      /{module:mathoid}/v1/request:
+        post:
+          x-request-handler:
+            - store:
+                request:
+                  method: put
+                  uri: /{domain}/sys/post_data/mathoid.request/
+                  body:
+                    q: '{$.request.body.q}'
+                    type: '{$$.default($.request.body.type, "tex")}'
+                    format: '{$$.default($.request.body.format, "json")}'
+            - handle_req:
+                request:
+                  method: post
+                  uri: /{domain}/sys/mathoid/v1/handler
+                  headers:
+                    cache-control: '{cache-control}'
+                    x-resource-location: '{$.store.body}'
+                  body:
+                    q: '{$.request.body.q}'
+                    type: '{$$.default($.request.body.type, "tex")}'
+                    format: '{$$.default($.request.body.format, "json")}'
+      /{module:mathoid}/v1/request/{hash}:
+        get:
+          x-setup-handler:
+            - init:
+                uri: /{domain}/sys/post_data/mathoid.request
+          x-request-handler:
+            - get_from_storage:
+                request:
+                  method: get
+                  uri: /{domain}/sys/post_data/mathoid.request/{hash}
+            - handle_req:
+                request:
+                  method: post
+                  uri: /{domain}/sys/mathoid/v1/handler
+                  headers:
+                    cache-control: '{cache-control}'
+                    x-resource-location: '{$.request.params.hash}'
+                  body: '{$.get_from_storage.body}'
+      /{module:mathoid}/v1/handler:
+        post:
+          x-setup-handler:
+            - init:
+                uri: /{domain}/sys/key_value/mathoid.data
+                body:
+                  keyType: string
+                  valueType: json
+          x-request-handler:
+            - check_storage:
+                request:
+                  method: get
+                  uri: /{domain}/sys/key_value/mathoid.data/{$.request.headers.x-resource-location}
+                  headers:
+                    cache-control: '{cache-control}'
+                return_if:
+                  status: '2xx'
+                return:
+                  status: 200
+                  headers: '{$.check_storage.body.headers}'
+                  body: '{$.check_storage.body.data}'
+                catch:
+                  status: 404
+            - mathoid:
+                request:
+                  method: post
+                  uri: http://mathoid-tester.wmflabs.org/{$.request.body.format}
+                  # force preq to convert the response into a string
+                  # so that it can be stored properly as a JSON
+                  encoding: utf8
+                  body:
+                    q: '{$.request.body.q}'
+                    type: '{$.request.body.type}'
+            - store:
+                request:
+                  method: put
+                  uri: /{domain}/sys/key_value/mathoid.data/{$.request.headers.x-resource-location}
+                  headers:
+                    content-type: application/json
+                  body:
+                    headers: '{$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location})}'
+                    data: '{$.mathoid.body}'
+                return:
+                  status: 200
+                  headers: '{$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location})}'
+                  body: '{$.mathoid.body}'
+
 
   wp-default-1.0.0: &wp/default/1.0.0
     x-subspecs:
@@ -206,6 +314,14 @@ templates:
           /{api:sys}:
             x-subspec: *wp/sys/1.0.0
 
+  gb-default-1.0.0: &gb/default/1.0.0
+    x-subspecs:
+      - paths:
+          # NOTE: no public API endpoints for now
+          /{api:sys}:
+            x-subspec: *gb/sys/1.0.0
+
+
 spec: &spec
   title: "The RESTBase root"
   # Some more general RESTBase info
@@ -214,6 +330,9 @@ spec: &spec
 #   /{domain:de.wikipedia.org}: *wp/default/1.0.0
 #   /{domain:es.wikipedia.org}: *wp/default/1.0.0
 #   /{domain:nl.wikipedia.org}: *wp/default/1.0.0
+
+    # global domain
+    /{domain:window.wikimedia.org}: *gb/default/1.0.0
 
 
 services:

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -9,7 +9,7 @@ templates:
   wmf-content-1.0.0: &wp/content/1.0.0
     swagger: '2.0'
     # swagger options, overriding the shared ones from the merged specs (?)
-    info:
+    info: &wp/content-info/1.0.0
       version: 1.0.0-beta
       title: Wikimedia REST API
       description: >
@@ -74,6 +74,7 @@ templates:
             options: # Passed to the module constructor
               conf:
                 hosts: [localhost]
+                keyspace: system
                 username: cassandra
                 password: cassandra
                 defaultConsistency: one # or 'one' for single-node testing
@@ -196,6 +197,14 @@ templates:
 #              service: 
 #                uri: http://revscore.wikimedia.org/{domain}/{title}/{revision}
 
+
+  global-content: &gb/content/1.0.0
+    swagger: '2.0'
+    info: *wp/content-info/1.0.0
+    x-subspecs:
+      - media/v1/mathoid
+
+
   global-sys: &gb/sys/1.0.0
     info:
       title: global domain sys API module
@@ -309,10 +318,12 @@ templates:
           /{api:sys}:
             x-subspec: *wp/sys/1.0.0
 
-  gb-default-1.0.0: &gb/default/1.0.0
+  global-default-1.0.0: &gb/default/1.0.0
     x-subspecs:
       - paths:
-          # NOTE: no public API endpoints for now
+          /{api:v1}:
+            x-subspec: *gb/content/1.0.0
+      - paths:
           /{api:sys}:
             x-subspec: *gb/sys/1.0.0
 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -178,6 +178,12 @@ templates:
                       request:
                         uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-text/{title}
 
+      /{module:pageviews}:
+        x-modules:
+          - name: pageviews
+            version: 1.0.0
+            type: file
+
 
   global-sys: &gb/sys/1.0.0
     info:
@@ -187,7 +193,7 @@ templates:
       /{module:table}: *wp/sys/table
       /{module:key_value}: *wp/sys/key_value
       /{module:post_data}: *wp/sys/post_data
-      /{module:mathoid}/v1/request:
+      /{module:mathoid}/v1/request/{format}:
         post:
           x-request-handler:
             - store:
@@ -197,19 +203,17 @@ templates:
                   body:
                     q: '{$.request.body.q}'
                     type: '{$$.default($.request.body.type, "tex")}'
-                    format: '{$$.default($.request.body.format, "json")}'
             - handle_req:
                 request:
                   method: post
-                  uri: /{domain}/sys/mathoid/v1/handler
+                  uri: /{domain}/sys/mathoid/v1/handler/{format}
                   headers:
                     cache-control: '{cache-control}'
                     x-resource-location: '{$.store.body}'
                   body:
                     q: '{$.request.body.q}'
                     type: '{$$.default($.request.body.type, "tex")}'
-                    format: '{$$.default($.request.body.format, "json")}'
-      /{module:mathoid}/v1/request/{hash}:
+      /{module:mathoid}/v1/request/{format}/{hash}:
         get:
           x-setup-handler:
             - init:
@@ -222,12 +226,12 @@ templates:
             - handle_req:
                 request:
                   method: post
-                  uri: /{domain}/sys/mathoid/v1/handler
+                  uri: /{domain}/sys/mathoid/v1/handler/{format}
                   headers:
                     cache-control: '{cache-control}'
                     x-resource-location: '{$.request.params.hash}'
                   body: '{$.get_from_storage.body}'
-      /{module:mathoid}/v1/handler:
+      /{module:mathoid}/v1/handler/{format}:
         post:
           x-setup-handler:
             - init:
@@ -246,17 +250,14 @@ templates:
                   status: '2xx'
                 return:
                   status: 200
-                  headers: '{$.check_storage.body.headers}'
-                  body: '{$.check_storage.body.data}'
+                  headers: '{$$.merge($.check_storage.body.data[$.request.params.format].headers,$.check_storage.body.headers)}'
+                  body: '{$.check_storage.body.data[$.request.params.format].body}'
                 catch:
                   status: 404
             - mathoid:
                 request:
                   method: post
-                  uri: http://mathoid-tester.wmflabs.org/{$.request.body.format}
-                  # force preq to convert the response into a string
-                  # so that it can be stored properly as a JSON
-                  encoding: utf8
+                  uri: http://mathoid-tester.wmflabs.org/complete
                   body:
                     q: '{$.request.body.q}'
                     type: '{$.request.body.type}'
@@ -271,8 +272,8 @@ templates:
                     data: '{$.mathoid.body}'
                 return:
                   status: 200
-                  headers: '{$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location})}'
-                  body: '{$.mathoid.body}'
+                  headers: '{$$.merge($.mathoid.body[$.request.params.format].headers,$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location}))}'
+                  body: '{$.mathoid.body[$.request.params.format].body}'
 
 
       /{module:pageviews}:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -276,12 +276,6 @@ templates:
                   body: '{$.mathoid.body[$.request.params.format].body}'
 
 
-      /{module:pageviews}:
-        x-modules:
-          - name: pageviews
-            version: 1.0.0
-            type: file
-
   wp-default-1.0.0: &wp/default/1.0.0
     x-subspecs:
       - paths:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -321,7 +321,7 @@ spec: &spec
     /{domain:en.wikipedia.beta.wmflabs.org}: *wp/default/1.0.0
 
     # global domain
-    /{domain:window.wikimedia.org}: *gb/default/1.0.0
+    /{domain:wikimedia.org}: *gb/default/1.0.0
 
 
 services:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -23,7 +23,7 @@ templates:
           ### High-volume access
             - Don't perform more than 500 requests/s to this API.
             - Set a unique `User-Agent` header that allows us to contact you
-              quickly.  Email addresses or URLs of contact pages work well.
+              quickly. Email addresses or URLs of contact pages work well.
             - Consider using our [HTML
               dumps](https://phabricator.wikimedia.org/T17017) once they
               become available.
@@ -39,6 +39,7 @@ templates:
       - mediawiki/v1/content
       - mediawiki/v1/graphoid
       - mediawiki/v1/mobileapps
+      - media/v1/mathoid
       - analytics/v1/pageviews
       - test
     securityDefinitions:
@@ -83,31 +84,48 @@ templates:
                   - name: test.group.local
                     domains: /./
 
-      /{module:page_revisions}:
+      /{module:page_revisions}: &wp/sys/page_revisions
         x-modules:
             - name: page_revisions
               version: 1.0.0
               type: file
 
-      /{module:key_value}:
+      /{module:key_value}: &wp/sys/key_value
         x-modules:
           - name: key_value
             version: 1.0.0
             type: file
 
-      /{module:post_data}:
-        x-modules:
-          - name: post_data
-            version: 1.0.0
-            type: file
-
-      /{module:key_rev_value}:
+      /{module:key_rev_value}: &wp/sys/key_rev_value
         x-modules:
           - name: key_rev_value
             version: 1.0.0
             type: file
 
-      /{module:parsoid}:
+      /{module:post_data}: &wp/sys/post_data
+        x-modules:
+          - name: post_data
+            version: 1.0.0
+            type: file
+
+      /{module:action}: &wp/sys/action
+        x-modules:
+          - name: action
+            type: file
+            options:
+              apiRequest:
+                method: post
+                uri: http://{domain}/w/api.php
+                headers:
+                  host: '{$.request.params.domain}'
+                body: '{$.request.body}'
+
+      /{module:page_save}: &wp/sys/page_save
+        x-modules:
+          - name: page_save
+            type: file
+
+      /{module:parsoid}: &wp/sys/parsoid
         x-modules:
           - name: parsoid
             version: 1.0.0
@@ -160,22 +178,102 @@ templates:
                       request:
                         uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-text/{title}
 
-      /{module:action}:
-        x-modules:
-          - name: action
-            type: file
-            options:
-              apiRequest:
-                method: post
-                uri: http://{domain}/w/api.php
-                headers:
-                  host: '{$.request.params.domain}'
-                body: '{$.request.body}'
 
-      /{module:page_save}:
-        x-modules:
-          - name: page_save
-            type: file
+  global-sys: &gb/sys/1.0.0
+    info:
+      title: global domain sys API module
+      version: 1.0.0
+    paths:
+      /{module:table}: *wp/sys/table
+      /{module:key_value}: *wp/sys/key_value
+      /{module:post_data}: *wp/sys/post_data
+      /{module:mathoid}/v1/request:
+        post:
+          x-request-handler:
+            - store:
+                request:
+                  method: put
+                  uri: /{domain}/sys/post_data/mathoid.request/
+                  body:
+                    q: '{$.request.body.q}'
+                    type: '{$$.default($.request.body.type, "tex")}'
+                    format: '{$$.default($.request.body.format, "json")}'
+            - handle_req:
+                request:
+                  method: post
+                  uri: /{domain}/sys/mathoid/v1/handler
+                  headers:
+                    cache-control: '{cache-control}'
+                    x-resource-location: '{$.store.body}'
+                  body:
+                    q: '{$.request.body.q}'
+                    type: '{$$.default($.request.body.type, "tex")}'
+                    format: '{$$.default($.request.body.format, "json")}'
+      /{module:mathoid}/v1/request/{hash}:
+        get:
+          x-setup-handler:
+            - init:
+                uri: /{domain}/sys/post_data/mathoid.request
+          x-request-handler:
+            - get_from_storage:
+                request:
+                  method: get
+                  uri: /{domain}/sys/post_data/mathoid.request/{hash}
+            - handle_req:
+                request:
+                  method: post
+                  uri: /{domain}/sys/mathoid/v1/handler
+                  headers:
+                    cache-control: '{cache-control}'
+                    x-resource-location: '{$.request.params.hash}'
+                  body: '{$.get_from_storage.body}'
+      /{module:mathoid}/v1/handler:
+        post:
+          x-setup-handler:
+            - init:
+                uri: /{domain}/sys/key_value/mathoid.data
+                body:
+                  keyType: string
+                  valueType: json
+          x-request-handler:
+            - check_storage:
+                request:
+                  method: get
+                  uri: /{domain}/sys/key_value/mathoid.data/{$.request.headers.x-resource-location}
+                  headers:
+                    cache-control: '{cache-control}'
+                return_if:
+                  status: '2xx'
+                return:
+                  status: 200
+                  headers: '{$.check_storage.body.headers}'
+                  body: '{$.check_storage.body.data}'
+                catch:
+                  status: 404
+            - mathoid:
+                request:
+                  method: post
+                  uri: http://mathoid-tester.wmflabs.org/{$.request.body.format}
+                  # force preq to convert the response into a string
+                  # so that it can be stored properly as a JSON
+                  encoding: utf8
+                  body:
+                    q: '{$.request.body.q}'
+                    type: '{$.request.body.type}'
+            - store:
+                request:
+                  method: put
+                  uri: /{domain}/sys/key_value/mathoid.data/{$.request.headers.x-resource-location}
+                  headers:
+                    content-type: application/json
+                  body:
+                    headers: '{$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location})}'
+                    data: '{$.mathoid.body}'
+                return:
+                  status: 200
+                  headers: '{$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location})}'
+                  body: '{$.mathoid.body}'
+
 
       /{module:pageviews}:
         x-modules:
@@ -204,6 +302,14 @@ templates:
           /{api:sys}:
             x-subspec: *wp/sys/1.0.0
 
+  gb-default-1.0.0: &gb/default/1.0.0
+    x-subspecs:
+      - paths:
+          # NOTE: no public API endpoints for now
+          /{api:sys}:
+            x-subspec: *gb/sys/1.0.0
+
+
 spec: &spec
   title: "The RESTBase root"
   # Some more general RESTBase info
@@ -214,6 +320,8 @@ spec: &spec
     /{domain:fr.wikipedia.org}: *wp/secure/1.0.0
     /{domain:en.wikipedia.beta.wmflabs.org}: *wp/default/1.0.0
 
+    # global domain
+    /{domain:window.wikimedia.org}: *gb/default/1.0.0
 
 
 services:
@@ -224,6 +332,7 @@ services:
       spec: *spec
       salt: secret
       default_page_size: 1
+      user_agent: RESTBase-testsuite
 
 test:
   content_types:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -42,7 +42,7 @@ templates:
       - media/v1/mathoid
       - analytics/v1/pageviews
       - test
-    securityDefinitions:
+    securityDefinitions: &wp/content-security/1.0.0
       mediawiki_auth:
         description: Checks permissions using MW api
         type: apiKey
@@ -77,6 +77,7 @@ templates:
             options: # Passed to the module constructor
               conf:
                 hosts: [localhost]
+                keyspace: system
                 username: cassandra
                 password: cassandra
                 defaultConsistency: one # or 'one' for single-node testing
@@ -188,6 +189,7 @@ templates:
   global-content: &gb/content/1.0.0
     swagger: '2.0'
     info: *wp/content-info/1.0.0
+    securityDefinitions: *wp/content-security/1.0.0
     x-subspecs:
       - media/v1/mathoid
 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -9,7 +9,7 @@ templates:
   wmf-content-1.0.0: &wp/content/1.0.0
     swagger: '2.0'
     # swagger options, overriding the shared ones from the merged specs (?)
-    info:
+    info: &wp/content-info/1.0.0
       version: 1.0.0-beta
       title: Wikimedia REST API
       description: >
@@ -185,6 +185,13 @@ templates:
             type: file
 
 
+  global-content: &gb/content/1.0.0
+    swagger: '2.0'
+    info: *wp/content-info/1.0.0
+    x-subspecs:
+      - media/v1/mathoid
+
+
   global-sys: &gb/sys/1.0.0
     info:
       title: global domain sys API module
@@ -297,10 +304,12 @@ templates:
           /{api:sys}:
             x-subspec: *wp/sys/1.0.0
 
-  gb-default-1.0.0: &gb/default/1.0.0
+  global-default-1.0.0: &gb/default/1.0.0
     x-subspecs:
       - paths:
-          # NOTE: no public API endpoints for now
+          /{api:v1}:
+            x-subspec: *gb/content/1.0.0
+      - paths:
           /{api:sys}:
             x-subspec: *gb/sys/1.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.7.13",
+  "version": "0.8.0",
   "description": "REST storage and service dispatcher",
   "main": "server.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "cassandra-uuid": "^0.0.2",
     "preq": "^0.4.4",
     "restbase-mod-table-cassandra": "^0.8.0",
-    "service-runner": "^0.2.8",
+    "service-runner": "^0.2.10",
     "swagger-router": "^0.1.2",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "tassembly": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "REST storage and service dispatcher",
   "main": "server.js",
   "scripts": {

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -1,0 +1,128 @@
+# Mathoid - math formula rendering service
+
+swagger: 2.0
+
+paths:
+  /{module:media}/math:
+    post:
+      tags:
+        - Media
+        - Math
+      description: >
+        Renders a TeX formula into its mathematic representation in the given format.
+        Available formats are svg, json and mml.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
+      produces:
+        - image/svg+xml
+        - application/mathml+xml
+        - application/json
+      parameters:
+        - name: format
+          in: formData
+          description: The output format; can be svg, json or mml
+          type: string
+          required: false
+        - name: q
+          in: formData
+          description: The formula to render
+          type: string
+          required: true
+        - name: type
+          in: formData
+          description: The input type of the given formula; can be tex, inline-tex, mml or ascii
+          type: string
+          required: false
+      responses:
+        '200':
+          description: The rendered formula
+        '400':
+          description: Invalid format or type
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - do_post:
+            request:
+              method: post
+              uri: /window.wikimedia.org/sys/mathoid/v1/request
+              headers:
+                cache-control: '{cache-control}'
+              body: '{$.request.body}'
+      x-monitor: true
+      x-amples:
+        - title: Mathoid - test formula
+          request:
+            body:
+              format: json
+              q: E=mc^2
+              type: tex
+          response:
+            status: 200
+            headers:
+              content-type: /^application\/json/
+            body:
+              svg: /.+/
+              mml: /.+/
+              success: true
+        - title: Mathoid - test formula from storage
+          request:
+            body:
+              format: json
+              q: E=mc^2
+              type: tex
+          response:
+            status: 200
+            headers:
+              content-type: /^application\/json/
+            body:
+              svg: /.+/
+              mml: /.+/
+              success: true
+
+  /{module:media}/math/{hash}:
+    get:
+      tags:
+        - Media
+        - Math
+      description: >
+        Given a request hash, renders a TeX formula into its mathematic
+        representation in the given format. When a request is issued to the
+        `/media/math` endpoint, the response contains the *x-resource-location*
+        header denoting the hash ID of the POST data. Once obtained, this endpoint
+        may be used to avoid sending the payload.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
+      produces:
+        - image/svg+xml
+        - application/mathml+xml
+        - application/json
+      parameters:
+        - name: hash
+          in: path
+          description: The hash string of the previous POST data
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The rendered formula
+        '404':
+          description: Unknown hash ID
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - stored_post:
+            request:
+              method: get
+              uri: /window.wikimedia.org/sys/mathoid/v1/request/{hash}
+              headers:
+                cache-control: '{cache-control}'
+      x-monitor: false
+

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -10,7 +10,10 @@ paths:
         - Math
       description: >
         Renders a TeX formula into its mathematic representation in the given format.
-        Available formats are svg and mml.
+        Available formats are svg and mml. The response contains the `x-resource-location`
+        header which can be used to retrieve the same formula in a different formula. Just
+        append the value of the header to `/media/math/{format}/` and perform a GET request
+        against that URL.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
       produces:

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -57,7 +57,7 @@ paths:
         - do_post:
             request:
               method: post
-              uri: /window.wikimedia.org/sys/mathoid/v1/request
+              uri: /wikimedia.org/sys/mathoid/v1/request
               headers:
                 cache-control: '{cache-control}'
               body: '{$.request.body}'
@@ -130,7 +130,7 @@ paths:
         - stored_post:
             request:
               method: get
-              uri: /window.wikimedia.org/sys/mathoid/v1/request/{hash}
+              uri: /wikimedia.org/sys/mathoid/v1/request/{hash}
               headers:
                 cache-control: '{cache-control}'
       x-monitor: false

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -83,9 +83,10 @@ paths:
             headers:
               content-type: /^image\/svg/
             body: /.+/
-        - title: Mathoid - test formula from storage
+        - title: Mathoid - test formula from storage (global domain)
           request:
             params:
+              domain: wikimedia.org
               format: mml
             body:
               q: E=mc^2

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -23,6 +23,10 @@ paths:
           description: The output format; can be svg, json or mml
           type: string
           required: false
+          enum:
+            - svg
+            - json
+            - mml
         - name: q
           in: formData
           description: The formula to render
@@ -33,6 +37,11 @@ paths:
           description: The input type of the given formula; can be tex, inline-tex, mml or ascii
           type: string
           required: false
+          enum:
+            - tex
+            - inline-tex
+            - mml
+            - ascii
       responses:
         '200':
           description: The rendered formula

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -52,6 +52,11 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+      security:
+        - header_match:
+            - header: 'x-rb-client-ip'
+              patterns:
+                - internal
       x-request-handler:
         - do_post:
             request:

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -3,14 +3,14 @@
 swagger: 2.0
 
 paths:
-  /{module:media}/math:
+  /{module:media}/math/{format}:
     post:
       tags:
         - Media
         - Math
       description: >
         Renders a TeX formula into its mathematic representation in the given format.
-        Available formats are svg, json and mml.
+        Available formats are svg and mml.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
       produces:
@@ -19,13 +19,12 @@ paths:
         - application/json
       parameters:
         - name: format
-          in: formData
-          description: The output format; can be svg, json or mml
+          in: path
+          description: The output format; can be svg or mml
           type: string
-          required: false
+          required: true
           enum:
             - svg
-            - json
             - mml
         - name: q
           in: formData
@@ -57,7 +56,7 @@ paths:
         - do_post:
             request:
               method: post
-              uri: /wikimedia.org/sys/mathoid/v1/request
+              uri: /wikimedia.org/sys/mathoid/v1/request/{format}
               headers:
                 cache-control: '{cache-control}'
               body: '{$.request.body}'
@@ -65,34 +64,30 @@ paths:
       x-amples:
         - title: Mathoid - test formula
           request:
+            params:
+              format: svg
             body:
-              format: json
               q: E=mc^2
               type: tex
           response:
             status: 200
             headers:
-              content-type: /^application\/json/
-            body:
-              svg: /.+/
-              mml: /.+/
-              success: true
+              content-type: /^image\/svg/
+            body: /.+/
         - title: Mathoid - test formula from storage
           request:
+            params:
+              format: mml
             body:
-              format: json
               q: E=mc^2
               type: tex
           response:
             status: 200
             headers:
-              content-type: /^application\/json/
-            body:
-              svg: /.+/
-              mml: /.+/
-              success: true
+              content-type: /^application\/mathml/
+            body: /.+/
 
-  /{module:media}/math/{hash}:
+  /{module:media}/math/{format}/{hash}:
     get:
       tags:
         - Media
@@ -100,7 +95,7 @@ paths:
       description: >
         Given a request hash, renders a TeX formula into its mathematic
         representation in the given format. When a request is issued to the
-        `/media/math` endpoint, the response contains the *x-resource-location*
+        `/media/math/{format}` endpoint, the response contains the *x-resource-location*
         header denoting the hash ID of the POST data. Once obtained, this endpoint
         may be used to avoid sending the payload.
 
@@ -110,6 +105,14 @@ paths:
         - application/mathml+xml
         - application/json
       parameters:
+        - name: format
+          in: path
+          description: The output format; can be svg or mml
+          type: string
+          required: true
+          enum:
+            - svg
+            - mml
         - name: hash
           in: path
           description: The hash string of the previous POST data
@@ -130,7 +133,7 @@ paths:
         - stored_post:
             request:
               method: get
-              uri: /wikimedia.org/sys/mathoid/v1/request/{hash}
+              uri: /wikimedia.org/sys/mathoid/v1/request/{format}/{hash}
               headers:
                 cache-control: '{cache-control}'
       x-monitor: false

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -9,11 +9,12 @@ paths:
         - Media
         - Math
       description: >
-        Renders a TeX formula into its mathematic representation in the given format.
-        Available formats are svg and mml. The response contains the `x-resource-location`
-        header which can be used to retrieve the same formula in a different formula. Just
-        append the value of the header to `/media/math/{format}/` and perform a GET request
-        against that URL.
+        Renders a TeX formula into its mathematic representation in the given
+        format. Available formats are svg and mml. The response contains the
+        `x-resource-location` header which can be used to retrieve the same
+        formula in a different render format. Just append the value of the
+        header to `/media/math/{format}/` and perform a GET request against
+        that URL.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
       produces:
@@ -103,9 +104,9 @@ paths:
       description: >
         Given a request hash, renders a TeX formula into its mathematic
         representation in the given format. When a request is issued to the
-        `/media/math/{format}` endpoint, the response contains the *x-resource-location*
-        header denoting the hash ID of the POST data. Once obtained, this endpoint
-        may be used to avoid sending the payload.
+        `/media/math/{format}` POST endpoint, the response contains the
+        `x-resource-location` header denoting the hash ID of the POST data. Once
+        obtained, this endpoint may be used to avoid sending the payload.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
       produces:


### PR DESCRIPTION
This PR adds two public routes:

- `POST /{domain}/media/math/{format}`
- `GET /{domain}/media/math/{format}/{hash}`

The first allows clients to perform a POST request to ask for a formula to be rendered. It takes the same parameters as Mathoid, namely `q` (the formula to be rendered) and `type` (the format or type of the supplied formula), with `format` (the desired output format) being present in the URI. Only `q` is mandatory while `type` defaults to `tex` if not supplied. Internally, the request is saved using the *post_data* module. The request hash is therefore calculated and is used to determine if the given formula has already been rendered by Mathoid. If so, the stored version is returned. Otherwise, a request is issued to Mathoid (to its `/complete` endpoint) and its result is stored. The API returns only the portion (*body*, *headers*) relevant to the sought format. In either case, the response contains the `x-resource-location` header which can be used to perform subsequent, low latency requests to obtain the same render (but possibly in a different format) via the second public endpoint.

Note that the endpoints and their storage are organised in such a way as to be domain-independent. This PR introduces a new, global domain - `wikimedia.org` - and all Mathoid requests are internally remapped to it. In other words, if a render with the data hash `12345` exists, it can be retrieved equally from all domains, regardless of the initial request's domain.

Also, this PR reorganises slightly the configuration files.

Bug: [T102030](https://phabricator.wikimedia.org/T102030)