### PR TITLE
Add analytics pageview module, spec, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules
 npm-debug.log
 # WebStorm IDE files
 .idea/*
+*.iml
+
+*swp

--- a/config.test.analytics.yaml
+++ b/config.test.analytics.yaml
@@ -1,0 +1,124 @@
+# RESTBase config for Analytics APIs
+
+info:
+  name: restbase
+
+
+templates:
+
+  wmf-content-1.0.0: &wp/content/1.0.0
+    swagger: '2.0'
+    # swagger options, overriding the shared ones from the merged specs (?)
+    info:
+      version: 1.0.0-beta
+      title: Wikimedia Analytics Pageviews REST API
+      description: >
+          This API aims to provide coherent and low-latency access to
+          Wikimedia content and services. It is currently in beta testing, so
+          things aren't completely locked down yet. Each entry point has
+          explicit stability markers to inform you about development status
+          and change policy, according to [our API version
+          policy](https://www.mediawiki.org/wiki/API_versioning).
+
+          ### High-volume access
+            - Don't perform more than 500 requests/s to this API.
+            - Set a unique `User-Agent` header that allows us to contact you
+              quickly.  Email addresses or URLs of contact pages work well.
+            - Consider using our [HTML
+              dumps](https://phabricator.wikimedia.org/T17017) once they
+              become available.
+
+      termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+      contact:
+        name: the Wikimedia Services team
+        url: http://mediawiki.org/wiki/RESTBase
+      license:
+        name: Apache2
+        url: http://www.apache.org/licenses/LICENSE-2.0
+    security:
+      # ACLs for public *.wikipedia.org wikis
+      - mediaWikiAuth:
+        - user:read
+    x-subspecs:
+      - analytics_v1_pageviews
+      - test_analytics
+
+  wmf-sys-1.0.0: &wp/sys/1.0.0
+    info: 
+      title: Default MediaWiki sys API module
+      version: 1.0.0
+    paths:
+      /{module:table}: &wp/sys/table # Can use this anchor to share the table
+        x-modules:
+          # There can be multiple modules too per stanza, as long as the
+          # exported symbols don't conflict. The operationIds from the spec
+          # will be resolved against all of the modules.
+          - name: restbase-mod-table-cassandra
+            version: 1.0.0
+            type: npm
+            options: # Passed to the module constructor
+              conf:
+                hosts: [localhost]
+                keyspace: system
+                username: cassandra
+                password: cassandra
+                defaultConsistency: one # or 'one' for single-node testing
+                storage_groups:
+                  - name: test.group.local
+                    domains:
+                      - /test\..*\.org$/
+                      - /test\.local$/
+                  - name: default.group.local
+                    domains: /./
+
+      /{module:pageviews}:
+        x-modules:
+            - name: pageviews
+              version: 1.0.0
+              type: file
+
+  wp-default-1.0.0: &wp/default/1.0.0
+    x-subspecs:
+      - paths:
+          /{api:v1}:
+            x-subspec: *wp/content/1.0.0
+      - paths:
+          /{api:sys}:
+            x-subspec: *wp/sys/1.0.0
+
+
+spec: &spec
+  title: "The RESTBase root"
+  # Some more general RESTBase info
+  paths:
+    # test domain
+    /{domain:en.wikipedia.test.local}: *wp/default/1.0.0
+
+
+services:
+  - name: restbase
+    module: ./lib/server
+    conf: 
+      port: 7231
+      spec: *spec
+      salt: secret
+      default_page_size: 1
+
+test:
+  content_types:
+    html: text/html;profile=mediawiki.org/specs/html/1.1.0;charset=utf-8
+    wikitext: text/plain;profile=mediawiki.org/specs/wikitext/1.0.0;charset=utf-8
+
+logging:
+  name: restbase
+  level: info
+  #streams:
+  ## XXX: Use gelf-stream -> logstash
+  #- type: gelf
+  #  host: <%= @logstash_host %>
+  #  port: <%= @logstash_port %>
+
+metrics:
+  #type: txstatsd
+  #host: localhost
+  #port: 8125

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -39,6 +39,8 @@ templates:
       - mediawiki/v1/content
       - mediawiki_v1_graphoid
       - mediawiki/v1/mobileapps
+      - analytics_v1_pageviews
+      - test_analytics
       - test
     securityDefinitions:
       mediawiki_auth:
@@ -170,6 +172,12 @@ templates:
         x-modules:
           - name: page_save
             type: file
+
+      /{module:pageviews}:
+        x-modules:
+            - name: pageviews
+              version: 1.0.0
+              type: file
 
   wp-default-1.0.0: &wp/default/1.0.0
     x-subspecs:

--- a/mods/pageviews.js
+++ b/mods/pageviews.js
@@ -1,0 +1,297 @@
+'use strict';
+
+/**
+ * Pageviews API module
+ *
+ * Main tasks:
+ * - TBD
+ */
+
+
+var URI = require('swagger-router').URI;
+
+// TODO: move to module
+var fs = require('fs');
+var yaml = require('js-yaml');
+var path = require('path');
+var spec = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '/pageviews.yaml')));
+
+
+// Pageviews Service
+function PJVS (options) {
+    this.options = options;
+    this.log = options.log || function(){};
+}
+
+
+var tables = {
+        article: 'pageviews.per.article',
+        project: 'pageviews.per.project',
+        tops: 'top.pageviews',
+    },
+    tableURI = function(domain, tableName) {
+        return new URI([domain, 'sys', 'table', tableName, '']);
+    },
+    tableSchemas = {
+        article: {
+            table: tables.article,
+            version: 1,
+            attributes: {
+                project     : 'string',
+                article     : 'string',
+                access      : 'string',
+                agent       : 'string',
+                granularity : 'string',
+                // the hourly timestamp will be stored as YYYYMMDDHH
+                timestamp   : 'string',
+                views       : 'int'
+            },
+            index: [
+                { attribute: 'project', type: 'hash' },
+                { attribute: 'article', type: 'hash' },
+                { attribute: 'access', type: 'hash' },
+                { attribute: 'agent', type: 'hash' },
+                { attribute: 'granularity', type: 'hash' },
+                { attribute: 'timestamp', type: 'range', order: 'asc' },
+            ]
+        },
+        project: {
+            table: tables.project,
+            version: 1,
+            attributes: {
+                project     : 'string',
+                access      : 'string',
+                agent       : 'string',
+                granularity : 'string',
+                // the hourly timestamp will be stored as YYYYMMDDHH
+                timestamp   : 'string',
+                views       : 'int'
+            },
+            index: [
+                { attribute: 'project', type: 'hash' },
+                { attribute: 'access', type: 'hash' },
+                { attribute: 'agent', type: 'hash' },
+                { attribute: 'granularity', type: 'hash' },
+                { attribute: 'timestamp', type: 'range', order: 'asc' },
+            ]
+        },
+        tops: {
+            table: tables.tops,
+            version: 1,
+            attributes: {
+                project  : 'string',
+                access   : 'string',
+                year     : 'string',
+                month    : 'string',
+                day      : 'string',
+                // format for this is a json array: [{rank: 1, article: <<title>>, views: 123}, ...]
+                articles : 'string'
+            },
+            index: [
+                { attribute: 'project', type: 'hash' },
+                { attribute: 'access', type: 'hash' },
+                { attribute: 'year', type: 'hash' },
+                { attribute: 'month', type: 'hash' },
+                { attribute: 'day', type: 'hash' },
+            ]
+        }
+    };
+
+/* general handler functions */
+var queryCatcher = function (e) {
+        if (e.status !== 404) {
+            throw e;
+        }
+    },
+    queryResponser = function (res) {
+        // always return at least an empty array so that queries for non-existing data don't error
+        res = res || {};
+        res.body = res.body || {items:[]};
+        res.headers = res.headers || {};
+        res.status = res.status || 200;
+        return res;
+    };
+
+
+PJVS.prototype.pageviewsForArticle = function (restbase, req) {
+    var rp = req.params,
+        dataRequest;
+
+    dataRequest = restbase.get({
+        uri: tableURI(rp.domain, tables.article),
+        body: {
+            table: tables.article,
+            attributes: {
+                project: rp.project,
+                access: rp.access,
+                agent: rp.agent,
+                article: rp.article,
+                granularity: rp.granularity,
+                timestamp: { between: [rp.start, rp.end] },
+            }
+        }
+
+    }).catch(queryCatcher);
+
+    return dataRequest.then(queryResponser);
+};
+
+PJVS.prototype.pageviewsForProjects = function (restbase, req) {
+    var rp = req.params,
+        dataRequest;
+
+    dataRequest = restbase.get({
+        uri: tableURI(rp.domain, tables.project),
+        body: {
+            table: tables.project,
+            attributes: {
+                project: rp.project,
+                access: rp.access,
+                agent: rp.agent,
+                granularity: rp.granularity,
+                timestamp: { between: [rp.start, rp.end] },
+            }
+        }
+
+    }).catch(queryCatcher);
+
+    return dataRequest.then(queryResponser);
+};
+
+PJVS.prototype.pageviewsForTops = function (restbase, req) {
+    var rp = req.params,
+        dataRequest;
+
+    if (rp.year === 'all-years') {
+        rp.month = 'all-months';
+    }
+    if (rp.month === 'all-months') {
+        rp.day = 'all-days';
+    }
+
+    dataRequest = restbase.get({
+        uri: tableURI(rp.domain, tables.tops),
+        body: {
+            table: tables.tops,
+            attributes: {
+                project: rp.project,
+                access: rp.access,
+                year: rp.year,
+                month: rp.month,
+                day: rp.day
+            }
+        }
+
+    }).catch(queryCatcher);
+
+    return dataRequest.then(queryResponser);
+};
+
+
+// The following three functions are just for testing
+
+PJVS.prototype.insertPageviewsForArticleTestData = function(restbase, req) {
+    var rp = req.params,
+        lastPromise;
+
+    lastPromise = restbase.put({ // Save / update the pageviews entry
+        uri: tableURI(rp.domain, tables.article),
+        body: {
+            table: tables.article,
+            attributes: {
+                project: rp.project,
+                article: rp.article,
+                granularity: rp.granularity,
+                access: rp.access,
+                agent: rp.agent,
+                timestamp: rp.timestamp,
+                views: rp.views,
+            },
+        }
+    });
+
+    return lastPromise;
+};
+
+
+PJVS.prototype.insertPageviewsForProjectTestData = function(restbase, req) {
+    var rp = req.params,
+        lastPromise;
+
+    lastPromise = restbase.put({ // Save / update the pageviews entry
+        uri: tableURI(rp.domain, tables.project),
+        body: {
+            table: tables.project,
+            attributes: {
+                project: rp.project,
+                granularity: rp.granularity,
+                access: rp.access,
+                agent: rp.agent,
+                timestamp: rp.timestamp,
+                views: rp.views,
+            },
+        }
+    });
+
+    return lastPromise;
+};
+
+
+
+PJVS.prototype.insertPageviewsForTopsTestData = function(restbase, req) {
+    var rp = req.params,
+        lastPromise;
+
+    lastPromise = restbase.put({ // Save / update the pageviews entry
+        uri: tableURI(rp.domain, tables.tops),
+        body: {
+            table: tables.tops,
+            attributes: {
+                project: rp.project,
+                access: rp.access,
+                year: rp.year,
+                month: rp.month,
+                day: rp.day,
+                articles: JSON.stringify([
+                    {rank: rp.rank, article: rp.article + rp.timespan, views: rp.views},
+                ]),
+            },
+        }
+    });
+
+    return lastPromise;
+};
+
+
+module.exports = function(options) {
+    var pjvs = new PJVS(options);
+
+    return {
+        spec: spec,
+        operations: {
+            pageviewsForArticle: pjvs.pageviewsForArticle.bind(pjvs),
+            pageviewsForProjects: pjvs.pageviewsForProjects.bind(pjvs),
+            pageviewsForTops: pjvs.pageviewsForTops.bind(pjvs),
+
+            // These operations just insert fake data, uncomment them above to play
+            insertPageviewsForArticleTestData: pjvs.insertPageviewsForArticleTestData.bind(pjvs),
+            insertPageviewsForProjectTestData: pjvs.insertPageviewsForProjectTestData.bind(pjvs),
+            insertPageviewsForTopsTestData: pjvs.insertPageviewsForTopsTestData.bind(pjvs),
+        },
+        resources: [
+            {
+                // pageviews per article table
+                uri: '/{domain}/sys/table/' + tables.article,
+                body: tableSchemas.article,
+            }, {
+                // pageviews per project table
+                uri: '/{domain}/sys/table/' + tables.project,
+                body: tableSchemas.project,
+            }, {
+                // top pageviews table
+                uri: '/{domain}/sys/table/' + tables.tops,
+                body: tableSchemas.tops,
+            }
+        ]
+    };
+};

