### PR TITLE
Use lowercased User-Agent header

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -158,7 +158,7 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
 RESTBase.prototype.defaultWebRequestHandler = function(req) {
     // Enforce the usage of UA
     req.headers = req.headers || {};
-    req.headers['User-Agent'] = req.headers['User-Agent'] || this.rb_config.user_agent;
+    req.headers['user-agent'] = req.headers['user-agent'] || this.rb_config.user_agent;
     if (this._authService) {
         this._authService.prepareRequest(this, req);
     }


### PR DESCRIPTION
Internally, we are using only lowercased header names, so enforce this for the user agent string as well.

This is a follow-up on #367 