### PR TITLE
Parsoid mod: add ability to stash wt2html transforms

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -264,11 +264,12 @@ rbUtil.makeETag = function(rev, tid, suffix) {
 // @param {string} etag
 // @return {object} with params rev / tid
 rbUtil.parseETag = function(etag) {
-    var bits = /^"?([^"\/]+)(?:\/([^"\/]+))"?$/.exec(etag);
+    var bits = /^"?([^"\/]+)(?:\/([^"\/]+))(?:\/([^"]+))?"?$/.exec(etag);
     if (bits) {
         return {
             rev: bits[1],
-            tid: bits[2]
+            tid: bits[2],
+            suffix: bits[3]
         };
     } else {
         return null;

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -250,9 +250,13 @@ rbUtil.HTTPError = HTTPError;
 
 
 // Create an etag value of the form
-// "<revision>/<tid>"
-rbUtil.makeETag = function(rev, tid) {
-    return '"' + rev + '/' + tid + '"';
+// "<revision>/<tid>/<optional_suffix>"
+rbUtil.makeETag = function(rev, tid, suffix) {
+    var etag = '"' + rev + '/' + tid;
+    if (suffix) {
+        etag += '/' + suffix;
+    }
+    return etag + '"';
 };
 
 // Parse an etag value of the form

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -822,6 +822,37 @@ module.exports = function(options) {
                 body: {
                     valueType: 'json'
                 }
+            },
+            // stashing resources for HTML, wikitext and data-parsoid
+            {
+                uri: '/{domain}/sys/key_rev_value/parsoid.stash.html',
+                body: {
+                    revisionRetentionPolicy: {
+                        type: 'latest',
+                        count: 1,
+                        grace_ttl: 86400
+                    },
+                    valueType: 'blob',
+                    version: 1
+                }
+            },
+            {
+                uri: '/{domain}/sys/key_rev_value/parsoid.stash.wikitext',
+                body: {
+                    valueType: 'blob'
+                }
+            },
+            {
+                uri: '/{domain}/sys/key_rev_value/parsoid.stash.data-parsoid',
+                body: {
+                    revisionRetentionPolicy: {
+                        type: 'latest',
+                        count: 1,
+                        grace_ttl: 86400
+                    },
+                    valueType: 'json',
+                    version: 1
+                }
             }
         ]
     };

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -907,9 +907,8 @@ module.exports = function(options) {
                 uri: '/{domain}/sys/key_rev_value/parsoid.stash.html',
                 body: {
                     revisionRetentionPolicy: {
-                        type: 'latest',
-                        count: 0,
-                        grace_ttl: 86400
+                        type: 'ttl',
+                        ttl: 86400
                     },
                     valueType: 'blob',
                     version: 1
@@ -919,9 +918,8 @@ module.exports = function(options) {
                 uri: '/{domain}/sys/key_rev_value/parsoid.stash.wikitext',
                 body: {
                     revisionRetentionPolicy: {
-                        type: 'latest',
-                        count: 0,
-                        grace_ttl: 86400
+                        type: 'ttl',
+                        ttl: 86400
                     },
                     valueType: 'blob',
                     version: 1
@@ -931,9 +929,8 @@ module.exports = function(options) {
                 uri: '/{domain}/sys/key_rev_value/parsoid.stash.data-parsoid',
                 body: {
                     revisionRetentionPolicy: {
-                        type: 'latest',
-                        count: 0,
-                        grace_ttl: 86400
+                        type: 'ttl',
+                        ttl: 86400
                     },
                     valueType: 'json',
                     version: 1

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -886,7 +886,13 @@ module.exports = function(options) {
             {
                 uri: '/{domain}/sys/key_rev_value/parsoid.stash.wikitext',
                 body: {
-                    valueType: 'blob'
+                    revisionRetentionPolicy: {
+                        type: 'latest',
+                        count: 1,
+                        grace_ttl: 86400
+                    },
+                    valueType: 'blob',
+                    version: 1
                 }
             },
             {

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -631,7 +631,7 @@ PSP.transformRevision = function(restbase, req, from, to) {
 
 };
 
-PSP.stashTranform = function(restbase, req, transformPromise) {
+PSP.stashTransform = function(restbase, req, transformPromise) {
     // A stash has been requested. We need to store the wikitext sent by
     // the client together with the page bundle returned by Parsoid, so it
     // can be later reused when transforming back from HTML to wikitext
@@ -708,7 +708,7 @@ PSP.callParsoidTransform = function callParsoidTransform(restbase, req, from, to
 
     var transformPromise = restbase.post(parsoidReq);
     if (req.body.stash && from === 'wikitext' && to === 'html') {
-        return this.stashTranform(restbase, req, transformPromise);
+        return this.stashTransform(restbase, req, transformPromise);
     }
     return transformPromise;
 

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -765,7 +765,7 @@ PSP.makeTransform = function(from, to) {
 
     return function(restbase, req) {
         var rp = req.params;
-        if (!req.body[from]) {
+        if (!req.body || !req.body[from]) {
             // XXX: This is a temporary log line to aid in
             // discovering what's going on in T112339
             // We need to remove it

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -986,6 +986,11 @@ paths:
           description: Return only `body.innerHTML`
           type: boolean
           required: false
+        - name: stash
+          in: formData
+          description: Whether to stash temporarily the result of the transformation
+          type: boolean
+          required: false
       responses:
         '200':
           description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec
@@ -1017,6 +1022,7 @@ paths:
                 wikitext: '{wikitext}'
                 bodyOnly: '{bodyOnly}'
                 body_only: '{body_only}'
+                stash: '{stash}'
       x-monitor: true
       x-amples:
         - title: Transform wikitext to html

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -988,7 +988,7 @@ paths:
           required: false
         - name: stash
           in: formData
-          description: Whether to stash temporarily the result of the transformation
+          description: Whether to temporarily stash the result of the transformation
           type: boolean
           required: false
       responses:

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -942,6 +942,8 @@ paths:
         - get_from_backend:
             request:
               uri: /{domain}/sys/parsoid/transform/html/to/wikitext{/title}{/revision}
+              headers:
+                if-match: '{if-match}'
               body:
                 html: '{html}'
                 scrubWikitext: '{scrubWikitext}'
@@ -1103,6 +1105,8 @@ paths:
         - get_from_backend:
             request:
               uri: /{domain}/sys/parsoid/transform/html/to/html{/title}{/revision}
+              headers:
+                if-match: '{if-match}'
               body:
                 html: '{html}'
                 bodyOnly: '{bodyOnly}'


### PR DESCRIPTION
This PR extends the *wt2html* transformations API to allow clients to indicate to RESTBase they plan to reuse the transformation at a later time, in which case RESTBase saves them in special buckets.

Summary:
- add the `stash` body flag to `POST /transform/wikitext/to/html`
- create the `parsoid.stash.data-parsoid`, `parsoid.stash.wikitext` and `parsoid.stash.html` buckets on start-up
- save the client-sent *wikitext* together with the *data-parsoid* and *html* Parsoid responses for the transform when the client sets `stash: true` when `POST`ing and set the ETag to `<rev>/<tid>/stash`
- detect when a client wants to use the stashed transform in a request to `/transform/html/to/wikitext` and reuse the stashed *wikitext*, *data-parsoid* and *html* originals.

Note: we should merge wikimedia/restbase-mod-table-spec#21 before merging this one.

Bug: [T114548](https://phabricator.wikimedia.org/T114548)