--- a/mods/pageviews.yaml
+++ b/mods/pageviews.yaml
@@ -1,0 +1,27 @@
+paths:
+    /per-article/{project}/{access}/{agent}/{article}/{granularity}/{start}/{end}:
+        get:
+          summary: query pageviews per article
+          operationId: pageviewsForArticle
+    /per-project/{project}/{access}/{agent}/{granularity}/{start}/{end}:
+        get:
+          summary: query pageviews per project
+          operationId: pageviewsForProjects
+    /top/{project}/{access}/{year}/{month}/{day}:
+        get:
+          summary: query top pageviews
+          operationId: pageviewsForTops
+
+    # These three endpoints are just for fake data:
+    /insert-per-article/{project}/{access}/{agent}/{article}/{granularity}/{timestamp}/{views}:
+        get:
+          summary: insert pageviews test data for per article queries
+          operationId: insertPageviewsForArticleTestData
+    /insert-per-project/{project}/{access}/{agent}/{granularity}/{timestamp}/{views}:
+        get:
+          summary: insert pageviews test data for per project queries
+          operationId: insertPageviewsForProjectTestData
+    /insert-top/{project}/{access}/{year}/{month}/{day}/{rank}/{article}/{views}:
+        get:
+          summary: insert pageviews test data for tops queries
+          operationId: insertPageviewsForTopsTestData

