### PR TITLE
Optimized templating

### DIFF
--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -192,7 +192,11 @@ function prepareRequestChain(conf) {
         if (requestConf.request) {
             template = new Template(requestConf.request);
             requestSpec.request = function(restbase, context) {
-                var req = template.eval(context);
+                var req = template.expand(context);
+                if (!requestConf.request.method) {
+                    // Do we really want this?
+                    req.method = context.request.method || 'get';
+                }
                 return restbase.request(req)
                 .then(function(res) {
                     context[requestName] = res;
@@ -210,12 +214,12 @@ function prepareRequestChain(conf) {
                 requestSpec.request = function(restbase, context) {
                     return originalRequestHandler(restbase, context)
                     .then(function() {
-                        return template.eval(context);
+                        return template.expand(context);
                     });
                 };
             } else {
                 requestSpec.request = function(restbase, context) {
-                    return template.eval(context);
+                    return template.expand(context);
                 };
             }
         }

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -4,45 +4,31 @@ var URI = require('swagger-router').URI;
 var TAssembly = require('tassembly');
 var url = require('url');
 var expressionCompiler = require('template-expression-compiler');
+require('core-js/shim');
 
-/**
- * Creates a function that sets a value at the path
- * and initializes all objects/arrays along the path.
- *
- * @param {string} path the path within an object/array separated
- *        with dots {e.g. test.body.a.b.c}
- * @param {object} spec spec element that contains provided path
- * @returns {Function} the function to set a value at path
- *          and initialize object along the path if needed
- * @private
- */
-function _setAtPath(path, spec) {
-    var pathArr = path.split('.');
-    var refArr = [];
-    var subspec = spec;
-    var code;
+var globalMethods = {
+    default: function(val, defVal) {
+        return val || defVal;
+    },
+    merge: function(destination, source) {
+        destination = destination || {};
+        source = source || {};
 
-    for (var idx = 0; idx < pathArr.length; idx++) {
-        var curRef = {};
-        curRef.ref = Array.isArray(subspec) ? '[' + pathArr[idx] + ']' : '["' + pathArr[idx] + '"]';
-        subspec = subspec[pathArr[idx]];
-        curRef.initializer = Array.isArray(subspec) ? '[]' : '{}';
-        refArr.push(curRef);
+        if (typeof destination !== 'object' || typeof source !== 'object') {
+            throw new Error('Illegal spec. Merge source and destination must be objects');
+        }
+
+        var result = Object.assign({}, destination);
+        Object.keys(source).forEach(function(keyName) {
+            if (result[keyName] === undefined) {
+                result[keyName] = source[keyName];
+            }
+        });
+        return result;
     }
+};
 
-    code =  'if (value !== undefined) {\n';
-    for (var i = 1; i < refArr.length; i++) {
-        var ref = refArr.slice(0, i).map(function(elem) { return elem.ref; }).join('');
-        code += 'obj' + ref + ' = obj' + ref + ' || ' + refArr[i - 1].initializer + ';\n';
-    }
-    code += 'obj' + refArr.map(function(elem) { return elem.ref; }).join('') + ' = value;\n';
-    code += '}';
-
-    /* jslint evil: true */
-    return new Function('obj', 'value', code);
-}
-
-function splitAndPrepareTAsseblyTemplate(templateSpec) {
+function splitAndPrepareTAsseblyTemplate(templateSpec, part) {
     var result = [];
     var templateNest = 0;
     var startIndex = 0;
@@ -59,7 +45,11 @@ function splitAndPrepareTAsseblyTemplate(templateSpec) {
         } else if (templateSpec[index] === '}') {
             if (templateNest === 1) { // The current template is finished
                 currentTemplate = templateSpec.substring(startIndex, index);
-                result.push(['raw', expressionCompiler.parse(currentTemplate)]);
+                var compiledExpression = expressionCompiler.parse(currentTemplate);
+                // FIXME: Rewrite path prefixes in expressionCompiler!
+                compiledExpression = compiledExpression.replace(/([,(\[:])m\./g,
+                            '$1rm.' + part + '.');
+                result.push(['raw', compiledExpression]);
                 startIndex = index + 1;
             } // Or and object literal finished
             templateNest--;
@@ -75,16 +65,53 @@ function splitAndPrepareTAsseblyTemplate(templateSpec) {
 }
 
 /**
- * Compiles a template into a function
- *
- * @param templateSpec template string (e.g. '{$.request.body.a}')
- * @param reqPart part of the request to lookup local properties in (e.g. headers, body etc.)
- * @param setValue callback for a result of template evaluation
- * @returns {Function} a template resolver for the provided template
+ * Creates a template resolver functuons for URI part of the spec
+ * @param {object} spec a root request spec object
+ * @returns {Function} a template resolver which should be applied to resolve URI
  */
-function compileTemplate(templateSpec, setValue, reqPart) {
+function createURIResolver(spec) {
+    if (/^\{[^\{}]+}$/.test(spec.uri) || /\{\$\$?\..+}/.test(spec.uri)) {
+        var tassemblyTemplate = splitAndPrepareTAsseblyTemplate(spec.uri);
+        var resolver = compileTAssembly(tassemblyTemplate, 'params');
+        return function(context) {
+            var value = resolver(context);
+            if (value.constructor !== URI) {
+                value = new URI(value, {}, false);
+            }
+            return value;
+        };
+    } else if (/^(?:https?:\/\/)?\{[^\/]+}\//.test(spec.uri)) {
+        // The host is templated - replace it with TAssembly and use URI.expand for path templates
+        var hostTemplate = /^((?:https?:\/\/)?\{[^\/]+}\/)/.exec(spec.uri)[1];
+        var hostTassembly = splitAndPrepareTAsseblyTemplate(hostTemplate);
+        var hostResolver = compileTAssembly(hostTassembly, 'params');
+        var path = spec.uri.substr(hostTemplate.length);
+        var pathTemplate = new URI('/' + path, {}, true);
+        return function(context) {
+            var newHost = hostResolver(context);
+            // FIXME: Support references to other parts of the request.
+            // params['$'] = context.rm;
+            var newUri = pathTemplate.expand(context.rm.request.params);
+            newUri.urlObj = url.parse(newHost + path);
+            return newUri;
+        };
+    } else {
+        return (function(uri) {
+            var uriTemplate = new URI(uri, {}, true);
+            return function(context) {
+                return uriTemplate.expand(context.rm.request.params);
+            };
+        })(spec.uri);
+    }
+}
+
+function errorHandler(e) {
+    console.error('ERR', e);
+    return undefined;
+}
+
+function compileTAssembly(template, reqPart) {
     var res;
-    var template = splitAndPrepareTAsseblyTemplate(templateSpec);
     var callback = function(bit) {
         if (res === undefined) {
             res = bit;
@@ -92,133 +119,88 @@ function compileTemplate(templateSpec, setValue, reqPart) {
             res += '' + bit;
         }
     };
-    var errorHandler = function() { return undefined; };
 
-    var resolveTemplate = TAssembly.compile(template, {
-        nestedTemplate: true,
-        cb: callback,
-        errorHandler: errorHandler
-    });
     var options = {
+        nestedTemplate: true,
         errorHandler: errorHandler,
         cb: callback,
-        globals: {
-            default: function(val, defVal) {
-                return val || defVal;
-            },
-            merge: function(destination, source) {
-                destination = destination || {};
-                source = source || {};
-
-                if (typeof destination !== 'object' || typeof source !== 'object') {
-                    throw new Error('Illegal spec. Merge source and destination must be objects');
-                }
-
-                var result = Object.assign({}, destination);
-                Object.keys(source).forEach(function(keyName) {
-                    if (result[keyName] === undefined) {
-                        result[keyName] = source[keyName];
-                    }
-                });
-                return result;
-            }
-        }
+        globals: globalMethods,
     };
+    var resolveTemplate = TAssembly.compile(template, options);
 
-    return function(newReq, context) {
-        var extendedContext = {
-            rc: null,
-            rm: context,
-            m: context.request[reqPart],
-            pms: [ context.request[reqPart] ],
-            g: options.globals,
-            options: options,
-            cb: options.cb
+    return function(context) {
+        var childContext = {
+            rc: context.rc,
+            rm: context.rm,
+            m: context.rm.request[reqPart],
+            cb: options.cb,
+            options: context.options || options,
         };
-        extendedContext.rc = extendedContext;
 
-        resolveTemplate(extendedContext);
+        resolveTemplate(childContext);
         var value = res;
         res = undefined; // Unitialize res to prepare to the next request
-        setValue(newReq, value);
+        return value;
     };
 }
 
 /**
- *  Constructs a list of resolvers for all templates in a request spec
+ * Rewrite a request template to a valid tassembly expression template.
  *
- * @param origSpec original full spec
- * @param subspec a request spec or subspec for a part of request
- * @param reqPart name of request part (e.g. headers, body, query)
- * @param path path to the current subspec within a full spec
- * @returns {Array} an array of template resolvers for every template found in the spec.
- *          Resolvers are functions with (newRequest, request) arguments
- *          that modify newRequest param.
- * @private
+ * Copies the object on write.
  */
-function _createTemplateResolvers(origSpec, subspec, reqPart, path) {
-
-    /**
-     * Makes an array of resolvers for every template found within a template spec object.
-     *
-     * @param templateSpec A subspec of an original request spec.
-     * @param templatePath A path to the current subspec
-     * @returns {Array} and array of resolvers for each template found in the subspec
-     */
-    function makeResolvers(templateSpec, templatePath) {
-        var setValue = _setAtPath(templatePath, origSpec);
-        if (templateSpec instanceof Object) {
-            return _createTemplateResolvers(origSpec, templateSpec, reqPart, templatePath);
-        } else if (/\{[^}]+}/.test(templateSpec)) {
-            return [ compileTemplate(templateSpec, setValue, reqPart) ];
-        } else {
-            return [ function(newReq) { setValue(newReq, templateSpec); } ];
-        }
-    }
-
-    if (!path) { path = reqPart; }
-    if (subspec instanceof Object) {
-        return Object.keys(subspec).map(function(key) {
-            return makeResolvers(subspec[key], path + '.' + key);
-        }).reduce(function(arr1, arr2) { return arr1.concat(arr2); });
-    } else {
-        return makeResolvers(subspec, path);
-    }
-}
-
-/**
- * Creates a template resolver functuons for URI part of the spec
- * @param {object} spec a root request spec object
- * @returns {Function} a template resolver which should be applied to resolve URI
- */
-function createURIResolver(spec) {
-    var setter = _setAtPath('uri', spec);
-    if (/^\{[^\{}]+}$/.test(spec.uri) || /\{\$\$?\..+}/.test(spec.uri)) {
-        var setValue = function(newReq, value) {
-            if (value.constructor !== URI) {
-                value = new URI(value, {}, false);
+function replaceComplexTemplates(part, subSpec, globals) {
+    if (subSpec && subSpec.constructor === Object) {
+        var res = {};
+        Object.keys(subSpec).forEach(function(key) {
+            res[key] = replaceComplexTemplates(part, subSpec[key], globals);
+        });
+        return res;
+    } else if (Array.isArray(subSpec)) {
+        return subSpec.map(function(elem) {
+            return replaceComplexTemplates(part, elem, globals);
+        });
+    } else if (subSpec && subSpec.constructor === String || subSpec === '') {
+        if (/\{.*\}/.test(subSpec)) {
+            // There is a template, now we need to check it for special stuff we replace
+            if (/^\{[^\}\[]+\}$/.test(subSpec)) {
+                // Simple variable: Remove braces
+                subSpec = subSpec.substring(1, subSpec.length - 1);
+                // FIXME: Replace with proper rewriting using the expression
+                // compiler.
+                subSpec = subSpec.replace(/([,(\[:] *)([a-z_])/g,
+                            '$1$.request.' + part + '.$2');
             }
-            setter(newReq, value);
-        };
-        return compileTemplate(spec.uri, setValue, 'params');
-    } else if (/^(?:https?:\/\/)?\{[^\/]+}\//.test(spec.uri)) {
-        // The host is templated - replace it with TAssembly and use URI.expand for path templates
-        var hostTemplate = /^((?:https?:\/\/)?\{[^\/]+}\/)/.exec(spec.uri)[1];
-        var hostResolver = compileTemplate(hostTemplate, setter, 'params');
-        var path = spec.uri.substr(hostTemplate.length);
-        var pathTemplate = new URI('/' + path, {}, true);
-        return function(newReq, context) {
-            hostResolver(newReq, context);
-            var newUri = pathTemplate.expand(context.request.params);
-            newUri.urlObj = url.parse(newReq.uri + path);
-            setter(newReq, newUri);
-        };
+            if (!/^[\$'"]/.test(subSpec) && !/[\{\[\(]/.test(subSpec)) {
+                // Simple local reference
+                // XXX: won't handle nested references
+                return '$.request.' + part + '.' + subSpec;
+            } else {
+                var tAssemblyTemplates = splitAndPrepareTAsseblyTemplate(subSpec, part);
+                if (tAssemblyTemplates.length > 1) {
+                    // This is a string with partial templates
+                    // Compile a function
+                    var resolver = compileTAssembly(tAssemblyTemplates, part);
+                    // Replace the complex template with a function call
+                    var fnName = 'fn_' + globals._i++;
+                    globals[fnName] = resolver;
+                    return '$$.' + fnName + '($context)';
+                } else if (/^\{.*\}$/.test(subSpec)) {
+                    // If it's a simple and resolvable function - just remove the braces
+                    return subSpec.substring(1, subSpec.length - 1);
+                } else {
+                    return subSpec;
+                }
+            }
+        } else {
+            // If it's not templated - wrap it into braces to let tassembly add it
+            return "'" + subSpec + "'";
+        }
     } else {
-        var uriTemplate = new URI(spec.uri, {}, true);
-        return function(newReq, context) {
-            setter(newReq, uriTemplate.expand(context.request.params));
-        };
+        // Other literals: Number, booleans
+        return subSpec;
     }
+    return subSpec;
 }
 
 /**
@@ -230,44 +212,63 @@ function createURIResolver(spec) {
  *              fields that couldn't be resolved from original request would be ignored.
  */
 function Template(spec) {
+    spec = Object.assign({}, spec);
     var self = this;
-    self.resolvers = [];
-    if (typeof spec === 'string') {
-        self.resolvers.push(compileTemplate(spec, function(newReq, val) {
-            newReq.val = val;
-        }));
+    var globals = Object.assign({}, globalMethods);
+    globals._i = 0;
+    Object.keys(spec).forEach(function(part) {
+        if (part === 'uri') {
+            globals.uri = createURIResolver(spec);
+            spec.uri = '$$.uri($context)';
+        } else if (part === 'method') {
+            spec.method = "'" + (spec.method || 'get') + "'";
+        } else {
+            spec[part] = replaceComplexTemplates(part, spec[part], globals);
+        }
+    });
 
-        self._eval = function(context) {
-            var result = {};
-            this.resolvers.forEach(function(resolver) {
-                resolver(result, context);
-            });
-            return result.val;
-        };
-    } else {
-        Object.keys(spec).forEach(function(reqPart) {
-            var setValue;
-            if (reqPart === 'uri') {
-                self.resolvers.push(createURIResolver(spec));
-            } else if (reqPart === 'method') {
-                setValue = _setAtPath('method', spec);
-                self.resolvers.push(function(newReq) {
-                    setValue(newReq, spec.method);
-                });
-            } else if (spec[reqPart]) {
-                self.resolvers = self.resolvers.concat(
-                    _createTemplateResolvers(spec, spec[reqPart], reqPart));
-            }
-        });
-
-        self._eval = function(context) {
-            var newReq = { method: context.request.method };
-            this.resolvers.forEach(function(resolver) {
-                resolver(newReq, context);
-            });
-            return newReq;
-        };
+    var completeTAssemblyTemplate;
+    try {
+        completeTAssemblyTemplate = expressionCompiler.parse(spec);
+    } catch (e) {
+        console.log('COMPILE ERROR');
+        console.log(JSON.stringify(spec, null, 2));
+        console.log(e);
+        throw e;
     }
+
+    var res;
+    var callback = function(bit) {
+        if (res === undefined) {
+            res = bit;
+        } else {
+            res += '' + bit;
+        }
+    };
+    var resolver = TAssembly.compile([['raw', completeTAssemblyTemplate]], {
+        nestedTemplate: true,
+        globals: globals,
+        cb: callback,
+        errorHandler: errorHandler
+    });
+    var options = {
+        errorHandler: errorHandler
+    };
+    var c = {
+        rc: null,
+        g: globals,
+        options: options,
+        cb: callback,
+    };
+    c.rc = c;
+    self.expand = function(m) {
+        c.rm = m;
+        c.m = m;
+        resolver(c);
+        var ret = res;
+        res = undefined;
+        return ret;
+    };
 }
 
 /**
@@ -276,8 +277,6 @@ function Template(spec) {
  * @param {object} context a context object where to take data from
  * @returns {object} a new request object with all templates either substituted or dropped
  */
-Template.prototype.eval = function(context) {
-    return this._eval(context);
-};
+Template.prototype.expand = null;
 
 module.exports = Template;

--- a/lib/reqTemplate.js
+++ b/lib/reqTemplate.js
@@ -4,7 +4,6 @@ var URI = require('swagger-router').URI;
 var TAssembly = require('tassembly');
 var url = require('url');
 var expressionCompiler = require('template-expression-compiler');
-require('core-js/shim');
 
 var globalMethods = {
     default: function(val, defVal) {
@@ -96,17 +95,14 @@ function createURIResolver(spec) {
             return newUri;
         };
     } else {
-        return (function(uri) {
-            var uriTemplate = new URI(uri, {}, true);
-            return function(context) {
-                return uriTemplate.expand(context.rm.request.params);
-            };
-        })(spec.uri);
+        var uriTemplate = new URI(spec.uri, {}, true);
+        return function(context) {
+            return uriTemplate.expand(context.rm.request.params);
+        };
     }
 }
 
 function errorHandler(e) {
-    console.error('ERR', e);
     return undefined;
 }
 
@@ -228,14 +224,7 @@ function Template(spec) {
     });
 
     var completeTAssemblyTemplate;
-    try {
-        completeTAssemblyTemplate = expressionCompiler.parse(spec);
-    } catch (e) {
-        console.log('COMPILE ERROR');
-        console.log(JSON.stringify(spec, null, 2));
-        console.log(e);
-        throw e;
-    }
+    completeTAssemblyTemplate = expressionCompiler.parse(spec);
 
     var res;
     var callback = function(bit) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -387,7 +387,7 @@ Router.prototype.handleResources = function(restbase) {
         if (value && Array.isArray(value.resources) && value.resources.length > 0) {
             return P.each(value.resources, function(reqSpec) {
                 var reqTemplate = new Template(reqSpec);
-                var req = reqTemplate.eval({
+                var req = reqTemplate.expand({
                     request: {
                         params: {
                             domain: path[0]

--- a/mods/action.js
+++ b/mods/action.js
@@ -181,7 +181,7 @@ function buildEditResponse(res) {
 }
 
 ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
-    var apiRequest = this.apiRequestTemplate.eval({
+    var apiRequest = this.apiRequestTemplate.expand({
         request: req
     });
     apiRequest.body.action = defBody.action;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "service-runner": "^0.2.5",
     "swagger-router": "^0.1.1",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
-    "tassembly": "^0.1.4",
+    "tassembly": "^0.2.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "template-expression-compiler": "^0.1.0"
   },

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -175,7 +175,7 @@ describe('router - misc', function() {
                 'string_templated': 'test field_value_with_underscore'
             }
         };
-        var result = new Template(requestTemplate).eval({
+        var result = new Template(requestTemplate).expand({
             request: testRequest,
             additional_context: {
                 field: 'additional_test_value'
@@ -188,7 +188,7 @@ describe('router - misc', function() {
         var requestTemplate = {
             uri: 'http://{domain}/path1/{path2}'
         };
-        var result = new Template(requestTemplate).eval({
+        var result = new Template(requestTemplate).expand({
             request: {
                 params: {
                     domain: 'en.wikipedia.org',
@@ -206,7 +206,7 @@ describe('router - misc', function() {
         var requestTemplate = {
             uri: '/{domain}/path1{/optional}'
         };
-        var resultNoOptional = new Template(requestTemplate).eval({
+        var resultNoOptional = new Template(requestTemplate).expand({
             request: {
                 params: {
                     domain: 'en.wikipedia.org'
@@ -214,7 +214,7 @@ describe('router - misc', function() {
             }
         });
         assert.deepEqual(resultNoOptional.uri, new URI('/en.wikipedia.org/path1{/optional}', {}, true).expand());
-        var resultWithOptional = new Template(requestTemplate).eval({
+        var resultWithOptional = new Template(requestTemplate).expand({
             request: {
                 params: {
                     domain: 'en.wikipedia.org',
@@ -231,7 +231,7 @@ describe('router - misc', function() {
         var requestTemplate = {
             uri: 'http://{domain}/path1/{+path}'
         };
-        var result = new Template(requestTemplate).eval({
+        var result = new Template(requestTemplate).expand({
             request: {
                 params: {
                     domain: 'en.wikipedia.org',
@@ -249,7 +249,7 @@ describe('router - misc', function() {
         var requestTemplate = {
             uri: '{uri}'
         };
-        var result = new Template(requestTemplate).eval({
+        var result = new Template(requestTemplate).expand({
             request: {
                 params: {
                     uri: 'en.wikipedia.org/path1/test1/test2/test3'
@@ -281,7 +281,7 @@ describe('router - misc', function() {
             },
             body: 'a'
         };
-        assert.deepEqual(template.eval({request:request}).uri, '/path/test/a');
+        assert.deepEqual(template.expand({request:request}).uri, '/path/test/a');
     });
 
     it('supports default values in req templates', function() {
@@ -293,7 +293,7 @@ describe('router - misc', function() {
                 withObject: '{$$.default($.request.body.test, {temp: "default"})}'
             }
         });
-        var evaluatedNoDefaults = template.eval({
+        var evaluatedNoDefaults = template.expand({
             request: {
                 method: 'get',
                 body: {
@@ -305,7 +305,7 @@ describe('router - misc', function() {
         assert.deepEqual(evaluatedNoDefaults.body.complete, 'value');
         assert.deepEqual(evaluatedNoDefaults.body.partial, '/test/value');
         assert.deepEqual(evaluatedNoDefaults.body.withObject, 'value');
-        var evaluatedDefaults = template.eval({
+        var evaluatedDefaults = template.expand({
             request: {
                 method: 'get',
                 body: {}
@@ -323,7 +323,7 @@ describe('router - misc', function() {
                 merged: '{$$.merge($.request.body.first, second)}'
             }
         });
-        var evaluated = template.eval({
+        var evaluated = template.expand({
             request: {
                 method: 'get',
                 body: {


### PR DESCRIPTION
This PR optimizes request templating further. The templating micro-benchmark
is now about 2-3 times faster, with a further 3x speedup to be had if we
hoisted the try/catch one level.

However, profiles don't really show this code (before or after) as that much
of a bottleneck.  There are some gains to be made here for RESTBase as a
whole, but they will primarily benefit otherwise cheap entry points, where
request rewriting is a bigger part of the overall request cost. For most HTML
requests, much more time is spent in the Cassandra driver.

To summarize, I wouldn't call this change necessarily super-critical for
overall RESTBase performance, at this point.

- Don't silently ignore when entire sub-trees are undefined. This is still
  supported where needed (via default(), for example), but making this the
  default strikes me as dangerous.
- More aggressively expand all simple templates inline by rewriting local
  references to the path prefix. This isn't perfect yet, but does work rather
  well.
- Rename Template.eval to Template.expand; `eval` is not popular with jshint.

- More robust scope rewriting (see inline notes)
- Possibly, reduce the try/catch tax by moving that up to the request wrapper,
  similar to the technique described by the bluebird authors:
  https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#2-unsupported-syntax)
- Reconsider if we really want to default to `method: spec.method ||
  request.method || 'get'`, or just `method: spec.method || 'get'`. This
  strikes me as a little bit too much magic, and it's good to call out
  potentially state-changing requests explicitly.
- Remove commented-out inline microbenchmarking code.