### PR TITLE
Swagger Docs: Update RESTBase URL

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -16,7 +16,7 @@ function staticServe(restbase, req) {
             body = body.replace(/((?:src|href)=['"])/g, '$1?doc=&path=')
                 // Some self-promotion
                 .replace(/<a id="logo".*?<\/a>/,
-                        '<a id="logo" href="http://restbase.org">RESTBase</a>')
+                        '<a id="logo" href="https://www.mediawiki.org/wiki/RESTBase">RESTBase</a>')
                 .replace(/<title>[^<]*<\/title>/,
                         '<title>RESTBase docs</title>')
                 // Replace the default url with ours, switch off validation &


### PR DESCRIPTION
`restbase.org` has expired, so let's link the logo in the documentation to the mediawiki.org page about RESTBase.