### PR TITLE
MobileApps: Set up RESTBase storage

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -152,34 +152,144 @@ templates:
           paths:
             /html/{title}:
               get:
+                x-setup-handler:
+                  - init:
+                      method: put
+                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html
+                      body:
+                        revisionRetentionPolicy:
+                          type: 'latest'
+                          count: 1
+                          grace_ttl: 86400
+                        valueType: 'json'
+                        version: 1
                 x-request-handler:
-                  - get_from_backend:
+                  - handle_req:
                       request:
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html/{title}
+                        method: get
+                        uri: /{domain}/sys/mobileapps/handling/mobile-html/{title}
+                        headers:
+                          cache-control: '{cache-control}'
             /sections/{title}:
               get:
+                x-setup-handler:
+                  - init:
+                      method: put
+                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections
+                      body:
+                        revisionRetentionPolicy:
+                          type: 'latest'
+                          count: 1
+                          grace_ttl: 86400
+                        valueType: 'json'
+                        version: 1
                 x-request-handler:
-                  - get_from_backend:
+                  - handle_req:
                       request:
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections/{title}
+                        method: get
+                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections/{title}
+                        headers:
+                          cache-control: '{cache-control}'
             /sections-lead/{title}:
               get:
+                x-setup-handler:
+                  - init:
+                      method: put
+                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections-lead
+                      body:
+                        revisionRetentionPolicy:
+                          type: 'latest'
+                          count: 1
+                          grace_ttl: 86400
+                        valueType: 'json'
+                        version: 1
                 x-request-handler:
-                  - get_from_backend:
+                  - handle_req:
                       request:
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections-lead/{title}
+                        method: get
+                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections-lead/{title}
+                        headers:
+                          cache-control: '{cache-control}'
             /sections-remaining/{title}:
               get:
+                x-setup-handler:
+                  - init:
+                      method: put
+                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections-remaining
+                      body:
+                        revisionRetentionPolicy:
+                          type: 'latest'
+                          count: 1
+                          grace_ttl: 86400
+                        valueType: 'json'
+                        version: 1
                 x-request-handler:
-                  - get_from_backend:
+                  - handle_req:
                       request:
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections-remaining/{title}
+                        method: get
+                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections-remaining/{title}
+                        headers:
+                          cache-control: '{cache-control}'
             /text/{title}:
               get:
+                x-setup-handler:
+                  - init:
+                      method: put
+                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-text
+                      body:
+                        revisionRetentionPolicy:
+                          type: 'latest'
+                          count: 1
+                          grace_ttl: 86400
+                        valueType: 'json'
+                        version: 1
                 x-request-handler:
-                  - get_from_backend:
+                  - handle_req:
                       request:
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-text/{title}
+                        method: get
+                        uri: /{domain}/sys/mobileapps/handling/mobile-text/{title}
+                        headers:
+                          cache-control: '{cache-control}'
+            /handling/{route}/{title}:
+              get:
+                x-request-handler:
+                  - get_rev:
+                      request:
+                        method: get
+                        uri: /{domain}/sys/page_revisions/page/{title}
+                        headers:
+                          cache-control: '{cache-control}'
+                  - check_storage:
+                      request:
+                        method: get
+                        uri: /{domain}/sys/key_rev_value/mobileapps.{$.request.params.route}/{$.request.params.title}/{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}
+                      return_if:
+                        status: '2xx'
+                      return:
+                        status: 200
+                        headers: '{$.check_storage.body.headers}'
+                        body: '{$.check_storage.body.body}'
+                      catch:
+                        status: 404
+                  - get_mobileapps:
+                      request:
+                        method: get
+                        uri: http://appservice.wmflabs.org/{domain}/v1/page/{$.request.params.route}/{$.request.params.title}
+                        headers:
+                          x-restbase-etag: '{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}'
+                  - store:
+                      request:
+                        method: put
+                        uri: /{domain}/sys/key_rev_value/mobileapps.{$.request.params.route}/{$.request.params.title}/{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}
+                        headers:
+                          content-type: application/json
+                        body:
+                          headers: '{$.get_mobileapps.headers}'
+                          body: '{$.get_mobileapps.body}'
+                      return:
+                        status: 200
+                        headers: '{$.get_mobileapps.headers}'
+                        body: '{$.get_mobileapps.body}'
 
 #      /{module:revscore}:
 #        title: Simple revscore service wrapper

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -167,7 +167,7 @@ templates:
                   - handle_req:
                       request:
                         method: get
