### PR TITLE
CORS: Add the Access-Control-Expose-Headers header

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -34,6 +34,7 @@ function handleResponse(opts, req, resp, response) {
         rh['access-control-allow-origin'] = '*';
         rh['access-control-allow-methods'] = 'GET';
         rh['access-control-allow-headers'] = 'accept, content-type';
+        rh['access-control-expose-headers'] = 'etag';
 
         // Set up security headers
         // https://www.owasp.org/index.php/List_of_useful_HTTP_headers

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -22,6 +22,7 @@ describe('item requests', function() {
             assert.deepEqual(res.headers['access-control-allow-origin'], '*');
             assert.deepEqual(res.headers['access-control-allow-methods'], 'GET');
             assert.deepEqual(res.headers['access-control-allow-headers'], 'accept, content-type');
+            assert.deepEqual(res.headers['access-control-expose-headers'], 'etag');
         });
     });
     it('should transparently create a new HTML revision for Main_Page', function() {


### PR DESCRIPTION
Cross-site requests need to be able to read the `ETag` header. In order to do so in browsers, RESTBase must send the `Access-Control-Expose-Headers` header and set its value to `etag`.

Bug: [T115165](https://phabricator.wikimedia.org/T115165)