### PR TITLE
Return 409 if a tranform request is done for a restricted revision

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -707,14 +707,14 @@ PSP.makeTransform = function(from, to) {
         return transform
         .catch(function(e) {
             // In case a page was deleted/revision restricted while edit was happening,
-            // return 429 Conflict error instead of a general 400
+            // return 410 Gone or 409 Conflict error instead of a general 400
             var pageDeleted = e.status === 404 && e.body
                     && /Page was deleted/.test(e.body.description);
             var revisionRestricted = e.status === 403 && e.body
                     && /Access is restricted/.test(e.body.description);
             if (pageDeleted || revisionRestricted) {
                 throw new rbUtil.HTTPError({
-                    status: 429,
+                    status: pageDeleted ? 410 : 409,
                     body: {
                         type: 'revision#conflict',
                         title: 'Conflict detected',

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -705,18 +705,8 @@ PSP.makeTransform = function(from, to) {
             transform = self.callParsoidTransform(restbase, req, from, to);
         }
         return transform
-        // XXX: This is a temporary catch to aid in
-        // discovering what's going on in T112339
-        // We need to remove it
         .catch(function(e) {
-            if (to === 'wikitext' && e.status && e.status >= 400 && e.status < 500) {
-                self.log('warn/transform', {
-                    message: e.body.description || e.body.message,
-                    req: req,
-                    status: e.status
-                });
-            }
-            // In case the a page was deleted/revision restricted wkile edit was happening,
+            // In case a page was deleted/revision restricted while edit was happening,
             // return 429 Conflict error instead of a general 400
             var pageDeleted = e.status === 404 && e.body
                     && /Page was deleted/.test(e.body.description);
@@ -730,6 +720,19 @@ PSP.makeTransform = function(from, to) {
                         title: 'Conflict detected',
                         description: e.body.description
                     }
+                });
+            }
+            throw e;
+        })
+        // XXX: This is a temporary catch to aid in
+        // discovering what's going on in T112339
+        // We need to remove it
+        .catch(function(e) {
+            if (to === 'wikitext' && e.status && e.status >= 400 && e.status < 500) {
+                self.log('warn/transform', {
+                    message: e.body.description || e.body.message,
+                    req: req,
+                    status: e.status
                 });
             }
             throw e;

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -910,6 +910,10 @@ paths:
           description: Unknown page title or revision
           schema:
             $ref: '#/definitions/problem'
+        '429':
+          descripting: Revision was changed or restricted
+          schema:
+            $ref: '#/definitions/problem'
         default:
           description: Error
           schema:
@@ -970,6 +974,10 @@ paths:
             $ref: '#/definitions/problem'
         '404':
           description: Unknown page title or revision
+          schema:
+            $ref: '#/definitions/problem'
+        '429':
+          descripting: Revision was changed or restricted
           schema:
             $ref: '#/definitions/problem'
         default:
@@ -1048,6 +1056,10 @@ paths:
           description: Unknown page title or revision
           schema:
             $ref: '#/definitions/problem'
+        '429':
+          descripting: Revision was changed or restricted
+          schema:
+            $ref: '#/definitions/problem'
         default:
           description: Error
           schema:
@@ -1103,6 +1115,10 @@ paths:
             $ref: '#/definitions/problem'
         '404':
           description: Unknown page title or revision
+          schema:
+            $ref: '#/definitions/problem'
+        '429':
+          descripting: Revision was changed or restricted
           schema:
             $ref: '#/definitions/problem'
         default:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -910,8 +910,12 @@ paths:
           description: Unknown page title or revision
           schema:
             $ref: '#/definitions/problem'
-        '429':
-          descripting: Revision was changed or restricted
+        '409':
+          descripting: Revision was restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '410':
+          descripting: Page was deleted
           schema:
             $ref: '#/definitions/problem'
         default:
@@ -976,8 +980,12 @@ paths:
           description: Unknown page title or revision
           schema:
             $ref: '#/definitions/problem'
-        '429':
-          descripting: Revision was changed or restricted
+        '409':
+          descripting: Revision was restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '410':
+          descripting: Page was deleted
           schema:
             $ref: '#/definitions/problem'
         default:
@@ -1056,8 +1064,12 @@ paths:
           description: Unknown page title or revision
           schema:
             $ref: '#/definitions/problem'
-        '429':
-          descripting: Revision was changed or restricted
+        '409':
+          descripting: Revision was restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '410':
+          descripting: Page was deleted
           schema:
             $ref: '#/definitions/problem'
         default:
@@ -1117,8 +1129,12 @@ paths:
           description: Unknown page title or revision
           schema:
             $ref: '#/definitions/problem'
-        '429':
-          descripting: Revision was changed or restricted
+        '409':
+          descripting: Revision was restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '410':
+          descripting: Page was deleted
           schema:
             $ref: '#/definitions/problem'
         default:

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -230,6 +230,25 @@ describe('transform api', function() {
             assert.deepEqual(res.body, '');
         });
     });
+
+    it('returns 429 if revision was restricted while edit happened', function() {
+        var badPageName = 'User_talk:DivineAlpha%2fQ1_2015_discussions';
+        var badRevNumber = 645504917;
+        return preq.post({
+            uri: server.config.baseURL
+                + '/transform/html/to/wikitext/' + badPageName + '/' + badRevNumber,
+            body: {
+                html: '<html><head>' +
+                    '<meta property="mw:TimeUuid" content="71966eaf-62cd-11e5-8a88-952fdaad0387"/>' +
+                    '</head><body></body></html>'
+            }
+        })
+        .then(function() {
+            throw new Error('Error should be thrown');
+        }, function(e) {
+            assert.deepEqual(e.status, 429);
+        })
+    });
 });
 
 

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -231,7 +231,7 @@ describe('transform api', function() {
         });
     });
 
-    it('returns 429 if revision was restricted while edit happened', function() {
+    it('returns 409 if revision was restricted while edit happened', function() {
         var badPageName = 'User_talk:DivineAlpha%2fQ1_2015_discussions';
         var badRevNumber = 645504917;
         return preq.post({
@@ -246,7 +246,7 @@ describe('transform api', function() {
         .then(function() {
             throw new Error('Error should be thrown');
         }, function(e) {
-            assert.deepEqual(e.status, 429);
+            assert.deepEqual(e.status, 409);
         })
     });
 });


### PR DESCRIPTION
Right now if the page was deleted or a revision was restricted while it was edited in VE, transform endpoints return 400 errors, however this situation is more about an edit conflict. 