### PR TITLE
Log remaining bodyOnly uses / users

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -746,6 +746,10 @@ PSP.makeTransform = function(from, to) {
             // Handle body_only flag.
             // bodyOnly is deprecated and will be removed at some point
             if (to === 'html' && (req.body.body_only || req.body.bodyOnly)) {
+                // Log remaining bodyOnly uses / users
+                if (req.body.bodyOnly) {
+                    self.log('warn/parsoid/bodyonly', req.headers);
+                }
                 innerRes.body = cheapBodyInnerHTML(innerRes.body);
             }
             return innerRes;

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -744,7 +744,9 @@ PSP.makeTransform = function(from, to) {
             var innerRes = res.body[to];
             innerRes.status = 200;
             // Handle body_only flag.
-            // bodyOnly is deprecated and will be removed at some point
+            // bodyOnly is deprecated and will be removed at some point.
+            // XXX: Remove bodyOnly support after end of November 2015 (see
+            // https://phabricator.wikimedia.org/T114185).
             if (to === 'html' && (req.body.body_only || req.body.bodyOnly)) {
                 // Log remaining bodyOnly uses / users
                 if (req.body.bodyOnly) {


### PR DESCRIPTION
We are planning to switch off bodyOnly by the end of November (see
https://lists.wikimedia.org/pipermail/mediawiki-api/2015-October/003656.html),
and it would be nice to make sure that there are no remaining users of the old
form before removing it.