### PR TITLE
Re-revert the removal of v1 is mobileapps sys endpoints

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -117,7 +117,7 @@ templates:
                 request:
                   uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
 
-      /{module:mobileapps}/v1:
+      /{module:mobileapps}:
         x-subspec:
           info:
             title: Mobileapps sys API module

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -118,7 +118,7 @@ templates:
                 request:
                   uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
 
-      /{module:mobileapps}/v1:
+      /{module:mobileapps}:
         x-subspec:
           info:
             title: Mobileapps sys API module

--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -36,7 +36,7 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
-              uri: /{domain}/sys/mobileapps/v1/html/{title}
+              uri: /{domain}/sys/mobileapps/html/{title}
       x-monitor: true
       x-amples:
         - title: Get MobileApps Main Page
@@ -81,7 +81,7 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
-              uri: /{domain}/sys/mobileapps/v1/sections/{title}
+              uri: /{domain}/sys/mobileapps/sections/{title}
       x-monitor: false
 
   /{module:page}/mobile-html-sections-lead/{title}:
@@ -116,7 +116,7 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
-              uri: /{domain}/sys/mobileapps/v1/sections-lead/{title}
+              uri: /{domain}/sys/mobileapps/sections-lead/{title}
       x-monitor: false
 
   /{module:page}/mobile-html-sections-remaining/{title}:
@@ -152,7 +152,7 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
-              uri: /{domain}/sys/mobileapps/v1/sections-remaining/{title}
+              uri: /{domain}/sys/mobileapps/sections-remaining/{title}
       x-monitor: false
 
   /{module:page}/mobile-text/{title}:
@@ -187,5 +187,5 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
-              uri: /{domain}/sys/mobileapps/v1/text/{title}
+              uri: /{domain}/sys/mobileapps/text/{title}
       x-monitor: false


### PR DESCRIPTION
In https://github.com/wikimedia/restbase/pull/342 @gwicke have reverted a change that removed /v1 from sys mobile endpoints, because it added yet another config change after staging testing and before the deploy. Now we can re-revert that change.