### PR TITLE
Replaced x-forwarded-for with x-client-ip

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -171,10 +171,8 @@ function handleRequest(opts, req, resp) {
     req.headers = req.headers || {};
     req.headers['x-request-id'] = req.headers['x-request-id'] || rbUtil.generateRequestId();
 
-    var xff = req.headers['x-forwarded-for'];
-    var remoteAddr = xff && xff.split(',')[0].trim()
-            || req.socket.remoteAddress;
-    req.headers['x-rb-client-ip'] = remoteAddr;
+    var remoteAddr = req.headers['x-client-ip'] || req.socket.remoteAddress;
+    req.headers['x-client-ip'] = remoteAddr;
 
     var reqOpts = {
         conf: opts.conf,
@@ -189,7 +187,7 @@ function handleRequest(opts, req, resp) {
                     'if-match': req.headers['if-match'],
                     'user-agent': req.headers['user-agent'],
                     'x-forwarded-for': req.headers['x-forwarded-for'],
-                    'x-rb-client-ip': req.headers['x-rb-client-ip'],
+                    'x-client-ip': req.headers['x-client-ip'],
                     'x-request-id': req.headers['x-request-id'],
                 },
             },

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -58,7 +58,7 @@ paths:
             $ref: '#/definitions/problem'
       security:
         - header_match:
-            - header: 'x-rb-client-ip'
+            - header: 'x-client-ip'
               patterns:
                 - internal
       x-request-handler:

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -75,7 +75,7 @@ paths:
     post:
       security:
         - header_match:
-            - header: 'x-rb-client-ip'
+            - header: 'x-client-ip'
               patterns:
                 - internal
       x-request-handler:

--- a/test/features/post_data.js
+++ b/test/features/post_data.js
@@ -63,7 +63,7 @@ describe('post_data', function () {
         return preq.post({
             uri: server.config.baseURL + '/post_data/',
             headers: {
-                'x-forwarded-for': '123.123.123.123'
+                'x-client-ip': '123.123.123.123'
             },
             body: {
                 key: 'value2'


### PR DESCRIPTION
We have `x-client-ip` header forwarded to RESTBase now, and it's more accurate, that relying on x-forwarded-for header, so replaced. Also removed custom `x-rb-client-ip` header

Bug: https://phabricator.wikimedia.org/T114843