### PR TITLE
Removed the client_ip check from post_data

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -50,7 +50,12 @@ templates:
         x-internal-request-whitelist:
           - /http:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
           - http://parsoid-lb.eqiad.wikimedia.org
-
+      header_match:
+        description: Checks client ip against one of the predefined whitelists
+        x-error-message: This client is not allowed to use the endpoint
+        x-whitelists:
+          internal:
+            - /^(?:::ffff:)?(?:10|127)\./
 
   wmf-sys-1.0.0: &wp/sys/1.0.0
     info:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -31,6 +31,21 @@ templates:
     x-subspecs:
       # Pull in the default REST content API spec.
       - mediawiki/v1/content
+    securityDefinitions:
+      mediawiki_auth:
+        description: Checks permissions using MW api
+        type: apiKey
+        in: header
+        name: cookie
+        x-internal-request-whitelist:
+          - http://localhost/w/api.php
+          - http://localhost:8142
+      header_match:
+        description: Checks client ip against one of the predefined whitelists
+        x-error-message: This client is not allowed to use the endpoint
+        x-whitelists:
+          internal:
+            - /^(?:localhost)|(?:127\.)/
 
   # The internal storage modules and services under /sys/ are defined here.
   wmf-sys-1.0.0: &wp/sys/1.0.0

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -51,18 +51,17 @@ templates:
           - http://fr.wikipedia.org/w/api.php
           # Left as a regex for test purpose
           - /http:\/\/parsoid\-lb\.eqiad\.wikimedia\.org/
-
-  wmf-sys-1.0.0: &wp/sys/1.0.0
-    info:
-      title: Default MediaWiki sys API module
-      version: 1.0.0
-    securityDefinitions:
-      header_match: 
+      header_match:
         description: Checks client ip against one of the predefined whitelists
         x-error-message: This client is not allowed to use the endpoint
         x-whitelists:
           internal:
             - /^(?:::ffff:)?(?:10|127)\./
+
+  wmf-sys-1.0.0: &wp/sys/1.0.0
+    info:
+      title: Default MediaWiki sys API module
+      version: 1.0.0
     paths:
       /{module:table}: &wp/sys/table # Can use this anchor to share the table
         x-modules:

--- a/mods/post_data.yaml
+++ b/mods/post_data.yaml
@@ -21,8 +21,3 @@ paths:
   /{bucket}/:
     put:
       operationId: putRevision
-      security:
-        - header_match:
-            - header: 'x-rb-client-ip'
-              patterns:
-                - internal

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -73,6 +73,11 @@ paths:
 
   /{module:post_data}/:
     post:
+      security:
+        - header_match:
+            - header: 'x-rb-client-ip'
+              patterns:
+                - internal
       x-request-handler:
         - put_to_storage:
             request:


### PR DESCRIPTION
Follow-up on https://github.com/wikimedia/restbase/pull/336

We don't need to check clients IP in the post_data service unconditionally, but check individual routes using it instead.