### PR TITLE
Restrict only user/comment information if needed

### DIFF
--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -167,6 +167,19 @@ describe('revision requests with en.wikipedia.org', function() {
             assert.deepEqual(res.status, 403);
         });
     });
+
+    it('should restrict user and comment', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/title/User:Pchelolo%2fRestricted_Rev'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            var item = res.body.items[0];
+            assert.deepEqual(item.user_id, null);
+            assert.deepEqual(item.user_text, null);
+            assert.deepEqual(item.comment, null);
+        })
+    })
 });
 
 describe('revision requests with test2.wikipedia.org', function() {

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -175,9 +175,9 @@ describe('revision requests with en.wikipedia.org', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             var item = res.body.items[0];
-            assert.deepEqual(item.user_id, null);
-            assert.deepEqual(item.user_text, null);
-            assert.deepEqual(item.comment, null);
+            assert.deepEqual(!!item.user_id, false);
+            assert.deepEqual(!!item.user_text, false);
+            assert.deepEqual(!!item.comment, false);
         })
     })
 });


### PR DESCRIPTION
There are several types of revision deletion flags: `texthidden`, `sha1hidden`, `commenthidden`, `userhidden` and `suppressed`. Only for the first 2 types 403 should be returned by restbase. For `commenthidden` and `userhidden` we just should delete user or comment info. The `suppressed` flag states that other restrictions are applied to admins too, but as we can't distinguish admins, we can simply ignore it. 

Related:
Docs for revision deleting: https://www.mediawiki.org/wiki/Manual:RevisionDelete
MW API source, that sets the flags: https://doc.wikimedia.org/mediawiki-core/master/php/ApiQueryRevisionsBase_8php_source.html 

Bug: https://phabricator.wikimedia.org/T113117