--- a/specs/analytics_v1_pageviews.yaml
+++ b/specs/analytics_v1_pageviews.yaml
@@ -1,0 +1,291 @@
+swagger: '2.0'
+info:
+  version: '1.0.0-beta'
+  title: Analytics Pageviews API
+  description: Analytics Pageviews API.
+  termsofservice: https://github.com/wikimedia/restbase#restbase
+  contact:
+    name: Analytics
+    email: analytics@lists.wikimedia.org
+    url: https://www.mediawiki.org/wiki/Analytics
+  license:
+    name: Apache licence, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+x-default-params:
+  domain: analytics.wikimedia.org
+paths:
+  /{module:pageviews}/:
+    get:
+      tags:
+        - Pageviews data
+      description: >
+        List pageviews data sub-apis.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: The queriable sub-items
+          schema:
+            $ref: '#/definitions/listing'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-monitor: false
+
+  /{module:pageviews}/per-article/{project}/{access}/{agent}/{article}/{granularity}/{start}/{end}:
+    get:
+      tags:
+        - Pageviews data
+        - per-article
+      description: >
+        List pageviews for a given article in a project, over a given time period.
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json
+      parameters:
+        - name: project
+          in: path
+          description: Name of the project
+          type: string
+          required: true
+        - name: access
+          in: path
+          description: Type of access method [all-access|desktop|mobile-app|mobile-web]
+          type: string
+          required: true
+        - name: agent
+          in: path
+          description: Type of user agent [all-agents|user|spider]
+          type: string
+          required: true
+        - name: article
+          in: path
+          description: Name of the article for which to get data
+          type: string
+          required: true
+        - name: granularity
+          in: path
+          description: Time granularity of the response data [hourly|daily]
+          type: string
+          required: true
+        - name: start
+          in: path
+          description: Start timestamp in YYYYMMDDHH format
+          type: string
+          required: true
+        - name: end
+          in: path
+          description: End timestamp in YYYYMMDDHH format
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of values
+          schema:
+            $ref: '#/definitions/article'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/pageviews/per-article/{project}/{access}/{agent}/{article}/{granularity}/{start}/{end}
+      x-monitor: false
+
+  /{module:pageviews}/per-project/{project}/{access}/{agent}/{granularity}/{start}/{end}:
+    get:
+      tags:
+        - Pageviews data
+        - per-project
+      description: >
+        List pageviews for a given project, over a given time period.
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json
+      parameters:
+        - name: project
+          in: path
+          description: Name of the project [all-projects|project-name]
+          type: string
+          required: true
+        - name: access
+          in: path
+          description: Type of access method [all-access|desktop|mobile-app|mobile-web]
+          type: string
+          required: true
+        - name: agent
+          in: path
+          description: Type of user agent [all-agents|user|spider]
+          type: string
+          required: true
+        - name: granularity
+          in: path
+          description: Time granularity of the response data [hourly|daily]
+          type: string
+          required: true
+        - name: start
+          in: path
+          description: Start timestamp in YYYYMMDDHH format
+          type: string
+          required: true
+        - name: end
+          in: path
+          description: End timestamp in YYYYMMDDHH format
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of values
+          schema:
+            $ref: '#/definitions/project'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/pageviews/per-project/{project}/{access}/{agent}/{granularity}/{start}/{end}
+      x-monitor: false
+
+  /{module:pageviews}/top/{project}/{access}/{year}/{month}/{day}:
+    get:
+      tags:
+        - Pageviews data
+        - Top articles
+      description: >
+        List pageviews for a given project, over a given time period.
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json
+      parameters:
+        - name: project
+          in: path
+          description: Name of the project [all-projects|project-name]
+          type: string
+          required: true
+        - name: access
+          in: path
+          description: Type of access method [all-access|desktop|mobile-app|mobile-web]
+          type: string
+          required: true
+        - name: year
+          in: path
+          description: The year for which to retrieve top articles [all-years|year]
+          type: string
+          required: true
+        - name: month
+          in: path
+          description: The month for which to retrieve top articles [all-months|month]
+          type: string
+          required: true
+        - name: day
+          in: path
+          description: The day for which to retrieve top articles [all-days|day]
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of top articles in the project
+          schema:
+            $ref: '#/definitions/tops'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-backend-request:
+        uri: /{domain}/sys/pageviews/top/{project}/{access}/{year}/{month}/{day}
+      x-monitor: false
+
+
+definitions:
+  # A https://tools.ietf.org/html/draft-nottingham-http-problem
+  problem:
+    required:
+      - type
+    properties:
+      type:
+        type: string
+      title:
+        type: string
+      detail:
+        type: string
+      instance:
+        type: string
+
+  listing:
+    description: The result format for listings
+    required:
+      - items
+    properties:
+      items:
+        type: array
+        items:
+          type: string
+
+  article:
+    required:
+      - items
+    properties:
+      items:
+        type: array
+        properties:
+          project:
+            type : string
+          access:
+            type : string
+          article:
+            type: string
+          agent:
+            type: string
+          granularity:
+            type: string
+          timestamp:
+            # the hourly timestamp will be stored as YYYYMMDDHH
+            type: string
+          views:
+            type: integer
+            format: int64
+
+  project:
+    required:
+      - items
+    properties:
+      items:
+        type: array
+        properties:
+          project:
+            type : string
+          access:
+            type : string
+          agent:
+            type: string
+          granularity:
+            type: string
+          timestamp:
+            # the hourly timestamp will be stored as YYYYMMDDHH
+            type: string
+          views:
+            type: integer
+            format: int64
+
+  tops:
+    required:
+      - items
+    properties:
+      items:
+        type: array
+        properties:
+          project:
+            type: string
+          access:
+            type : string
+          year:
+            type: string
+          month:
+            type: string
+          day:
+            type: string
+          articles:
+            # format for this is a json array: [{rank: 1, article: <<title>>, views: 123}, ...]
+            type: string