-                        uri: /{domain}/sys/mobileapps/handling/mobile-html/{title}
+                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html/{title}
                         headers:
                           cache-control: '{cache-control}'
             /sections/{title}:
@@ -187,7 +187,7 @@ templates:
                   - handle_req:
                       request:
                         method: get
-                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections/{title}
+                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections/{title}
                         headers:
                           cache-control: '{cache-control}'
             /sections-lead/{title}:
@@ -207,7 +207,7 @@ templates:
                   - handle_req:
                       request:
                         method: get
-                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections-lead/{title}
+                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections-lead/{title}
                         headers:
                           cache-control: '{cache-control}'
             /sections-remaining/{title}:
@@ -227,7 +227,7 @@ templates:
                   - handle_req:
                       request:
                         method: get
-                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections-remaining/{title}
+                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections-remaining/{title}
                         headers:
                           cache-control: '{cache-control}'
             /text/{title}:
@@ -247,10 +247,10 @@ templates:
                   - handle_req:
                       request:
                         method: get
-                        uri: /{domain}/sys/mobileapps/handling/mobile-text/{title}
+                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-text/{title}
                         headers:
                           cache-control: '{cache-control}'
-            /handling/{route}/{title}:
+            /handling/rev/{route}/{title}:
               get:
                 x-request-handler:
                   - get_rev:
@@ -259,28 +259,24 @@ templates:
                         uri: /{domain}/sys/page_revisions/page/{title}
                         headers:
                           cache-control: '{cache-control}'
-                  - check_storage:
+                  - cache_branch:
                       request:
-                        method: get
-                        uri: /{domain}/sys/key_rev_value/mobileapps.{$.request.params.route}/{$.request.params.title}/{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}
-                      return_if:
-                        status: '2xx'
-                      return:
-                        status: 200
-                        headers: '{$.check_storage.body.headers}'
-                        body: '{$.check_storage.body.body}'
-                      catch:
-                        status: 404
+                        method: post
+                        uri: /{domain}/sys/mobileapps/handling/content/{$$.default($.request.headers.cache-control, 'none-given')}/{route}/{title}
+                        body: '{$.get_rev.body}'
+            /handling/content/no-cache/{route}/{title}:
+              post:
+                x-request-handler:
                   - get_mobileapps:
                       request:
                         method: get
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/{$.request.params.route}/{$.request.params.title}
+                        uri: http://appservice.wmflabs.org/{domain}/v1/page/{route}/{title}
                         headers:
-                          x-restbase-etag: '{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}'
+                          x-restbase-etag: '{$.request.body.items[0].rev}/{$.request.body.items[0].tid}'
                   - store:
                       request:
                         method: put
-                        uri: /{domain}/sys/key_rev_value/mobileapps.{$.request.params.route}/{$.request.params.title}/{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}
+                        uri: /{domain}/sys/key_rev_value/mobileapps.{route}/{title}/{$.request.body.items[0].rev}/{$.request.body.items[0].tid}
                         headers:
                           content-type: application/json
                         body:
@@ -290,6 +286,26 @@ templates:
                         status: 200
                         headers: '{$.get_mobileapps.headers}'
                         body: '{$.get_mobileapps.body}'
