### PR TITLE
Bug fix: Parsoid stashing: Ensure title/revision are present

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -501,6 +501,17 @@ PSP._getOriginalContent = function(restbase, req, revision, tid) {
 PSP._getStashedContent = function(restbase, req, etag) {
     var self = this;
     var rp = req.params;
+    if (!rp.title || !rp.revision) {
+        throw new rbUtil.HTTPError({
+            status: 400,
+            body: {
+                type: 'invalid_request',
+                description: 'Stashed data can be retrieved only for a specific' +
+                        ' title/revision combination'
+            }
+        });
+    }
+    rp.title = rbUtil.normalizeTitle(rp.title);
     function getStash(format) {
         return restbase.get({
             uri: self.getBucketURI(rp, 'stash.' + format, etag.tid)
@@ -782,6 +793,17 @@ PSP.makeTransform = function(from, to) {
                 body: {
                     type: 'invalid_request',
                     description: 'Missing request parameter: ' + from
+                }
+            });
+        }
+        // check if we have all the info for stashing
+        if (req.body.stash && !(rp.title && rp.revision)) {
+            throw new rbUtil.HTTPError({
+                status: 400,
+                body: {
+                    type: 'invalid_request',
+                    description: 'Data can be stashed only for a specific' +
+                            ' title/revision combination'
                 }
             });
         }

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -955,7 +955,8 @@ paths:
       tags:
         - Transforms
       description: >
-        Transform wikitext to HTML
+        Transform wikitext to HTML. Note that if set `stash: true`, you need to
+        supply both the title and the revision ID.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       consumes:


### PR DESCRIPTION
There is a subtle bug in the Parsoid stashing logic whereby if the title and revision are not provided, a 500 is returned since the bucket URI has an undefined path component. This PR fixes that for both `/transform/wikitext/to/html` (storing the stash) and `/transform/html/to/wikitext` (retrieving the stashed content).