--- a/specs/test_analytics.yaml
+++ b/specs/test_analytics.yaml
@@ -1,0 +1,32 @@
+# Simple test spec for analytics Pageviews API
+
+swagger: 2.0
+
+paths:
+  # These three endpoints are just for fake data insertion:
+  /{module:pageviews}/insert-per-article/{project}/{access}/{agent}/{article}/{granularity}/{timestamp}/{views}:
+    get:
+      description: >
+        Insert fake pageviews data for a given article in a project
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      x-backend-request:
+        uri: /{domain}/sys/pageviews/insert-per-article/{project}/{access}/{agent}/{article}/{granularity}/{timestamp}/{views}
+      x-monitor: false
+
+  /{module:pageviews}/insert-per-project/{project}/{access}/{agent}/{granularity}/{timestamp}/{views}:
+    get:
+      description: >
+        Insert fake pageviews data for a given project
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      x-backend-request:
+        uri: /{domain}/sys/pageviews/insert-per-project/{project}/{access}/{agent}/{granularity}/{timestamp}/{views}
+      x-monitor: false
+
+  /{module:pageviews}/insert-top/{project}/{access}/{year}/{month}/{day}/{rank}/{article}/{views}:
+    get:
+      description: >
+        Insert fake pageviews data for top articles
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      x-backend-request:
+        uri: /{domain}/sys/pageviews/insert-top/{project}/{access}/{year}/{month}/{day}/{rank}/{article}/{views}
+      x-monitor: false