+            /handling/content/{cache-default}/{route}/{title}:
+              post:
+                x-request-handler:
+                  - check_storage:
+                      request:
+                        method: get
+                        uri: /{domain}/sys/key_rev_value/mobileapps.{route}/{title}/{$.request.body.items[0].rev}/{$.request.body.items[0].tid}
+                      return_if:
+                        status: '2xx'
+                      return:
+                        status: 200
+                        headers: '{$.check_storage.body.headers}'
+                        body: '{$.check_storage.body.body}'
+                      catch:
+                        status: 404
+                  - render:
+                      request:
+                        method: post
+                        uri: /{domain}/sys/mobileapps/handling/content/no-cache/{route}/{title}
+                        body: '{$.request.body}'
 
 #      /{module:revscore}:
 #        title: Simple revscore service wrapper

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -150,34 +150,144 @@ templates:
           paths:
             /html/{title}:
               get:
+                x-setup-handler:
+                  - init:
+                      method: put
+                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html
+                      body:
+                        revisionRetentionPolicy:
+                          type: 'latest'
+                          count: 1
+                          grace_ttl: 86400
+                        valueType: 'json'
+                        version: 1
                 x-request-handler:
-                  - get_from_backend:
+                  - handle_req:
                       request:
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html/{title}
+                        method: get
+                        uri: /{domain}/sys/mobileapps/handling/mobile-html/{title}
+                        headers:
+                          cache-control: '{cache-control}'
             /sections/{title}:
               get:
+                x-setup-handler:
+                  - init:
+                      method: put
+                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections
+                      body:
+                        revisionRetentionPolicy:
+                          type: 'latest'
+                          count: 1
+                          grace_ttl: 86400
+                        valueType: 'json'
+                        version: 1
                 x-request-handler:
-                  - get_from_backend:
+                  - handle_req:
                       request:
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections/{title}
+                        method: get
+                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections/{title}
+                        headers:
+                          cache-control: '{cache-control}'
             /sections-lead/{title}:
               get:
+                x-setup-handler:
+                  - init:
+                      method: put
+                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections-lead
+                      body:
+                        revisionRetentionPolicy:
+                          type: 'latest'
+                          count: 1
+                          grace_ttl: 86400
+                        valueType: 'json'
+                        version: 1
                 x-request-handler:
-                  - get_from_backend:
+                  - handle_req:
                       request:
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections-lead/{title}
+                        method: get
+                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections-lead/{title}
+                        headers:
+                          cache-control: '{cache-control}'
             /sections-remaining/{title}:
               get:
+                x-setup-handler:
+                  - init:
+                      method: put
+                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections-remaining
+                      body:
+                        revisionRetentionPolicy:
+                          type: 'latest'
+                          count: 1
+                          grace_ttl: 86400
+                        valueType: 'json'
+                        version: 1
                 x-request-handler:
-                  - get_from_backend:
+                  - handle_req:
                       request:
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-html-sections-remaining/{title}
+                        method: get
+                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections-remaining/{title}
+                        headers:
+                          cache-control: '{cache-control}'
             /text/{title}:
               get:
+                x-setup-handler:
+                  - init:
+                      method: put
+                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-text
+                      body:
+                        revisionRetentionPolicy:
+                          type: 'latest'
+                          count: 1
+                          grace_ttl: 86400
+                        valueType: 'json'
+                        version: 1
                 x-request-handler:
