### PR TITLE
Added support for cache-control: no-cache in /html/{title} endpoint

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -349,7 +349,10 @@ PSP.getRevisionInfo = function(restbase, req) {
     }
 
     return restbase.get({
-        uri: new URI(path)
+        uri: new URI(path),
+        headers: {
+            'cache-control': req.headers && req.headers['cache-control']
+        }
     })
     .then(function(res) {
         return res.body.items[0];
@@ -392,8 +395,7 @@ PSP.getFormat = function(format, restbase, req) {
         uri: self.getBucketURI(rp, format, rp.tid)
     });
 
-    if (req.headers && /no-cache/i.test(req.headers['cache-control'])
-            && rp.revision) {
+    if (req.headers && /no-cache/i.test(req.headers['cache-control'])) {
         // Check content generation either way
         contentReq = contentReq.then(function(res) {
                 if (req.headers['if-unmodified-since']) {

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -220,10 +220,13 @@ paths:
       tags:
         - Page content
       description: >
-        Retrieve the latest html for a page title.
+        Retrieve the latest html for a page title available in storage.
 
         If you know the revision as well, then please use the
         `{title}/{revision}` end point instead for better performance.
+
+        Supply the `Cache-Control: no-cache` header to force a fetch
+        of the most recent version.
 
         See [the MediaWiki DOM
         spec](https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec) for a

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -210,4 +210,50 @@ describe('on-demand generation of html and data-parsoid', function() {
                 .indexOf("style-src http://*.wikipedia.org https://*.wikipedia.org 'unsafe-inline'") > 0, true);
         });
     });
+
+    it('should honor no-cache on /html/{title} endpoint', function() {
+        var testPage = "User:Pchelolo%2fRev_Test";
+        var firstRev = 682093020;
+        // 1. Pull in a non-final revision of a title
+        return preq.get({
+            uri: pageUrl + '/html/' + testPage + '/' + firstRev
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(/First revision/.test(res.body), true);
+            return preq.get({
+                uri: pageUrl + '/html/' + testPage,
+                headers: {
+                    'cache-control': 'no-cache'
+                }
+            });
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(/Second Revision/.test(res.body), true);
+        })
+    });
+
+    it('should honor no-cache on /html/{title} endpoint with sections', function() {
+        var testPage = "User:Pchelolo%2fRev_Section_Test";
+        var firstRev = 682100867;
+        // 1. Pull in a non-final revision of a title
+        return preq.get({
+            uri: pageUrl + '/html/' + testPage + '/' + firstRev
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(/First Revision/.test(res.body), true);
+            return preq.get({
+                uri: pageUrl + '/html/' + testPage + '?sections=mwAQ',
+                headers: {
+                    'cache-control': 'no-cache'
+                }
+            });
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(/Second Revision/.test(res.body.mwAQ), true);
+        })
+    });
 });


### PR DESCRIPTION
There's a bug on phabricator about adding support for `cache-control: no-cache` header to the `/html/{title}` endpoint. It's quite simple to implement now, because `/title/{title}` also supports the no-cache header.

This impl is not perfect, because it requires re-render even if the content hasn't been changed. It could be fixed by using the `page_touched` property from MW API, but we currently don't expose it from the `page_revisions` module. Exposing it would be one more nice use for page-related metadata when it's finished. Another option is to start exposing it by adding a static (?) column in the page_revisions table, but as I understand this property doesn't have much value for not-last revisions.

Bug: https://phabricator.wikimedia.org/T97387