--- a/test/features/pageviews/pageviews.js
+++ b/test/features/pageviews/pageviews.js
@@ -1,0 +1,97 @@
+'use strict';
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, afterEach */
+
+var assert = require('../../utils/assert.js');
+var preq   = require('preq');
+var server = require('../../utils/server.js');
+
+
+describe('pageviews endpoints', function () {
+    this.timeout(20000);
+
+    //Start server before running tests
+    before(function () { return server.start(); });
+
+    var articleEndpoint = '/pageviews/per-article/en.wikipedia/desktop/spider/one/daily/2015070100/2015070300';
+    var projectEndpoint = '/pageviews/per-project/en.wikipedia/mobile-app/spider/hourly/2015070100/2015070102';
+    var topsEndpoint = '/pageviews/top/en.wikipedia/mobile-web/2015/all-months/30';
+
+    // Fake data insertion endpoints
+    var insertArticleEndpoint = '/pageviews/insert-per-article/en.wikipedia/desktop/spider/one/daily/2015070200';
+    var insertProjectEndpoint = '/pageviews/insert-per-project/en.wikipedia/mobile-app/spider/hourly/2015070101';
+    var insertTopsEndpoint = '/pageviews/insert-top/en.wikipedia/mobile-web/2015/all-months/all-days/1/one';
+
+    // Test Article Endpoint
+
+    it('should return empty when no per article data is available', function () {
+        return preq.get({
+            uri: server.config.baseURL + articleEndpoint
+        }).then(function (res) {
+            assert.deepEqual(res.body.items.length, 0);
+        });
+    });
+
+    it('should return the expected per article data after insertion', function () {
+        return preq.get({
+            uri: server.config.baseURL + insertArticleEndpoint + '/100'
+        }).then(function (res){
+            return preq.get({
+                uri: server.config.baseURL + articleEndpoint
+            })
+        }).then(function (res) {
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].views, 100);
+        });
+    });
+
+
+    // Test Project Endpoint
+
+    it('should return empty when no per project data is available', function () {
+        return preq.get({
+            uri: server.config.baseURL + projectEndpoint
+        }).then(function (res) {
+            assert.deepEqual(res.body.items.length, 0);
+        });
+    });
+
+    it('should return the expected per project data after insertion', function () {
+        return preq.get({
+            uri: server.config.baseURL + insertProjectEndpoint + '/1000'
+        }).then(function (res){
+            return preq.get({
+                uri: server.config.baseURL + projectEndpoint
+            })
+        }).then(function (res) {
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].views, 1000);
+        });
+    });
+
+
+    // Test Top Endpoint
+
+    it('should return empty when no tops data is available', function () {
+        return preq.get({
+            uri: server.config.baseURL + topsEndpoint
+        }).then(function (res) {
+            assert.deepEqual(res.body.items.length, 0);
+        });
+    });
+
+    it('should return the expected tops data after insertion', function () {
+        return preq.get({
+            uri: server.config.baseURL + insertTopsEndpoint + '/2000'
+        }).then(function (res){
+            return preq.get({
+                uri: server.config.baseURL + topsEndpoint
+            })
+        }).then(function (res) {
+            assert.deepEqual(res.body.items.length, 1);
+            var article = JSON.parse(res.body.items[0].articles)[0];
+            assert.deepEqual(article.views, 2000);
+        });
+    });
+});


### PR DESCRIPTION
Bug on phabricator: T107053

These would be the frontend to backend mappings we need on all wikis (basically just making the {domain} map implicitly to the {project} parameter on our backend:

      /{module:stats}/views/v1/per-article/{access}/{agent}/{article}/{granularity}/{start}/{end}
        get:
          x-request-handler:
            - get_view_stats_per_article
                request:
                  uri: http://wikimedia.org/stats/views/v1/per-article/{domain}/{access}/{agent}/{article}/{granularity}/{start}/{end}

      /{module:stats}/views/v1/per-project/{access}/{agent}/{granularity}/{start}/{end}
        get:
          x-request-handler:
            - get_view_stats_per_project
                request:
                  uri: http://wikimedia.org/stats/views/v1/per-project/{domain}/{access}/{agent}/{granularity}/{start}/{end}

      /{module:stats}/views/v1/top/{access}/{year}/{month}/{day}
        get:
          x-request-handler:
            - get_view_top_stats
                request:
                  uri: http://wikimedia.org/stats/views/v1/top/{domain}/{access}/{year}/{month}/{day}

And for the global wikimedia.org we could just pass whatever comes after stats/* straight through, there would be no rewriting.  This is where people could pass values such as "all-projects" for the {project} parameter.
