### PR TITLE
Various fixes

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -45,7 +45,8 @@ var securityDefinitionCreators = {
         return {
             prepareRequest: function(restbase, req) {
                 if (isInternalRequest(req)) {
-                    rbUtil.copyForwardedHeaders(restbase, req, ['cookie', 'x-forwarded-for']);
+                    rbUtil.copyForwardedHeaders(restbase, req,
+                        ['cookie', 'x-forwarded-for', 'x-client-ip']);
                 }
             },
             checkPermissions: function(restbase, req, permDefinitions) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -173,6 +173,7 @@ function handleRequest(opts, req, resp) {
 
     var remoteAddr = req.headers['x-client-ip'] || req.socket.remoteAddress;
     req.headers['x-client-ip'] = remoteAddr;
+    req.headers['x-forwarded-for'] = remoteAddr;
 
     var reqOpts = {
         conf: opts.conf,
@@ -186,7 +187,6 @@ function handleRequest(opts, req, resp) {
                     'content-type': req.headers['content-type'],
                     'if-match': req.headers['if-match'],
                     'user-agent': req.headers['user-agent'],
-                    'x-forwarded-for': req.headers['x-forwarded-for'],
                     'x-client-ip': req.headers['x-client-ip'],
                     'x-request-id': req.headers['x-request-id'],
                 },

--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -779,17 +779,6 @@ PSP.makeTransform = function(from, to) {
     return function(restbase, req) {
         var rp = req.params;
         if (!req.body || !req.body[from]) {
-            // XXX: This is a temporary log line to aid in
-            // discovering what's going on in T112339
-            // We need to remove it
-            if (to === 'wikitext') {
-                self.log('warn/transform', {
-                    message: 'Missing request parameter: ' + from,
-                    req: req,
-                    status: 400
-                });
-            }
-            // XXX: End temp code
             throw new rbUtil.HTTPError({
                 status: 400,
                 body: {
@@ -835,20 +824,6 @@ PSP.makeTransform = function(from, to) {
             }
             throw e;
         })
-        // XXX: This is a temporary catch to aid in
-        // discovering what's going on in T112339
-        // We need to remove it
-        .catch(function(e) {
-            if (to === 'wikitext' && e.status && e.status >= 400 && e.status < 500) {
-                self.log('warn/transform', {
-                    message: e.body.description || e.body.message,
-                    req: req,
-                    status: e.status
-                });
-            }
-            throw e;
-        })
-        // XXX: End temp code
         .then(function(res) {
             // Unwrap to the flat response format
             var innerRes = res.body[to];

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -418,6 +418,7 @@ describe('page save api', function() {
                     uri: htmlUri,
                     headers: {
                         'x-forwarded-for': '123.123.123.123',
+                        'x-client-ip': '123.123.123.123',
                         cookie: 'test'
                     },
                     body: {
@@ -435,7 +436,7 @@ describe('page save api', function() {
         if (NOCK_TESTS) {
             var api = nock(prodApiURI, {
                 reqheaders: {
-                    'x-forwarded-for': '123.123.123.123',
+                    'x-client-ip': '123.123.123.123',
                     cookie: 'test'
                 }
             })

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -417,7 +417,6 @@ describe('page save api', function() {
                 return preq.post({
                     uri: htmlUri,
                     headers: {
-                        'x-forwarded-for': '123.123.123.123',
                         'x-client-ip': '123.123.123.123',
                         cookie: 'test'
                     },
@@ -437,6 +436,7 @@ describe('page save api', function() {
             var api = nock(prodApiURI, {
                 reqheaders: {
                     'x-client-ip': '123.123.123.123',
+                    'x-forwarded-for': '123.123.123.123',
                     cookie: 'test'
                 }
             })

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -36,8 +36,11 @@ elif [ "$2" = "sqlite" ]; then
 elif [ "$2" = "cassandra" ]; then
     runTest "cassandra" $1
 elif [ "$2" = "all" ]; then
-    runTest "sqlite" $1
     runTest "cassandra" $1
+    cassandra_result=$?
+    runTest "sqlite" $1
+    sqlite_result=$?
+    exit $(($cassandra_result + $sqlite_result))
 else
     echo "Invalid testing mode"
     exit 1


### PR DESCRIPTION
Various fixes and improvements:
1. Improved test script to sum sqlite and cassandra exit codes
2. Removed temporary logging in parsoid transforms
3. Replace `x-forwarded-for` header with `x-client-ip`, which is the real trusted IP of the client. XFF header could be faked.