### PR TITLE
Use LTS node release in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
-    - "4.1"
+    - "4.2"
     - "iojs-v2.5.0"
 
 sudo: false


### PR DESCRIPTION
A first LTS node.js was just released [4.2.0](https://github.com/nodejs/node/blob/v4.2.0/CHANGELOG.md), so we should use this version in 4.x branch in travis tests.