### PR TITLE
Add a first-class representation of pages

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -105,7 +105,6 @@ templates:
                 storage_groups:
                   - name: test.group.local
                     domains: /./
-                #unsupported_features: fallback
 
       /{module:page_revisions}: &wp/sys/page_revisions
         x-modules:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -105,6 +105,7 @@ templates:
                 storage_groups:
                   - name: test.group.local
                     domains: /./
+                #unsupported_features: fallback
 
       /{module:page_revisions}: &wp/sys/page_revisions
         x-modules:

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -309,6 +309,22 @@ rbUtil.normalizeContentType = function(res) {
             contentType.format(contentType.parse(res.headers['content-type']));
     }
 };
+// Create a uniform but shallow request object copy with sane defaults. This
+// keeps code dealing with this request monomorphic (good for perf), and
+// avoids subtle bugs when requests shared between recursive requests are
+// mutated in another control branch. At the very minimum, we are mutating the
+// .params property for each sub-request.
+rbUtil.cloneRequest = function(req) {
+    return {
+        uri: req.uri || req.url || null,
+        method: req.method || 'get',
+        headers: req.headers || {},
+        query: req.query || {},
+        body: req.body || null,
+        params: req.params || {}
+    };
+};
+
 
 /***
  * MediaWiki-specific functions

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -246,14 +246,6 @@ util.inherits(HTTPError, Error);
 
 rbUtil.HTTPError = HTTPError;
 
-function HTTPRedirect(response) {
-    Error.call(this);
-    this.name = this.constructor.name;
-    Object.assign(this, response);
-}
-util.inherits(HTTPRedirect, Error);
-rbUtil.HTTPRedirect = HTTPRedirect;
-
 // Create an etag value of the form
 // "<revision>/<tid>/<optional_suffix>"
 rbUtil.makeETag = function(rev, tid, suffix) {

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -309,22 +309,6 @@ rbUtil.normalizeContentType = function(res) {
             contentType.format(contentType.parse(res.headers['content-type']));
     }
 };
-// Create a uniform but shallow request object copy with sane defaults. This
-// keeps code dealing with this request monomorphic (good for perf), and
-// avoids subtle bugs when requests shared between recursive requests are
-// mutated in another control branch. At the very minimum, we are mutating the
-// .params property for each sub-request.
-rbUtil.cloneRequest = function(req) {
-    return {
-        uri: req.uri || req.url || null,
-        method: req.method || 'get',
-        headers: req.headers || {},
-        query: req.query || {},
-        body: req.body || null,
-        params: req.params || {}
-    };
-};
-
 
 /***
  * MediaWiki-specific functions

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -240,15 +240,19 @@ function HTTPError(response) {
     if (response.body && response.body.type) {
         this.message += ': ' + response.body.type;
     }
-
-    for (var key in response) {
-        this[key] = response[key];
-    }
+    Object.assign(this, response);
 }
 util.inherits(HTTPError, Error);
 
 rbUtil.HTTPError = HTTPError;
 
+function HTTPRedirect(response) {
+    Error.call(this);
+    this.name = this.constructor.name;
+    Object.assign(this, response);
+}
+util.inherits(HTTPRedirect, Error);
+rbUtil.HTTPRedirect = HTTPRedirect;
 
 // Create an etag value of the form
 // "<revision>/<tid>/<optional_suffix>"

--- a/lib/server.js
+++ b/lib/server.js
@@ -261,7 +261,7 @@ function handleRequest(opts, req, resp) {
         return handleResponse(reqOpts, newReq, resp, result);
     })
     .catch(function(e) {
-        if (!e || (e.name !== 'HTTPError' && e.name !== 'HTTPRedirect')) {
+        if (!e || e.name !== 'HTTPError') {
             var originalError = e;
             var stack = e && e.stack;
             e = new rbUtil.HTTPError({

--- a/lib/server.js
+++ b/lib/server.js
@@ -204,6 +204,11 @@ function handleRequest(opts, req, resp) {
         reqOpts.metrics.increment('requests.private');
     } else {
         reqOpts.metrics.increment('requests.public');
+        Object.keys(req.headers).forEach(function(headerName) {
+            if (/(?:^x-restbase)|(?:^x-rb)/.test(headerName)) {
+                delete newReq.headers[headerName];
+            }
+        });
     }
 
     // Create a new, clean request object
@@ -215,15 +220,6 @@ function handleRequest(opts, req, resp) {
         method: req.method.toLowerCase(),
         headers: req.headers
     };
-
-    // Remove x-restbase and x-rb headers if the request is not local
-    if (!/^(?:::ffff:)?(?:10|127)\./.test(remoteAddr) && newReq.headers) {
-        Object.keys(newReq.headers).forEach(function(headerName) {
-            if (/(?:^x-restbase)|(?:^x-rb)/.test(headerName)) {
-                delete newReq.headers[headerName];
-            }
-        });
-    }
 
     // Start off by parsing any POST data with BusBoy
     return rbUtil.parsePOST(req)

--- a/lib/server.js
+++ b/lib/server.js
@@ -216,6 +216,15 @@ function handleRequest(opts, req, resp) {
         headers: req.headers
     };
 
+    // Remove x-restbase and x-rb headers if the request is not local
+    if (!/^(?:::ffff:)?(?:10|127)\./.test(remoteAddr) && newReq.headers) {
+        Object.keys(newReq.headers).forEach(function(headerName) {
+            if (/(?:^x-restbase)|(?:^x-rb)/.test(headerName)) {
+                delete newReq.headers[headerName];
+            }
+        });
+    }
+
     // Start off by parsing any POST data with BusBoy
     return rbUtil.parsePOST(req)
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -265,7 +265,7 @@ function handleRequest(opts, req, resp) {
         return handleResponse(reqOpts, newReq, resp, result);
     })
     .catch(function(e) {
-        if (!e || e.name !== 'HTTPError') {
+        if (!e || (e.name !== 'HTTPError' && e.name !== 'HTTPRedirect')) {
             var originalError = e;
             var stack = e && e.stack;
             e = new rbUtil.HTTPError({

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -85,7 +85,7 @@ PRS.prototype.getTableSchema = function() {
 
 PRS.prototype.pageTableName = 'page_data';
 PRS.prototype.pageTableURI = function(domain) {
-    return new URI([domain, 'sys', 'table', this.tableName, '']);
+    return new URI([domain, 'sys', 'table', this.pageTableName, '']);
 };
 PRS.prototype.getPageTableSchema = function() {
     return {
@@ -538,7 +538,10 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
                         && res.pageData.body.items
                         && res.pageData.body.items.length) {
                     var latestEvent = res.pageData.body.items[0];
-                    if (latestEvent.event_type === 'rename_to') {
+                    var latestRev = res.revisionInfo.body.items[0];
+                    if (latestEvent.event_type === 'rename_to'
+                            && uuid.fromString(latestEvent.tid).getDate()
+                                >= uuid.fromString(latestRev.tid).getDate()) {
                         throw new rbUtil.HTTPError({
                             status: 404,
                             body: {

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -379,38 +379,38 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
         };
 
         var actions = [
-        // Check if the same revision is already in storage
-        restbase.get({
-            uri: self.tableURI(rp.domain),
-            body: {
-                table: self.tableName,
-                attributes: {
-                    title: rbUtil.normalizeTitle(dataResp.title),
-                    rev: parseInt(apiRev.revid)
-                }
-            }
-        })
-        .then(function(res) {
-            var sameRev = res && res.body.items
-                && res.body.items.length > 0
-                && self._checkSameRev(revision, res.body.items[0]);
-            if (!sameRev) {
-                throw new rbUtil.HTTPError({ status: 404 });
-            }
-        })
-        .catch(function(e) {
-            if (e.status === 404) {
-                return restbase.put({ // Save / update the revision entry
-                    uri: self.tableURI(rp.domain),
-                    body: {
-                        table: self.tableName,
-                        attributes: revision
+            // Check if the same revision is already in storage
+            restbase.get({
+                uri: self.tableURI(rp.domain),
+                body: {
+                    table: self.tableName,
+                    attributes: {
+                        title: rbUtil.normalizeTitle(dataResp.title),
+                        rev: parseInt(apiRev.revid)
                     }
-                });
-            } else {
-                throw e;
-            }
-        })
+                }
+            })
+            .then(function(res) {
+                var sameRev = res && res.body.items
+                        && res.body.items.length > 0
+                        && self._checkSameRev(revision, res.body.items[0]);
+                if (!sameRev) {
+                    throw new rbUtil.HTTPError({ status: 404 });
+                }
+            })
+            .catch(function(e) {
+                if (e.status === 404) {
+                    return restbase.put({ // Save / update the revision entry
+                        uri: self.tableURI(rp.domain),
+                        body: {
+                            table: self.tableName,
+                            attributes: revision
+                        }
+                    });
+                } else {
+                    throw e;
+                }
+            })
         ];
         // Also check if the page title was changed and set a log rename history
         var parentTitle = req.headers['x-restbase-parenttitle'];

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -545,7 +545,8 @@ PRS.prototype._checkRename = function(restbase, req, parentRevNumber) {
 
             return self.getRevision(restbase, parentRevReq)
             .then(function(parentRes) {
-                if (parentRes.body.count > 0
+                if (parentRes.body.items
+                        && parentRes.body.items.length
                         && parentRes.body.items[0].title !== currentRev.title) {
                     var parentRev = parentRes.body.items[0];
                     // The page was renamed - note it in the page table

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -544,11 +544,19 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
                                 >= uuid.fromString(latestRev.tid).getDate()) {
                         return self._getLatestPageTitle(restbase, req, latestEvent)
                         .then(function(latestTitle) {
-                            throw new rbUtil.HTTPError({
-                                status: 404,
-                                body: {
-                                    type: 'not_found#page_revisions',
-                                    description: 'Page was renamed to ' + latestTitle
+                            var rootPath = restbase._rootReq.uri.path;
+                            var newPath = [];
+                            rootPath.forEach(function(pathElement) {
+                                if (pathElement === rp.title) {
+                                    newPath.push(encodeURIComponent(latestTitle));
+                                } else {
+                                    newPath.push(pathElement);
+                                }
+                            });
+                            throw new rbUtil.HTTPRedirect({
+                                status: 301,
+                                headers: {
+                                    location: '/' + newPath.join('/')
                                 }
                             });
                         });

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -83,7 +83,7 @@ PRS.prototype.getTableSchema = function() {
     };
 };
 
-PRS.prototype.pageTableName = 'page_data';
+PRS.prototype.pageTableName = 'page';
 PRS.prototype.pageTableURI = function(domain) {
     return new URI([domain, 'sys', 'table', this.pageTableName, '']);
 };
@@ -460,7 +460,7 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
         }
     })
     .catch(function(e) {
-        // Ignore lack of page_data
+        // Ignore lack of page data
         if (e.status !== 404) {
             throw e;
         }
@@ -574,17 +574,22 @@ PRS.prototype._createRenameChecker = function(restbase, req) {
                 .then(function(latestTitle) {
                     var rootPath = restbase._rootReq.uri.path;
                     var newPath = [];
+                    var titleSeen = false;
                     rootPath.forEach(function(pathElement) {
-                        if (pathElement === rp.title) {
-                            newPath.push(encodeURIComponent(latestTitle));
+                        if (pathElement !== rp.title) {
+                            if (titleSeen) {
+                                newPath.push(pathElement);
+                                newPath = ['..'].concat(newPath);
+                            }
                         } else {
-                            newPath.push(pathElement);
+                            newPath.push(encodeURIComponent(latestTitle));
+                            titleSeen = true;
                         }
                     });
                     throw new rbUtil.HTTPRedirect({
                         status: 301,
                         headers: {
-                            location: '/' + newPath.join('/')
+                            location: newPath.join('/')
                         }
                     });
                 });

--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -524,7 +524,13 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
             });
         } else {
             revisionRequest = P.props({
-                revisionInfo: getLatestTitleRevision(),
+                revisionInfo: getLatestTitleRevision()
+                .catch(function(e) {
+                    if (e.status !== 404) {
+                        throw e;
+                    }
+                    return self.fetchAndStoreMWRevision(restbase, req);
+                }),
                 pageData: pageDataRequest
             })
             .then(function(res) {
@@ -543,15 +549,6 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
                     }
                 }
                 return res;
-            })
-            .catch(function(e) {
-                if (e.status !== 404 || /^Page was renamed/.test(e.body.description)) {
-                    throw e;
-                }
-                return P.props({
-                    revisionInfo: self.fetchAndStoreMWRevision(restbase, req),
-                    pageData: pageDataRequest
-                });
             });
         }
     } else {

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -271,6 +271,7 @@ paths:
                 if-unmodified-since: '{if-unmodified-since}'
                 x-restbase-mode: '{x-restbase-mode}'
                 x-restbase-parentrevision: '{x-restbase-parentrevision}'
+                x-restbase-parenttitle: '{x-restbase-parenttitle}'
               query:
                 sections: '{sections}'
       x-monitor: true
@@ -428,6 +429,7 @@ paths:
                 if-unmodified-since: '{if-unmodified-since}'
                 x-restbase-mode: '{x-restbase-mode}'
                 x-restbase-parentrevision: '{x-restbase-parentrevision}'
+                x-restbase-parenttitle: '{x-restbase-parenttitle}'
               query:
                 page: '{page}'
       x-monitor: false
@@ -501,6 +503,7 @@ paths:
                 if-unmodified-since: '{if-unmodified-since}'
                 x-restbase-mode: '{x-restbase-mode}'
                 x-restbase-parentrevision: '{x-restbase-parentrevision}'
+                x-restbase-parenttitle: '{x-restbase-parenttitle}'
               query:
                 sections: '{sections}'
       x-monitor: false

--- a/test/features/errors/notfound.js
+++ b/test/features/errors/notfound.js
@@ -6,7 +6,6 @@
 var assert = require('../../utils/assert.js');
 var preq   = require('preq');
 var server = require('../../utils/server.js');
-var nock = require('nock');
 
 describe('404 handling', function() {
 
@@ -80,95 +79,4 @@ describe('404 handling', function() {
             assert.contentType(e, 'application/problem+json');
         });
     });
-    it('should set page_deleted on deleted page', function() {
-        var apiURI = server.config
-            .conf.templates['wmf-sys-1.0.0']
-            .paths['/{module:action}']['x-modules'][0].templates.apiRequest.uri;
-        apiURI = apiURI.replace('{domain}', 'en.wikipedia.org');
-        var title = 'TestingTitle';
-        var revision = 12345;
-        var emptyResponse = {'batchcomplete':'','query':{'badrevids':{'12345' :{'revid':'12345'}}}};
-
-        nock.enableNetConnect();
-        var api = nock(apiURI)
-            // The first request should return a page so that we store it.
-        .post('')
-        .reply(200, {
-            'batchcomplete': '',
-            'query': {
-                'pages': {
-                    '11089416': {
-                        'pageid': 11089416,
-                        'ns': 0,
-                        'title': title,
-                        'contentmodel': 'wikitext',
-                        'pagelanguage': 'en',
-                        'touched': '2015-05-22T08:49:39Z',
-                        'lastrevid': 653508365,
-                        'length': 2941,
-                        'revisions': [{
-                            'revid': revision,
-                            'user': 'Chuck Norris',
-                            'userid': 3606755,
-                            'timestamp': '2015-03-25T20:29:50Z',
-                            'size': 2941,
-                            'sha1': 'c47571122e00f28402d2a1b75cff77a22e7bfecd',
-                            'contentmodel': 'wikitext',
-                            'comment': 'Test',
-                            'tags': []
-                        }]
-                    }
-                }
-            }
-        })
-        // Other requests return nothing as if the page is deleted.
-        .post('')
-        .reply(200, emptyResponse)
-        .post('')
-        .reply(200, emptyResponse);
-        // Fetch the page
-        return preq.get({
-            uri: server.config.bucketURL + '/title/' + title,
-            headers: {
-                'cache-control': 'no-cache'
-            }
-        })
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0].rev, revision);
-        })
-        // Now fetch info that it's deleted
-        .then(function() {
-            return preq.get({
-                uri: server.config.bucketURL + '/title/' + title,
-                headers: {
-                    'cache-control': 'no-cache'
-                }});
-        })
-        .then(function() {
-            throw new Error('404 should have been returned for a deleted page');
-        })
-        .catch(function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
-        })
-        // Getting it by revision id should also return 404
-        .then(function() {
-            return preq.get({uri: server.config.bucketURL + '/revision/' + revision});
-        })
-        .then(function() {
-            throw new Error('404 should have been returned for a deleted page');
-        })
-        .catch(function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
-        })
-        .then(function() {
-            api.done();
-        })
-        .finally(function() {
-            nock.cleanAll();
-        });
-    })
 });

--- a/test/features/pagecontent/delete_undelete.js
+++ b/test/features/pagecontent/delete_undelete.js
@@ -18,7 +18,7 @@ describe('Delete/undelete handling', function() {
     var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
             .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
-    apiURI = apiURI.replace('{domain}', 'en.wikipedia.org');
+    apiURI = apiURI.replace('{domain}', 'en.wikipedia.beta.wmflabs.org');
 
     function getEmptyResponse(revid) {
         return {'batchcomplete':'','query':{'badrevids':{'12345' :{'revid':'' + revid}}}};
@@ -56,7 +56,7 @@ describe('Delete/undelete handling', function() {
 
     function fetchPage(title, revision) {
         return preq.get({
-            uri: server.config.bucketURL + '/title/' + title,
+            uri: server.config.labsBucketURL + '/title/' + title,
             headers: {
                 'cache-control': 'no-cache'
             }
@@ -71,7 +71,7 @@ describe('Delete/undelete handling', function() {
     function sendDeleteSignal(title) {
         // Now fetch info that it's deleted
         return preq.get({
-            uri: server.config.bucketURL + '/title/' + title,
+            uri: server.config.labsBucketURL + '/title/' + title,
             headers: {
                 'cache-control': 'no-cache'
             }
@@ -87,7 +87,7 @@ describe('Delete/undelete handling', function() {
     function sendUndeleteSignal(title, revision) {
         // Now fetch info that it's deleted
         return preq.get({
-            uri: server.config.bucketURL + '/title/' + title,
+            uri: server.config.labsBucketURL + '/title/' + title,
             headers: {
                 'cache-control': 'no-cache'
             }
@@ -100,7 +100,7 @@ describe('Delete/undelete handling', function() {
     }
 
     function assertRevisionDeleted(revision) {
-        return preq.get({uri: server.config.bucketURL + '/revision/' + revision})
+        return preq.get({uri: server.config.labsBucketURL + '/revision/' + revision})
         .then(function() {
             throw new Error('404 should have been returned for a deleted page');
         }, function(e) {
@@ -111,7 +111,7 @@ describe('Delete/undelete handling', function() {
 
     function signalPageEdit(title, revision) {
         return preq.get({
-            uri: server.config.bucketURL + '/html/' + title + '/' + revision,
+            uri: server.config.labsBucketURL + '/html/' + title + '/' + revision,
             headers: {
                 'cache-control': 'no-cache',
                 'If-Unmodified-Since': new Date().toString
@@ -160,7 +160,7 @@ describe('Delete/undelete handling', function() {
         .post('').reply(200, getApiResponse(title, 12346, 12345));
         // Verify that it's deleted
         return preq.get({
-            uri: server.config.bucketURL + '/title/' + title
+            uri: server.config.labsBucketURL + '/title/' + title
         })
         .then(function() {
             throw new Error('Should throw 404');
@@ -169,7 +169,7 @@ describe('Delete/undelete handling', function() {
             assert.contentType(e, 'application/problem+json');
         })
         .then(function() { return sendUndeleteSignal(title, 12346); })
-        .then(function() { return preq.get({uri: server.config.bucketURL + '/revision/' + 12346}); })
+        .then(function() { return preq.get({uri: server.config.labsBucketURL + '/revision/' + 12346}); })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body.items.length, 1);
@@ -197,7 +197,7 @@ describe('Delete/undelete handling', function() {
         .then(function() { return fetchPage(title, 12346) })
         .then(function() { return sendDeleteSignal(title); })
         .then(function() { return signalPageEdit(title, 12347); })
-        .then(function() { return preq.get({uri: server.config.bucketURL + '/revision/' + 12347}); })
+        .then(function() { return preq.get({uri: server.config.labsBucketURL + '/revision/' + 12347}); })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body.items.length, 1);
@@ -225,7 +225,7 @@ describe('Delete/undelete handling', function() {
         .then(function() { return signalPageEdit(title, 12346); })
         .then(function() { return sendDeleteSignal(title); })
         .then(function() { return sendUndeleteSignal(title, 12346); })
-        .then(function() { return preq.get({uri: server.config.bucketURL + '/revision/' + 12346}); })
+        .then(function() { return preq.get({uri: server.config.labsBucketURL + '/revision/' + 12346}); })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body.items.length, 1);

--- a/test/features/pagecontent/delete_undelete.js
+++ b/test/features/pagecontent/delete_undelete.js
@@ -157,7 +157,7 @@ describe('Delete/undelete handling', function() {
         // After the previous test the page in storage is marked as deleted, so if MW API returns a response,
         // we need to understand that the page was undeleted and update a good_after
         var api = nock(apiURI)
-        .post('').reply(200, getApiResponse(title, 12346));
+        .post('').reply(200, getApiResponse(title, 12347));
         // Verify that it's deleted
         return preq.get({
             uri: server.config.bucketURL + '/title/' + title
@@ -168,7 +168,7 @@ describe('Delete/undelete handling', function() {
             assert.deepEqual(e.status, 404);
             assert.contentType(e, 'application/problem+json');
         })
-        .then(function() { return sendUndeleteSignal(title, 12346); })
+        .then(function() { return sendUndeleteSignal(title, 12347); })
         .then(function() { return preq.get({uri: server.config.bucketURL + '/revision/' + 12345}); })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
@@ -218,18 +218,18 @@ describe('Delete/undelete handling', function() {
         .post('').reply(200, getEmptyResponse(12345))
         .post('').reply(200, getApiResponse(title, 12346))
         .post('').reply(200, getEmptyResponse(12346))
-        .post('').reply(200, getApiResponse(title, 12346));
+        .post('').reply(200, getApiResponse(title, 12347));
         // Fetch the page
         return fetchPage(title, 12345)
         .then(function() { return sendDeleteSignal(title); })
         .then(function() { return signalPageEdit(title, 12346); })
         .then(function() { return sendDeleteSignal(title); })
-        .then(function() { return sendUndeleteSignal(title, 12346); })
-        .then(function() { return preq.get({uri: server.config.bucketURL + '/revision/' + 12346}); })
+        .then(function() { return sendUndeleteSignal(title, 12347); })
+        .then(function() { return preq.get({uri: server.config.bucketURL + '/revision/' + 12347}); })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0].rev, 12346);
+            assert.deepEqual(res.body.items[0].rev, 12347);
         })
         .then(function() { return assertRevisionDeleted(12345); })
         .then(function() { api.done(); })

--- a/test/features/pagecontent/delete_undelete.js
+++ b/test/features/pagecontent/delete_undelete.js
@@ -8,7 +8,7 @@ var preq   = require('preq');
 var server = require('../../utils/server.js');
 var nock = require('nock');
 
-describe('404 handling', function() {
+describe('Delete/undelete handling', function() {
     this.timeout(20000);
 
     before(function () {
@@ -54,91 +54,110 @@ describe('404 handling', function() {
         };
     }
 
-    // This test also prepares environment for other tests
-    it('should set page_deleted on deleted page', function() {
-        var title = 'TestingTitle';
-        nock.enableNetConnect();
-        var api = nock(apiURI)
-        // Return a page so that we store it.
-        .post('')
-        .reply(200, getApiResponse(title, 12345))
-        // Return a new revision for the same page so that we store it.
-        .post('')
-        .reply(200, getApiResponse(title, 12346))
-        // Other requests return nothing as if the page is deleted.
-        .post('')
-        .reply(200, getEmptyResponse(12346));
-
-        // Fetch the page
+    function fetchPage(title, revision) {
         return preq.get({
             uri: server.config.bucketURL + '/title/' + title,
             headers: {
                 'cache-control': 'no-cache'
             }
         })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, revision);
+        });
+    }
+
+    function sendDeleteSignal(title) {
+        // Now fetch info that it's deleted
+        return preq.get({
+            uri: server.config.bucketURL + '/title/' + title,
+            headers: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .then(function() {
+            throw new Error('404 should have been returned for a deleted page');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+        })
+    }
+
+    function sendUndeleteSignal(title, revision) {
+        // Now fetch info that it's deleted
+        return preq.get({
+            uri: server.config.bucketURL + '/title/' + title,
+            headers: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, revision);
+        });
+    }
+
+    function assertRevisionDeleted(revision) {
+        return preq.get({uri: server.config.bucketURL + '/revision/' + revision})
+        .then(function() {
+            throw new Error('404 should have been returned for a deleted page');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+        });
+    }
+
+    function signalPageEdit(title, revision) {
+        return preq.get({
+            uri: server.config.bucketURL + '/html/' + title + '/' + revision,
+            headers: {
+                'cache-control': 'no-cache',
+                'If-Unmodified-Since': new Date().toString
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+        });
+    }
+
+    // This test also prepares environment for other tests
+    it('should set page_deleted on deleted page', function() {
+        var title = 'TestingTitle';
+        nock.enableNetConnect();
+        var api = nock(apiURI)
+        // Return a page so that we store it.
+        .post('').reply(200, getApiResponse(title, 12345))
+        // Return a new revision for the same page so that we store it.
+        .post('').reply(200, getApiResponse(title, 12346))
+        // Other requests return nothing as if the page is deleted.
+        .post('').reply(200, getEmptyResponse(12346));
+
+        // Fetch the page
+        return fetchPage(title, 12345)
         .delay(1000)
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0].rev, 12345);
-            // Fetch one more page
-            return preq.get({
-                uri: server.config.bucketURL + '/title/' + title,
-                headers: {
-                    'cache-control': 'no-cache'
-                }
-            })
-        })
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0].rev, 12346);
-            // Now fetch info that it's deleted
-            return preq.get({
-                uri: server.config.bucketURL + '/title/' + title,
-                headers: {
-                    'cache-control': 'no-cache'
-                }});
-        })
-        .then(function() {
-            throw new Error('404 should have been returned for a deleted page');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
-        })
-        .then(function() {
-            api.done();
-        })
-        .finally(function() {
-            nock.cleanAll();
-        });
+        .then(function() { return fetchPage(title, 12346) })
+        .then(function() { return sendDeleteSignal(title); })
+        .then(function() { api.done(); })
+        .finally(function() { nock.cleanAll(); });
     });
+
     it('should restrict access by revision', function() {
-        return preq.get({uri: server.config.bucketURL + '/revision/' + 12346})
-        .then(function() {
-            throw new Error('404 should have been returned for a deleted page');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
-        });
+        return assertRevisionDeleted(12346);
     });
+
     it('should restrict access to older revisions', function() {
-        return preq.get({uri: server.config.bucketURL + '/revision/' + 12345})
-        .then(function() {
-            throw new Error('404 should have been returned for a deleted page');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
-        });
+        return assertRevisionDeleted(12345);
     });
+
     it('should understand that page was undeleted', function() {
         var title = 'TestingTitle';
         nock.enableNetConnect();
         // After the previous test the page in storage is marked as deleted, so if MW API returns a response,
         // we need to understand that the page was undeleted and update a good_after
         var api = nock(apiURI)
-        .post('')
-        .reply(200, getApiResponse(title, 12346));
+        .post('').reply(200, getApiResponse(title, 12346));
         // Verify that it's deleted
         return preq.get({
             uri: server.config.bucketURL + '/title/' + title
@@ -149,121 +168,71 @@ describe('404 handling', function() {
             assert.deepEqual(e.status, 404);
             assert.contentType(e, 'application/problem+json');
         })
-        // Now fetch info that it's undeleted
-        .then(function() {
-            return preq.get({
-                uri: server.config.bucketURL + '/title/' + title,
-                headers: {
-                    'cache-control': 'no-cache'
-                }});
-        })
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0].rev, 12346);
-            // And older revisions should be undeleted too
-            return preq.get({uri: server.config.bucketURL + '/revision/' + 12345});
-        })
+        .then(function() { return sendUndeleteSignal(title, 12346); })
+        .then(function() { return preq.get({uri: server.config.bucketURL + '/revision/' + 12345}); })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body.items.length, 1);
             assert.deepEqual(res.body.items[0].rev, 12345);
         })
-        .then(function() {
-            api.done();
-        })
-        .finally(function() {
-            nock.cleanAll();
-        });
+        .then(function() { api.done(); })
+        .finally(function() { nock.cleanAll(); });
     });
+
     it('should not undelete if a new page with the same title was created', function() {
         var title = 'TestingTitle2';
         nock.enableNetConnect();
         var api = nock(apiURI)
         // Return a page so that we store it.
-        .post('')
-        .reply(200, getApiResponse(title, 12345))
+        .post('').reply(200, getApiResponse(title, 12345))
         // Return a new revision for the same page so that we store it.
-        .post('')
-        .reply(200, getApiResponse(title, 12346))
+        .post('').reply(200, getApiResponse(title, 12346))
         // Other requests return nothing as if the page is deleted.
-        .post('')
-        .reply(200, getEmptyResponse(12346))
+        .post('').reply(200, getEmptyResponse(12346))
         // And then we created a new page with the same title
-        .post('')
-        .reply(200, getApiResponse(title, 12347));
+        .post('').reply(200, getApiResponse(title, 12347));
         // Fetch the page
-        return preq.get({
-            uri: server.config.bucketURL + '/title/' + title,
-            headers: {
-                'cache-control': 'no-cache'
-            }
-        })
+        return fetchPage(title, 12345)
         .delay(1000)
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0].rev, 12345);
-            // Fetch one more page
-            return preq.get({
-                uri: server.config.bucketURL + '/title/' + title,
-                headers: {
-                    'cache-control': 'no-cache'
-                }
-            })
-        })
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0].rev, 12346);
-            // Now fetch info that it's deleted
-            return preq.get({
-                uri: server.config.bucketURL + '/title/' + title,
-                headers: {
-                    'cache-control': 'no-cache'
-                }});
-        })
-        .then(function() {
-            throw new Error('404 should have been returned for a deleted page');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
-            // Now signal an edit
-            return preq.get({
-                uri: server.config.bucketURL + '/html/' + title + '/' + 12347,
-                headers: {
-                    'cache-control': 'no-cache',
-                    'If-Unmodified-Since': new Date().toString
-                }
-            });
-        })
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            return preq.get({uri: server.config.bucketURL + '/revision/' + 12347});
-        })
+        .then(function() { return fetchPage(title, 12346) })
+        .then(function() { return sendDeleteSignal(title); })
+        .then(function() { return signalPageEdit(title, 12347); })
+        .then(function() { return preq.get({uri: server.config.bucketURL + '/revision/' + 12347}); })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body.items.length, 1);
             assert.deepEqual(res.body.items[0].rev, 12347);
-            return preq.get({uri: server.config.bucketURL + '/revision/' + 12346});
         })
-        .then(function() {
-            throw new Error('Should throw 404');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
-            return preq.get({uri: server.config.bucketURL + '/revision/' + 12345});
-        }).then(function() {
-            throw new Error('Should throw 404');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
+        .then(function() { return assertRevisionDeleted(12345); })
+        .then(function() { return assertRevisionDeleted(12346); })
+        .then(function() { api.done(); })
+        .finally(function() { nock.cleanAll(); });
+    });
+
+    it('should handle delete/undelete on pages created instead of deleted', function() {
+        var title = 'TestingTitle3';
+        nock.enableNetConnect();
+        var api = nock(apiURI)
+        // Return a page so that we store it.
+        .post('').reply(200, getApiResponse(title, 12345))
+        .post('').reply(200, getEmptyResponse(12345))
+        .post('').reply(200, getApiResponse(title, 12346))
+        .post('').reply(200, getEmptyResponse(12346))
+        .post('').reply(200, getApiResponse(title, 12346));
+        // Fetch the page
+        return fetchPage(title, 12345)
+        .then(function() { return sendDeleteSignal(title); })
+        .then(function() { return signalPageEdit(title, 12346); })
+        .then(function() { return sendDeleteSignal(title); })
+        .then(function() { return sendUndeleteSignal(title, 12346); })
+        .then(function() { return preq.get({uri: server.config.bucketURL + '/revision/' + 12346}); })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, 12346);
         })
-        .then(function() {
-            api.done();
-        })
-        .finally(function() {
-            nock.cleanAll();
-        });
-    })
+        .then(function() { return assertRevisionDeleted(12345); })
+        .then(function() { api.done(); })
+        .finally(function() { nock.cleanAll(); });
+    });
 });

--- a/test/features/pagecontent/delete_undelete.js
+++ b/test/features/pagecontent/delete_undelete.js
@@ -1,0 +1,269 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var assert = require('../../utils/assert.js');
+var preq   = require('preq');
+var server = require('../../utils/server.js');
+var nock = require('nock');
+
+describe('404 handling', function() {
+    this.timeout(20000);
+
+    before(function () {
+        return server.start();
+    });
+
+    var apiURI = server.config
+            .conf.templates['wmf-sys-1.0.0']
+            .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+    apiURI = apiURI.replace('{domain}', 'en.wikipedia.org');
+
+    function getEmptyResponse(revid) {
+        return {'batchcomplete':'','query':{'badrevids':{'12345' :{'revid':'' + revid}}}};
+    }
+    function getApiResponse(title, revid) {
+        return {
+            'batchcomplete': '',
+            'query': {
+                'pages': {
+                    '11089416': {
+                        'pageid': 11089416,
+                        'ns': 0,
+                        'title': title,
+                        'contentmodel': 'wikitext',
+                        'pagelanguage': 'en',
+                        'touched': '2015-05-22T08:49:39Z',
+                        'lastrevid': 653508365,
+                        'length': 2941,
+                        'revisions': [{
+                            'revid': revid,
+                            'user': 'Chuck Norris',
+                            'userid': 3606755,
+                            'timestamp': '2015-03-25T20:29:50Z',
+                            'size': 2941,
+                            'sha1': 'c47571122e00f28402d2a1b75cff77a22e7bfecd',
+                            'contentmodel': 'wikitext',
+                            'comment': 'Test',
+                            'tags': []
+                        }]
+                    }
+                }
+            }
+        };
+    }
+
+    // This test also prepares environment for other tests
+    it('should set page_deleted on deleted page', function() {
+        var title = 'TestingTitle';
+        nock.enableNetConnect();
+        var api = nock(apiURI)
+        // Return a page so that we store it.
+        .post('')
+        .reply(200, getApiResponse(title, 12345))
+        // Return a new revision for the same page so that we store it.
+        .post('')
+        .reply(200, getApiResponse(title, 12346))
+        // Other requests return nothing as if the page is deleted.
+        .post('')
+        .reply(200, getEmptyResponse(12346));
+
+        // Fetch the page
+        return preq.get({
+            uri: server.config.bucketURL + '/title/' + title,
+            headers: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .delay(1000)
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, 12345);
+            // Fetch one more page
+            return preq.get({
+                uri: server.config.bucketURL + '/title/' + title,
+                headers: {
+                    'cache-control': 'no-cache'
+                }
+            })
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, 12346);
+            // Now fetch info that it's deleted
+            return preq.get({
+                uri: server.config.bucketURL + '/title/' + title,
+                headers: {
+                    'cache-control': 'no-cache'
+                }});
+        })
+        .then(function() {
+            throw new Error('404 should have been returned for a deleted page');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+        })
+        .then(function() {
+            api.done();
+        })
+        .finally(function() {
+            nock.cleanAll();
+        });
+    });
+    it('should restrict access by revision', function() {
+        return preq.get({uri: server.config.bucketURL + '/revision/' + 12346})
+        .then(function() {
+            throw new Error('404 should have been returned for a deleted page');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+        });
+    });
+    it('should restrict access to older revisions', function() {
+        return preq.get({uri: server.config.bucketURL + '/revision/' + 12345})
+        .then(function() {
+            throw new Error('404 should have been returned for a deleted page');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+        });
+    });
+    it('should understand that page was undeleted', function() {
+        var title = 'TestingTitle';
+        nock.enableNetConnect();
+        // After the previous test the page in storage is marked as deleted, so if MW API returns a response,
+        // we need to understand that the page was undeleted and update a good_after
+        var api = nock(apiURI)
+        .post('')
+        .reply(200, getApiResponse(title, 12346));
+        // Verify that it's deleted
+        return preq.get({
+            uri: server.config.bucketURL + '/title/' + title
+        })
+        .then(function() {
+            throw new Error('Should throw 404');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+        })
+        // Now fetch info that it's undeleted
+        .then(function() {
+            return preq.get({
+                uri: server.config.bucketURL + '/title/' + title,
+                headers: {
+                    'cache-control': 'no-cache'
+                }});
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, 12346);
+            // And older revisions should be undeleted too
+            return preq.get({uri: server.config.bucketURL + '/revision/' + 12345});
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, 12345);
+        })
+        .then(function() {
+            api.done();
+        })
+        .finally(function() {
+            nock.cleanAll();
+        });
+    });
+    it('should not undelete if a new page with the same title was created', function() {
+        var title = 'TestingTitle2';
+        nock.enableNetConnect();
+        var api = nock(apiURI)
+        // Return a page so that we store it.
+        .post('')
+        .reply(200, getApiResponse(title, 12345))
+        // Return a new revision for the same page so that we store it.
+        .post('')
+        .reply(200, getApiResponse(title, 12346))
+        // Other requests return nothing as if the page is deleted.
+        .post('')
+        .reply(200, getEmptyResponse(12346))
+        // And then we created a new page with the same title
+        .post('')
+        .reply(200, getApiResponse(title, 12347));
+        // Fetch the page
+        return preq.get({
+            uri: server.config.bucketURL + '/title/' + title,
+            headers: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .delay(1000)
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, 12345);
+            // Fetch one more page
+            return preq.get({
+                uri: server.config.bucketURL + '/title/' + title,
+                headers: {
+                    'cache-control': 'no-cache'
+                }
+            })
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, 12346);
+            // Now fetch info that it's deleted
+            return preq.get({
+                uri: server.config.bucketURL + '/title/' + title,
+                headers: {
+                    'cache-control': 'no-cache'
+                }});
+        })
+        .then(function() {
+            throw new Error('404 should have been returned for a deleted page');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+            // Now signal an edit
+            return preq.get({
+                uri: server.config.bucketURL + '/html/' + title + '/' + 12347,
+                headers: {
+                    'cache-control': 'no-cache',
+                    'If-Unmodified-Since': new Date().toString
+                }
+            });
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            return preq.get({uri: server.config.bucketURL + '/revision/' + 12347});
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].rev, 12347);
+            return preq.get({uri: server.config.bucketURL + '/revision/' + 12346});
+        })
+        .then(function() {
+            throw new Error('Should throw 404');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+            return preq.get({uri: server.config.bucketURL + '/revision/' + 12345});
+        }).then(function() {
+            throw new Error('Should throw 404');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.contentType(e, 'application/problem+json');
+        })
+        .then(function() {
+            api.done();
+        })
+        .finally(function() {
+            nock.cleanAll();
+        });
+    })
+});

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -279,7 +279,7 @@ describe('item requests', function() {
 
     // Nock is needed here, because the page are already renamed in MW API,
     // but we need to pretend it's happening while renaming.
-    it('should not store duplicated revison on rename', function() {
+    it('should not store duplicated revision on rename', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
             .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -244,6 +244,42 @@ describe('item requests', function() {
             assert.deepEqual(res.body.items, [241155]);
         });
     });
+
+    it('shoudl track page renames', function() {
+        // First load up the original title
+        return preq.get({
+            uri: server.config.bucketURL + '/title/User:Pchelolo%2fBefore_Rename',
+            headers: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            var parentRevision = res.body.items[0].rev;
+            // Now load up a renamed title same wat as hook does that
+            return preq.get({
+                uri: server.config.bucketURL + '/html/User:Pchelolo%2fAfter_Rename',
+                headers: {
+                    'cache-control': 'no-cache',
+                    'x-restbase-parentrevision': '' + parentRevision
+                }
+            });
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            // Now check that renamed title has a link to old title
+            return preq.get({
+                uri: server.config.bucketURL + '/title/User:Pchelolo%2fAfter_Rename'
+            });
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].renamed_from, 'User:Pchelolo/Before_Rename');
+        });
+    });
+
     //it('should return a new wikitext revision using proxy handler with id 624165266', function() {
     //    this.timeout(20000);
     //    return preq.get({

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -340,12 +340,11 @@ describe('item requests', function() {
                 'cache-control': 'no-cache'
             }
         })
-        .then(function() {
-            throw new Error('Should track renames');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.deepEqual(e.body.detail, 'Page was renamed to User:Pchelolo/After_Rename');
-        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-location'],
+                server.config.bucketURL + '/html/User%3APchelolo%2FAfter_Rename');
+        });
     });
 
     it('should allow creating new pages instead of renamed', function() {
@@ -413,11 +412,12 @@ describe('item requests', function() {
             return preq.get({
                 uri: server.config.bucketURL + '/title/User:Pchelolo%2fRenames1'
             })
-            .then(function() {
-                throw new Error('Should track renames');
-            }, function(e) {
-                assert.deepEqual(e.status, 404);
-                assert.deepEqual(e.body.detail, 'Page was renamed to User:Pchelolo/Renames3');
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body.items[0].title, 'User:Pchelolo/Renames3');
+                assert.deepEqual(res.body.items[0].rev, 685357639);
+                assert.deepEqual(res.headers['content-location'],
+                    server.config.bucketURL + '/title/User%3APchelolo%2FRenames3');
             });
         })
         .then(function() { api.done(); })

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -283,13 +283,13 @@ describe('item requests', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
             .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
-        apiURI = apiURI.replace('{domain}', 'en.wikipedia.org');
+        apiURI = apiURI.replace('{domain}', 'en.wikipedia.beta.wmflabs.org');
         nock.enableNetConnect();
         var api = nock(apiURI)
-        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Before_Rename', 679398266))
-        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/After_Rename', 679398351));
+        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Before_Rename', 281004))
+        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/After_Rename', 281005));
         return preq.get({
-            uri: server.config.bucketURL + '/html/User:Pchelolo%2fBefore_Rename/679398266',
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fBefore_Rename/281004',
             headers: {
                 'cache-control': 'no-cache'
             }
@@ -297,10 +297,10 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             return preq.get({
-                uri: server.config.bucketURL + '/html/User:Pchelolo%2fAfter_Rename/679398351',
+                uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fAfter_Rename/281005',
                 headers: {
                     'cache-control': 'no-cache',
-                    'x-restbase-parentrevision': 679398266,
+                    'x-restbase-parentrevision': 281004,
                     'x-restbase-parenttitle': 'User:Pchelolo/Before_Rename'
                 }
             });
@@ -308,16 +308,16 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             return preq.get({
-                uri: server.config.bucketURL + '/title/User:Pchelolo%2fAfter_Rename/'
+                uri: server.config.labsBucketURL + '/title/User:Pchelolo%2fAfter_Rename/'
             })
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0], 679398351);
+            assert.deepEqual(res.body.items[0], 281005);
             if (res.body.next) {
                 return preq.get({
-                    uri: server.config.bucketURL
+                    uri: server.config.labsBucketURL
                             + '/title/User:Pchelolo%2fAfter_Rename/'
                             + res.body._links.next.href
                 })
@@ -335,12 +335,12 @@ describe('item requests', function() {
 
     it('should track renames and restrict access to older content', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/User:Pchelolo%2fBefore_Rename'
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fBefore_Rename'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers['content-location'],
-            server.config.bucketURL + '/html/User%3APchelolo%2FAfter_Rename');
+            server.config.labsBucketURL + '/html/User%3APchelolo%2FAfter_Rename');
         });
     });
 
@@ -349,13 +349,13 @@ describe('item requests', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
             .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
-        apiURI = apiURI.replace('{domain}', 'en.wikipedia.org');
+        apiURI = apiURI.replace('{domain}', 'en.wikipedia.beta.wmflabs.org');
         nock.enableNetConnect();
         var api = nock(apiURI)
-        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Before_Rename', 679398266))
-        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/After_Rename', 679398351));
+        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Before_Rename', 281004))
+        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/After_Rename', 281005));
         return preq.get({
-            uri: server.config.bucketURL + '/html/User:Pchelolo%2fBefore_Rename',
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fBefore_Rename',
             headers: {
                 'cache-control': 'no-cache'
             }
@@ -363,7 +363,7 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers['content-location'],
-                server.config.bucketURL + '/html/User%3APchelolo%2FAfter_Rename');
+                server.config.labsBucketURL + '/html/User%3APchelolo%2FAfter_Rename');
         })
         .then(function() { api.done(); })
         .finally(function() {nock.cleanAll()});
@@ -372,7 +372,7 @@ describe('item requests', function() {
     it('should allow creating new pages instead of renamed', function() {
         // A 'redirect' page was created for this page, need to be able to add it too
         return preq.get({
-            uri: server.config.bucketURL + '/html/User:Pchelolo%2fBefore_Rename/679398352',
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fBefore_Rename/281006',
             headers: {
                 'cache-control': 'no-cache'
             }
@@ -380,13 +380,13 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             return preq.get({
-                uri: server.config.bucketURL + '/title/User:Pchelolo%2fBefore_Rename'
+                uri: server.config.labsBucketURL + '/title/User:Pchelolo%2fBefore_Rename'
             });
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0].rev, 679398352);
+            assert.deepEqual(res.body.items[0].rev, 281006);
         });
     });
 
@@ -394,15 +394,15 @@ describe('item requests', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
             .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
-        apiURI = apiURI.replace('{domain}', 'en.wikipedia.org');
+        apiURI = apiURI.replace('{domain}', 'en.wikipedia.beta.wmflabs.org');
         nock.enableNetConnect();
         var api = nock(apiURI)
-        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Renames1', 685356037))
-        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Renames2', 685357564))
-        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Renames3', 685357639));
+        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Renames1', 280999))
+        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Renames2', 281000))
+        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Renames3', 281002));
 
         return preq.get({
-            uri: server.config.bucketURL + '/html/User:Pchelolo%2fRenames1/685356037',
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fRenames1/280999',
             headers: {
                 'cache-control': 'no-cache'
             }
@@ -410,36 +410,36 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             return preq.get({
-                uri: server.config.bucketURL + '/html/User:Pchelolo%2fRenames2/685357564',
+                uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fRenames2/281000',
                 headers: {
                     'cache-control': 'no-cache',
                     'x-restbase-parenttitle': 'User:Pchelolo/Renames1',
-                    'x-restbase-parentrevision': '685356037'
+                    'x-restbase-parentrevision': '280999'
                 }
             });
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             return preq.get({
-                uri: server.config.bucketURL + '/html/User:Pchelolo%2fRenames3/685357639',
+                uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fRenames3/281002',
                 headers: {
                     'cache-control': 'no-cache',
                     'x-restbase-parenttitle': 'User:Pchelolo/Renames2',
-                    'x-restbase-parentrevision': '685357564'
+                    'x-restbase-parentrevision': '281000'
                 }
             });
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             return preq.get({
-                uri: server.config.bucketURL + '/title/User:Pchelolo%2fRenames1'
+                uri: server.config.labsBucketURL + '/title/User:Pchelolo%2fRenames1'
             })
             .then(function(res) {
                 assert.deepEqual(res.status, 200);
                 assert.deepEqual(res.body.items[0].title, 'User:Pchelolo/Renames3');
-                assert.deepEqual(res.body.items[0].rev, 685357639);
+                assert.deepEqual(res.body.items[0].rev, 281002);
                 assert.deepEqual(res.headers['content-location'],
-                    server.config.bucketURL + '/title/User%3APchelolo%2FRenames3');
+                    server.config.labsBucketURL + '/title/User%3APchelolo%2FRenames3');
             });
         })
         .then(function() { api.done(); })

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -282,10 +282,11 @@ describe('item requests', function() {
     it('should not store duplicated revision on rename', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
-            .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+            .paths['/{module:action}']['x-modules'][0].templates.apiRequest.uri;
         apiURI = apiURI.replace('{domain}', 'en.wikipedia.beta.wmflabs.org');
         nock.enableNetConnect();
         var api = nock(apiURI)
+        .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Before_Rename', 281004))
         .post('').reply(200, responseWithTitleRevision('User:Pchelolo/Before_Rename', 281004))
         .post('').reply(200, responseWithTitleRevision('User:Pchelolo/After_Rename', 281005));
         return preq.get({
@@ -348,7 +349,7 @@ describe('item requests', function() {
     it('should track renames and restrict access to older content (no-cache)', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
-            .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+            .paths['/{module:action}']['x-modules'][0].templates.apiRequest.uri;
         apiURI = apiURI.replace('{domain}', 'en.wikipedia.beta.wmflabs.org');
         nock.enableNetConnect();
         var api = nock(apiURI)
@@ -390,10 +391,10 @@ describe('item requests', function() {
         });
     });
 
-    it('should return the lastest page title', function() {
+    it('should return the latest page title', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
-            .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+            .paths['/{module:action}']['x-modules'][0].templates.apiRequest.uri;
         apiURI = apiURI.replace('{domain}', 'en.wikipedia.beta.wmflabs.org');
         nock.enableNetConnect();
         var api = nock(apiURI)


### PR DESCRIPTION
This is ready for review.

This PR adds a `page_data` table, that stores `rename_to`, `rename_from`, `delete` and `undelete` events for a page title. Events are sorted by `tid`, so looking at the latest event in the page table, when pulling a revision, we can see what happened with a page. If event is `deleted` - page is deleted, return `404`, if it's `rename_to` - page was renamed and latest revisions under this title shouldn't be shown any more (by historic revisions should be). Storing the full history of page-related events gives us an opportunity to make nice features in future, like provide listings of page revisions that follow renames.

To detect deletes, we use the same logic as before. To detect renames, I'm adding a new header to the update hook `x-restbase-parenttitle`. It's sent on `move` events, and renames are stored. Undelete is detected, when we receive a revision from MW API (using `no-cache` header), but according to the page table, the revision is deleted. In than case we follow the page table back in time, find the previous delete event and restore the `good_after` timestamp. We can't simply drop it, because the page can be deleted, then another one created instead of it, deleted and then restored.

When revision is fetched, page data for it's title is fetched too (in parallel), and checked for renames and deletes. When the page table is empty, the overhead is really low, not more than 5%. Obviously, when there's a long renaming history, finding a real latest page title takes many turnarounds to the page table, so performance drops, but that's a corner case and wouldn't be observed frequently. On `html` endpoints, we check the revision with `getTitleRevision`, so content is hidden for them accordingly too.

Also, we've had a bug, that on renames a revision got duplicated in the old and new titles. Now it's fixed.

This was tested `a lot` with vagrant installation, I've created really long and complicated sequences of renames/deletes/undeletes/creating_pages_instead_of_deleted_ones and everything seem to work correctly.

Right now, this PR exposes a security vulnerability, which should be handled before it's release, and I wanted to chat about the options first. The `x-restbase-parentrevision` and `x-restbase-parenttitle` headers would be meaningful, and making them point to random places, an attacker could completely mess up the database. What I propose to do, is to restrict them to internal clients only (the hook). To do that, I'm going to remove these headers from the spec, but for internal clients we will include all provided headers. So the spec would white-list the safe headers, but internal clients would be able to by-pass the white-list. Thoughts?

I've tested this patch in vagrant without required updates to the hook, and there's no major issues in first merging and deploying this, and then replying the hook. Of course, it would be better to deploy hook changes sooner than later, but in that period nothing catastrophic would happen and no invalid data would be generated.