### PR TITLE
Small promise chain hot path

### DIFF
--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -264,11 +264,24 @@ function prepareRequestChain(conf) {
 function createHandler(spec) {
     validateSpec(spec);
     var requestChain = prepareRequestChain(spec);
-    return function(restbase, req) {
-        return generatePromiseChain(restbase, {
-            request: req
-        }, requestChain);
-    };
+    if (requestChain.length === 1
+            && requestChain[0].length === 1
+            && requestChain[0][0].request
+            && !requestChain[0][0].return
+            && !requestChain[0][0].catch) {
+        var handler = requestChain[0][0].request;
+        return function(restbase, req) {
+            return handler(restbase, {
+                request: req
+            });
+        };
+    } else {
+        return function(restbase, req) {
+            return generatePromiseChain(restbase, {
+                request: req
+            }, requestChain);
+        };
+    }
 }
 
 /**

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -255,6 +255,18 @@ function prepareRequestChain(conf) {
     });
 }
 
+function isSimpleChain(requestChain) {
+    if (requestChain.length === 1
+            && requestChain[0].length === 1) {
+        var requestTemplate = requestChain[0][0];
+        return requestTemplate.request
+            && !requestTemplate.return
+            && !requestTemplate.catch;
+    } else {
+        return false;
+    }
+}
+
 /**
  * Creates a handler function from the handler spec.
  *
@@ -264,11 +276,7 @@ function prepareRequestChain(conf) {
 function createHandler(spec) {
     validateSpec(spec);
     var requestChain = prepareRequestChain(spec);
-    if (requestChain.length === 1
-            && requestChain[0].length === 1
-            && requestChain[0][0].request
-            && !requestChain[0][0].return
-            && !requestChain[0][0].catch) {
+    if (isSimpleChain(requestChain)) {
         var handler = requestChain[0][0].request;
         return function(restbase, req) {
             return handler(restbase, {


### PR DESCRIPTION
Simple single-request handlers are by far the most common, so it's worth
optimizing for them. In local testing, this seems to improve throughput (as
measured by `ab -c 20 -n 10000
localhost:7231/en.wikipedia.org/v1/page/html/Foobar` from around 840 req/s to
about 870 req/s.