### PR TITLE
Include more client info in log entries

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -181,7 +181,16 @@ function handleRequest(opts, req, resp) {
             req: {
                 method: req.method.toLowerCase(),
                 uri: req.url,
-                headers: req.headers,
+                headers: {
+                    'cache-control': req.headers['cache-control'],
+                    'content-length': req.headers['content-length'],
+                    'content-type': req.headers['content-type'],
+                    'if-match': req.headers['if-match'],
+                    'user-agent': req.headers['user-agent'],
+                    'x-forwarded-for': req.headers['x-forwarded-for'],
+                    'x-rb-client-ip': req.headers['x-rb-client-ip'],
+                    'x-request-id': req.headers['x-request-id'],
+                },
             },
             request_id: req.headers['x-request-id']
         }),

--- a/lib/server.js
+++ b/lib/server.js
@@ -170,12 +170,18 @@ function handleRequest(opts, req, resp) {
     req.headers = req.headers || {};
     req.headers['x-request-id'] = req.headers['x-request-id'] || rbUtil.generateRequestId();
 
+    var xff = req.headers['x-forwarded-for'];
+    var remoteAddr = xff && xff.split(',')[0].trim()
+            || req.socket.remoteAddress;
+    req.headers['x-rb-client-ip'] = remoteAddr;
+
     var reqOpts = {
         conf: opts.conf,
         logger: opts.logger.child({
             req: {
                 method: req.method.toLowerCase(),
-                uri: req.url
+                uri: req.url,
+                headers: req.headers,
             },
             request_id: req.headers['x-request-id']
         }),
@@ -186,11 +192,6 @@ function handleRequest(opts, req, resp) {
     reqOpts.log = reqOpts.logger.log.bind(reqOpts.logger);
 
     // Simplistic count of requests from public & private networks
-    var xff = req.headers['x-forwarded-for'];
-    var remoteAddr = xff && xff.split(',')[0].trim()
-            || req.socket.remoteAddress;
-    req.headers['x-rb-client-ip'] = remoteAddr;
-
     if (/^(?:::ffff:)?(?:10|127)\./.test(remoteAddr)) {
         reqOpts.metrics.increment('requests.private');
     } else {


### PR DESCRIPTION
Include all client headers (plus some RB-internal ones) in log entries.