-                  - get_from_backend:
+                  - handle_req:
                       request:
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-text/{title}
+                        method: get
+                        uri: /{domain}/sys/mobileapps/handling/mobile-text/{title}
+                        headers:
+                          cache-control: '{cache-control}'
+            /handling/{route}/{title}:
+              get:
+                x-request-handler:
+                  - get_rev:
+                      request:
+                        method: get
+                        uri: /{domain}/sys/page_revisions/page/{title}
+                        headers:
+                          cache-control: '{cache-control}'
+                  - check_storage:
+                      request:
+                        method: get
+                        uri: /{domain}/sys/key_rev_value/mobileapps.{$.request.params.route}/{$.request.params.title}/{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}
+                      return_if:
+                        status: '2xx'
+                      return:
+                        status: 200
+                        headers: '{$.check_storage.body.headers}'
+                        body: '{$.check_storage.body.body}'
+                      catch:
+                        status: 404
+                  - get_mobileapps:
+                      request:
+                        method: get
+                        uri: http://appservice.wmflabs.org/{domain}/v1/page/{$.request.params.route}/{$.request.params.title}
+                        headers:
+                          x-restbase-etag: '{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}'
+                  - store:
+                      request:
+                        method: put
+                        uri: /{domain}/sys/key_rev_value/mobileapps.{$.request.params.route}/{$.request.params.title}/{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}
+                        headers:
+                          content-type: application/json
+                        body:
+                          headers: '{$.get_mobileapps.headers}'
+                          body: '{$.get_mobileapps.body}'
+                      return:
+                        status: 200
+                        headers: '{$.get_mobileapps.headers}'
+                        body: '{$.get_mobileapps.body}'
 
   global-content: &gb/content/1.0.0
     swagger: '2.0'

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -165,7 +165,7 @@ templates:
                   - handle_req:
                       request:
                         method: get
-                        uri: /{domain}/sys/mobileapps/handling/mobile-html/{title}
+                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html/{title}
                         headers:
                           cache-control: '{cache-control}'
             /sections/{title}:
@@ -185,7 +185,7 @@ templates:
                   - handle_req:
                       request:
                         method: get
-                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections/{title}
+                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections/{title}
                         headers:
                           cache-control: '{cache-control}'
             /sections-lead/{title}:
@@ -205,7 +205,7 @@ templates:
                   - handle_req:
                       request:
                         method: get
-                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections-lead/{title}
+                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections-lead/{title}
                         headers:
                           cache-control: '{cache-control}'
             /sections-remaining/{title}:
@@ -225,7 +225,7 @@ templates:
                   - handle_req:
                       request:
                         method: get
-                        uri: /{domain}/sys/mobileapps/handling/mobile-html-sections-remaining/{title}
+                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections-remaining/{title}
                         headers:
                           cache-control: '{cache-control}'
             /text/{title}:
@@ -245,10 +245,10 @@ templates:
                   - handle_req:
                       request:
                         method: get
-                        uri: /{domain}/sys/mobileapps/handling/mobile-text/{title}
+                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-text/{title}
                         headers:
                           cache-control: '{cache-control}'
-            /handling/{route}/{title}:
+            /handling/rev/{route}/{title}:
               get:
                 x-request-handler:
                   - get_rev:
@@ -257,28 +257,24 @@ templates:
                         uri: /{domain}/sys/page_revisions/page/{title}
                         headers:
                           cache-control: '{cache-control}'
-                  - check_storage:
+                  - cache_branch:
                       request:
-                        method: get
-                        uri: /{domain}/sys/key_rev_value/mobileapps.{$.request.params.route}/{$.request.params.title}/{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}
-                      return_if:
-                        status: '2xx'
-                      return:
-                        status: 200
-                        headers: '{$.check_storage.body.headers}'
-                        body: '{$.check_storage.body.body}'
-                      catch:
-                        status: 404
+                        method: post
+                        uri: /{domain}/sys/mobileapps/handling/content/{$$.default($.request.headers.cache-control, 'none-given')}/{route}/{title}
+                        body: '{$.get_rev.body}'
+            /handling/content/no-cache/{route}/{title}:
+              post:
+                x-request-handler:
                   - get_mobileapps:
                       request:
                         method: get
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/{$.request.params.route}/{$.request.params.title}
+                        uri: http://appservice.wmflabs.org/{domain}/v1/page/{route}/{title}
                         headers:
-                          x-restbase-etag: '{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}'
+                          x-restbase-etag: '{$.request.body.items[0].rev}/{$.request.body.items[0].tid}'
                   - store:
                       request:
                         method: put
