### PR TITLE
Enable testing with node 4.1, and drop heapdump from devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
+    - "4.1"
     - "iojs-v2.5.0"
 
 sudo: false

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "devDependencies": {
     "bunyan": "^1.4.0",
     "coveralls": "^2.11.2",
-    "heapdump": "^0.3.7",
     "istanbul": "^0.3.15",
     "mocha": "^2.2.5",
     "mocha-jscs": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -51,15 +51,15 @@
   "devDependencies": {
     "bunyan": "^1.4.0",
     "coveralls": "^2.11.2",
-    "heapdump": "^0.3.5",
+    "heapdump": "^0.3.7",
     "istanbul": "^0.3.15",
     "mocha": "^2.2.5",
+    "mocha-jscs": "^1.2.0",
     "mocha-jshint": "^2.2.3",
     "mocha-lcov-reporter": "^0.0.2",
-    "swagger-test": "0.2.0",
-    "url-template": "^2.0.6",
     "nock": "^2.10.0",
     "restbase-mod-table-sqlite": "^0.1.8",
-    "mocha-jscs": "^1.2.0"
+    "swagger-test": "0.2.0",
+    "url-template": "^2.0.6"
   }
 }


### PR DESCRIPTION
- Start testing with node 4.1
- Drop the heapdump dependency. While heapdump@0.3.7 works fine locally (on Debian unstable), it fails to compile in travis. I didn't investigate deeply, but noticed that we install heapdump explicitly in our Dockerfile anyway, so don't necessarily need it as a devDependency.