### PR TITLE
low-cased the swagger's CSP policy header

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -39,7 +39,7 @@ function staticServe(restbase, req) {
             status: 200,
             headers: {
                 'content-type': contentType,
-                'Content-Security-Policy': "default-src 'none'; " +
+                'content-security-policy': "default-src 'none'; " +
                     "script-src 'self' 'unsafe-inline'; connect-src 'self'; " +
                     "style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self';"
             },


### PR DESCRIPTION
I've just noticed that PR https://github.com/wikimedia/restbase/pull/333 have completely broken the swagger ui documentation. The problem was that swaggerUI.js was setting a camel-cased CSP header, and so additional low-cased CSP header was added. Apparently the last one took precedence in Safari (may be in other browsers too), so the browser couldn't load any resources.