### PR TITLE
Removed the delay from resource handler and check resources length

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -384,16 +384,8 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specR
 Router.prototype.handleResources = function(restbase) {
     var self = this;
     return this.tree.visitAsync(function(value, path) {
-        if (value && Array.isArray(value.resources)) {
-            return P.resolve(value.resources)
-            /* Workaround (forces setTimeout) to avoid excessive nextTick
-               recursion in bluebird with node 0.10. Otherwise, we see errors
-               like this with >~500 domains:
-               (node) warning: Recursive process.nextTick detected. This will
-               break in the next version of node. Please use setImmediate for
-               recursive deferral. */
-            .delay(0)
-            .each(function(reqSpec) {
+        if (value && Array.isArray(value.resources) && value.resources.length > 0) {
+            return P.each(value.resources, function(reqSpec) {
                 var reqTemplate = new Template(reqSpec);
                 var req = reqTemplate.eval({
                     request: {


### PR DESCRIPTION
Recently we've had to make resources array initialised by default, so `delay(0)` is called on every node now, making startup very slow. While debugging this, me and @d00rman tested startup without the `delay(0)` and it seems to work fine both locally and in staging, so this PR also removes that workaround.