-                        uri: /{domain}/sys/key_rev_value/mobileapps.{$.request.params.route}/{$.request.params.title}/{$.get_rev.body.items[0].rev}/{$.get_rev.body.items[0].tid}
+                        uri: /{domain}/sys/key_rev_value/mobileapps.{route}/{title}/{$.request.body.items[0].rev}/{$.request.body.items[0].tid}
                         headers:
                           content-type: application/json
                         body:
@@ -288,6 +284,26 @@ templates:
                         status: 200
                         headers: '{$.get_mobileapps.headers}'
                         body: '{$.get_mobileapps.body}'
+            /handling/content/{cache-default}/{route}/{title}:
+              post:
+                x-request-handler:
+                  - check_storage:
+                      request:
+                        method: get
+                        uri: /{domain}/sys/key_rev_value/mobileapps.{route}/{title}/{$.request.body.items[0].rev}/{$.request.body.items[0].tid}
+                      return_if:
+                        status: '2xx'
+                      return:
+                        status: 200
+                        headers: '{$.check_storage.body.headers}'
+                        body: '{$.check_storage.body.body}'
+                      catch:
+                        status: 404
+                  - render:
+                      request:
+                        method: post
+                        uri: /{domain}/sys/mobileapps/handling/content/no-cache/{route}/{title}
+                        body: '{$.request.body}'
 
   global-content: &gb/content/1.0.0
     swagger: '2.0'

--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -36,13 +36,27 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
+              method: get
               uri: /{domain}/sys/mobileapps/html/{title}
+              headers:
+                cache-control: '{cache-control}'
       x-monitor: true
       x-amples:
         - title: Get MobileApps Main Page
           request:
             params:
               domain: en.wikipedia.org
+              title: Main_Page
+            headers:
+              cache-control: no-cache
+          response:
+            status: 200
+            headers:
+              content-type: /text\/html/
+            body: /body/
+        - title: Get MobileApps Main Page from RB storage
+          request:
+            params:
               title: Main_Page
           response:
             status: 200
@@ -82,7 +96,10 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
+              method: get
               uri: /{domain}/sys/mobileapps/sections/{title}
+              headers:
+                cache-control: '{cache-control}'
       x-monitor: false
 
   /{module:page}/mobile-html-sections-lead/{title}:
@@ -117,7 +134,10 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
+              method: get
               uri: /{domain}/sys/mobileapps/sections-lead/{title}
+              headers:
+                cache-control: '{cache-control}'
       x-monitor: false
 
   /{module:page}/mobile-html-sections-remaining/{title}:
@@ -153,7 +173,10 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
+              method: get
               uri: /{domain}/sys/mobileapps/sections-remaining/{title}
+              headers:
+                cache-control: '{cache-control}'
       x-monitor: false
 
   /{module:page}/mobile-text/{title}:
@@ -188,5 +211,8 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
+              method: get
               uri: /{domain}/sys/mobileapps/text/{title}
+              headers:
+                cache-control: '{cache-control}'
       x-monitor: false

--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -57,6 +57,7 @@ paths:
         - title: Get MobileApps Main Page from RB storage
           request:
             params:
+              domain: en.wikipedia.org
               title: Main_Page
           response:
             status: 200


### PR DESCRIPTION
Thus far, requests for the Mobile Content Service were only proxied through RESTBase. This commit sets up RESTBase to store the response from the back-end service and serve it on subsequent requests.

First, the current revision ID for a page is retrieved from the storage. Then, the storage is checked for the content rendered by the Mobile Content Service for the returned revision ID and time UUID. If data for that combination exists, it is returned. Otherwise, a request is placed to the Mobile Content Service to render the page and the result is stored in RESTBase and returned to the client. Note that, if the `Cache-Control: no-cache` header is supplied, the storage-check step is skipped and the back-end service is contacted for a new render right away, thus enabling re-renders even when the revision info hasn't changed. This principle is applied to all of the routes exposed by RESTBase for the Mobile Content Service.

Bug: [T102130](https://phabricator.wikimedia.org/T102130)