### PR TITLE
Added support for reverted order of properties in a timeuuid meta tag

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -509,8 +509,8 @@ PSP.transformRevision = function(restbase, req, from, to) {
             tid = rbUtil.parseETag(req.headers['if-match']).tid;
         } else if (req.body && req.body.html) {
             // Fall back to an inline meta tag in the HTML
-            var tidMatch = new RegExp('<meta\\s(?:content="([^"]+)"\\s)?' +
-                    'property="mw:TimeUuid"(?:\\scontent="([^"]+)")?\\s*\\/?>')
+            var tidMatch = new RegExp('<meta\\s+(?:content="([^"]+)"\\s+)?' +
+                    'property="mw:TimeUuid"(?:\\s+content="([^"]+)")?\\s*\\/?>')
                 .exec(req.body.html);
             tid = tidMatch && (tidMatch[1] || tidMatch[2]);
         }

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -509,8 +509,8 @@ PSP.transformRevision = function(restbase, req, from, to) {
             tid = rbUtil.parseETag(req.headers['if-match']).tid;
         } else if (req.body && req.body.html) {
             // Fall back to an inline meta tag in the HTML
-            var tidMatch = new RegExp('<meta (?:content="([^"]+)" )?' +
-                    'property="mw:TimeUuid"(?: content="([^"]+)")? *\/?>')
+            var tidMatch = new RegExp('<meta\\s(?:content="([^"]+)"\\s)?' +
+                    'property="mw:TimeUuid"(?:\\scontent="([^"]+)")?\\s*\\/?>')
                 .exec(req.body.html);
             tid = tidMatch && (tidMatch[1] || tidMatch[2]);
         }

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -509,9 +509,10 @@ PSP.transformRevision = function(restbase, req, from, to) {
             tid = rbUtil.parseETag(req.headers['if-match']).tid;
         } else if (req.body && req.body.html) {
             // Fall back to an inline meta tag in the HTML
-            var tidMatch = /<meta property="mw:TimeUuid" content="([^"]+)"\/?>/
-                                .exec(req.body.html);
-            tid = tidMatch && tidMatch[1];
+            var tidMatch = new RegExp('<meta (?:content="([^"]+)" )?' +
+                    'property="mw:TimeUuid"(?: content="([^"]+)")? *\/?>')
+                .exec(req.body.html);
+            tid = tidMatch && (tidMatch[1] || tidMatch[2]);
         }
         if (!tid) {
             throw new rbUtil.HTTPError({

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -231,6 +231,28 @@ describe('transform api', function() {
         });
     });
 
+    it('supports reversed order of properties in TimeUuid meta', function() {
+        var newHtml = testPage.html.replace(/<meta property="mw:TimeUuid" content="([^"]+)"\/?>/,
+                '<meta content="cc8ba6b3-636c-11e5-b601-24b4f65ab671" property="mw:TimeUuid" />');
+        return preq.post({
+            uri: server.config.baseURL
+                    + '/transform/html/to/html/' + testPage.title
+                    + '/' + testPage.revision,
+            body: {
+                html: newHtml
+            }
+        })
+        .then(function (res) {
+            assert.deepEqual(res.status, 200);
+            var pattern = /<div id="bar">Selser test<\/div>/;
+            if (!pattern.test(res.body)) {
+                throw new Error('Expected pattern in response: ' + pattern
+                + '\nSaw: ' + JSON.stringify(res, null, 2));
+            }
+            assert.contentType(res, contentTypes.html);
+        });
+    });
+
     it('returns 409 if revision was restricted while edit happened', function() {
         var badPageName = 'User_talk:DivineAlpha%2fQ1_2015_discussions';
         var badRevNumber = 645504917;


### PR DESCRIPTION
Although we want to move to `if-match` header instead of the TimeUuid meta tag hack, right now we have to fix the meta regex, since we have it. In IE11 the order of properties in a meta tag is reversed, so it wasn't matching correctly. Also a trailing whitespace is possible, support for it was also added into the RegExp.

Bug: https://phabricator.wikimedia.org/T113163