### PR TITLE
Allow HTTP pipelining

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -126,7 +126,6 @@ function handleResponse(opts, req, resp, response) {
                     body = new Buffer(body);
                 }
             }
-            response.headers.connection = 'close';
             var cType = response.headers['content-type'];
             if (/\bgzip\b/.test(req.headers['accept-encoding'])
                     && /^application\/json\b|^text\//.test(cType)) {


### PR DESCRIPTION
I don't actually recall why I added this header a long time ago. I do not
think that it still makes sense.

Clients like Varnish can get significantly better performance if pipelining is
enabled. Modern benchmark clients like wrk also get significantly better
throughput, and don't run out of connections.