### PR TITLE
RESTBase test suite can't use parsoid-lb endpoint

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -132,7 +132,7 @@ templates:
             version: 1.0.0
             type: file
             options:
-              parsoidHost: http://parsoid-lb.eqiad.wikimedia.org
+              parsoidHost:  http://parsoid-beta.wmflabs.org
               # For local testing, use:
               # parsoidHost: http://localhost:8000
 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -3,7 +3,6 @@
 info:
   name: restbase
 
-
 templates:
 
   wmf-content-1.0.0: &wp/content/1.0.0
@@ -51,8 +50,9 @@ templates:
         x-internal-request-whitelist:
           - http://en.wikipedia.org/w/api.php
           - http://fr.wikipedia.org/w/api.php
+          - http://en.wikipedia.beta.wmflabs.org
           # Left as a regex for test purpose
-          - /http:\/\/parsoid\-lb\.eqiad\.wikimedia\.org/
+          - /http:\/\/parsoid\-beta\.wmflabs\.org/
       header_match:
         description: Checks client ip against one of the predefined whitelists
         x-error-message: This client is not allowed to use the endpoint
@@ -132,7 +132,7 @@ templates:
             version: 1.0.0
             type: file
             options:
-              parsoidHost:  http://parsoid-beta.wmflabs.org
+              parsoidHost: http://parsoid-beta.wmflabs.org
               # For local testing, use:
               # parsoidHost: http://localhost:8000
 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -50,7 +50,7 @@ templates:
         x-internal-request-whitelist:
           - http://en.wikipedia.org/w/api.php
           - http://fr.wikipedia.org/w/api.php
-          - http://en.wikipedia.beta.wmflabs.org
+          - http://en.wikipedia.beta.wmflabs.org/w/api.php
           # Left as a regex for test purpose
           - /http:\/\/parsoid\-beta\.wmflabs\.org/
       header_match:

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -74,6 +74,7 @@ paths:
         - title: Mathoid - test formula
           request:
             params:
+              domain: en.wikipedia.org
               format: svg
             body:
               q: E=mc^2

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -782,6 +782,7 @@ paths:
         - title: Get rev by ID
           request:
             params:
+              domain: en.wikipedia.org
               revision: 642497713
           response:
             status: 200

--- a/specs/mediawiki/v1/graphoid.yaml
+++ b/specs/mediawiki/v1/graphoid.yaml
@@ -60,6 +60,7 @@ paths:
         - title: Get a graph from Graphoid
           request:
             params:
+              domain: en.wikipedia.org
               title: User:Pchelolo/Graph
               revision: 670213569
               graph_id: 1533aaad45c733dcc7e07614b54cbae4119a6747.png

--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -42,6 +42,7 @@ paths:
         - title: Get MobileApps Main Page
           request:
             params:
+              domain: en.wikipedia.org
               title: Main_Page
           response:
             status: 200

--- a/test/features/errors/invalid_request.js
+++ b/test/features/errors/invalid_request.js
@@ -41,9 +41,9 @@ describe('400 handling', function() {
 
     it('Should return 400 on invalid JSON sections', function() {
         var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
-        var pageWithSectionsRev = 669458404;
+        var pageWithSectionsRev = 275834;
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/sections/to/wikitext/'
                 + pageWithSectionsTitle
                 + '/' + pageWithSectionsRev,
@@ -62,9 +62,9 @@ describe('400 handling', function() {
 
     it('Should return 400 if non-existent section id provided', function() {
         var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
-        var pageWithSectionsRev = 669458404;
+        var pageWithSectionsRev = 275834;
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/sections/to/wikitext/'
                 + pageWithSectionsTitle
                 + '/' + pageWithSectionsRev,

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -27,12 +27,12 @@ describe('item requests', function() {
     });
     it('should transparently create a new HTML revision for Main_Page', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/Main_Page',
+            uri: server.config.labsBucketURL + '/html/Main_Page',
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             return preq.get({
-                uri: server.config.bucketURL + '/html/Main_Page/'
+                uri: server.config.labsBucketURL + '/html/Main_Page/'
             });
         })
         .then(function(res) {
@@ -41,34 +41,34 @@ describe('item requests', function() {
             }
         });
     });
-    it('should transparently create a new HTML revision with id 624484477', function() {
+    it('should transparently create a new HTML revision with id 252937', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/Foobar/624484477',
+            uri: server.config.labsBucketURL + '/html/Foobar/252937',
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
         });
     });
-    it('should transparently create data-parsoid with id 624165266, rev 2', function() {
+    it('should transparently create data-parsoid with id 241155, rev 2', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/Foobar/624165266'
+            uri: server.config.labsBucketURL + '/html/Foobar/241155'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
         });
     });
-    it('should return HTML just created by revision 624165266', function() {
+    it('should return HTML just created by revision 241155', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/Foobar/624165266'
+            uri: server.config.labsBucketURL + '/html/Foobar/241155'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, contentTypes.html);
         });
     });
-    it('should return data-parsoid just created by revision 624165266, rev 2', function() {
+    it('should return data-parsoid just created by revision 241155, rev 2', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/data-parsoid/Foobar/624165266'
+            uri: server.config.labsBucketURL + '/data-parsoid/Foobar/241155'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
@@ -76,9 +76,9 @@ describe('item requests', function() {
         });
     });
 
-    it('should return data-parsoid just created with revision 624484477, rev 2', function() {
+    it('should return data-parsoid just created with revision 252937, rev 2', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/data-parsoid/Foobar/624484477'
+            uri: server.config.labsBucketURL + '/data-parsoid/Foobar/252937'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
@@ -88,25 +88,25 @@ describe('item requests', function() {
 
     it('should return sections of Main_Page', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/Main_Page/664887982',
+            uri: server.config.labsBucketURL + '/html/Main_Page/262492',
             query: {
-                sections: 'mp-topbanner,mp-upper'
+                sections: 'mp-sister,mp-lang'
             },
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'application/json');
             var body = res.body;
-            if (!body['mp-topbanner'] || typeof body['mp-topbanner'] !== 'string'
-                    || !body['mp-upper']) {
+            if (!body['mp-sister'] || typeof body['mp-sister'] !== 'string'
+                    || !body['mp-lang']) {
                 throw new Error('Missing section content!');
             }
         })
         .then(function() {
             return preq.get({
-                uri: server.config.bucketURL + '/html/Main_Page',
+                uri: server.config.labsBucketURL + '/html/Main_Page',
                 query: {
-                    sections: 'mp-topbanner'
+                    sections: 'mp-sister'
                 },
             });
         })
@@ -114,7 +114,7 @@ describe('item requests', function() {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'application/json');
             var body = res.body;
-            if (!body['mp-topbanner'] || typeof body['mp-topbanner'] !== 'string') {
+            if (!body['mp-sister'] || typeof body['mp-sister'] !== 'string') {
                 throw new Error('Missing section content!');
             }
         });
@@ -122,7 +122,7 @@ describe('item requests', function() {
 
     it('section retrieval: error handling', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/Main_Page/664887982',
+            uri: server.config.labsBucketURL + '/html/Main_Page/262492',
             query: {
                 sections: 'somethingThatDoesNotExist'
             },
@@ -202,24 +202,24 @@ describe('item requests', function() {
 
     it('should list revisions for a title', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/title/Foobar/'
+            uri: server.config.labsBucketURL + '/title/Foobar/'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'application/json');
-            assert.deepEqual(res.body.items, [624484477]);
+            assert.deepEqual(res.body.items, [252937]);
             pagingToken = res.body._links.next.href;
         });
     });
 
     it('should list next set of revisions for a title using pagination', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/title/Foobar/' + pagingToken
+            uri: server.config.labsBucketURL + '/title/Foobar/' + pagingToken
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'application/json');
-            assert.deepEqual(res.body.items, [624165266]);
+            assert.deepEqual(res.body.items, [241155]);
         });
     });
     //it('should return a new wikitext revision using proxy handler with id 624165266', function() {

--- a/test/features/pagecontent/rerendering.js
+++ b/test/features/pagecontent/rerendering.js
@@ -19,8 +19,8 @@ describe('page re-rendering', function () {
 
     // A test page that includes the current date, so that it changes if
     // re-rendered more than a second apart.
-    var dynamic1 = '/html/User:GWicke%2fDate/653530930';
-    var dynamic2 = '/html/User:GWicke%2fDate/653529842';
+    var dynamic1 = '/html/User:Pchelolo%2fDate/275850';
+    var dynamic2 = '/html/User:Pchelolo%2fDate/275851';
 
     function hasTextContentType(res) {
         assert.contentType(res, 'text/html');
@@ -31,7 +31,7 @@ describe('page re-rendering', function () {
         var r1etag2;
         var r2etag1;
         return preq.get({
-            uri: server.config.bucketURL + dynamic1
+            uri: server.config.labsBucketURL + dynamic1
         })
         .then(function (res) {
             assert.deepEqual(res.status, 200);
@@ -42,7 +42,7 @@ describe('page re-rendering', function () {
             return P.delay(1500)
             .then(function() {
                 return preq.get({
-                    uri: server.config.bucketURL + dynamic1,
+                    uri: server.config.labsBucketURL + dynamic1,
                     headers: { 'cache-control': 'no-cache' }
                 });
             });
@@ -56,7 +56,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + dynamic1 + '/' + getTid(r1etag1)
+                uri: server.config.labsBucketURL + dynamic1 + '/' + getTid(r1etag1)
             });
         })
         .then(function (res) {
@@ -64,7 +64,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + dynamic1
+                uri: server.config.labsBucketURL + dynamic1
             });
         })
         .then(function (res) {
@@ -72,7 +72,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + dynamic1 + '/' + getTid(r1etag2)
+                uri: server.config.labsBucketURL + dynamic1 + '/' + getTid(r1etag2)
             });
         })
         .then(function (res) {
@@ -80,7 +80,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + dynamic2
+                uri: server.config.labsBucketURL + dynamic2
             });
         })
         .then(function (res) {
@@ -89,7 +89,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + dynamic2 + '/' + getTid(r2etag1)
+                uri: server.config.labsBucketURL + dynamic2 + '/' + getTid(r2etag1)
             });
         })
         .then(function (res) {
@@ -97,7 +97,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + dynamic1
+                uri: server.config.labsBucketURL + dynamic1
             });
         })
         .then(function (res) {
@@ -108,7 +108,7 @@ describe('page re-rendering', function () {
 
     it('should render & re-render independent revisions, if-unmodified-since support', function () {
         return preq.get({
-            uri: server.config.bucketURL + dynamic1,
+            uri: server.config.labsBucketURL + dynamic1,
             headers: {
                 'cache-control': 'no-cache',
                 'if-unmodified-since': 'Wed, 11 Dec 2013 16:00:00 GMT',
@@ -123,8 +123,8 @@ describe('page re-rendering', function () {
     });
 
     // A static test page
-    var static1 = '/html/User:GWicke%2fStatic/653529880';
-    var static2 = '/html/User:GWicke%2fStatic/653529961';
+    var static1 = '/html/User:Pchelolo%2fStatic/275852';
+    var static2 = '/html/User:Pchelolo%2fStatic/275853';
 
     it('should render & re-render independent revisions, but not update unchanged content', function () {
         var r1etag1;
@@ -132,7 +132,7 @@ describe('page re-rendering', function () {
         var r2etag1;
         var tid;
         return preq.get({
-            uri: server.config.bucketURL + static1
+            uri: server.config.labsBucketURL + static1
         })
         .then(function (res) {
             assert.deepEqual(res.status, 200);
@@ -140,7 +140,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + static1,
+                uri: server.config.labsBucketURL + static1,
                 headers: { 'cache-control': 'no-cache' }
             });
         })
@@ -153,7 +153,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + static1 + '/' + getTid(r1etag1)
+                uri: server.config.labsBucketURL + static1 + '/' + getTid(r1etag1)
             });
         })
         .then(function (res) {
@@ -161,7 +161,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + static1
+                uri: server.config.labsBucketURL + static1
             });
         })
         .then(function (res) {
@@ -169,7 +169,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + static1 + '/' + getTid(r1etag2)
+                uri: server.config.labsBucketURL + static1 + '/' + getTid(r1etag2)
             });
         })
         .then(function (res) {
@@ -177,7 +177,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + static2
+                uri: server.config.labsBucketURL + static2
             });
         })
         .then(function (res) {
@@ -186,7 +186,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + static2 + '/' + getTid(r2etag1)
+                uri: server.config.labsBucketURL + static2 + '/' + getTid(r2etag1)
             });
         })
         .then(function (res) {
@@ -194,7 +194,7 @@ describe('page re-rendering', function () {
             hasTextContentType(res);
 
             return preq.get({
-                uri: server.config.bucketURL + static1
+                uri: server.config.labsBucketURL + static1
             });
         })
         .then(function (res) {

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -12,7 +12,7 @@ var NOCK_TESTS = true;
 describe('page save api', function() {
 
     var htmlTitle = 'User:Mobrovac-WMF%2FRB_Save_Api_Test';
-    var uri = server.config.labsURL + '/wikitext/Save_test';
+    var uri = server.config.labsBucketURL + '/wikitext/Save_test';
     var htmlUri = server.config.bucketURL + '/html/' + htmlTitle;
     var wikitextToken = '';
     var htmlToken = '';
@@ -67,7 +67,7 @@ describe('page save api', function() {
                 }),
 
                 preq.get({
-                    uri: server.config.labsURL + '/revision/' + oldWikitextRev
+                    uri: server.config.labsBucketURL + '/revision/' + oldWikitextRev
                 })
                 .then(function(res) {
                     oldWikitextETag = res.headers.etag;
@@ -268,7 +268,7 @@ describe('page save api', function() {
                 assert.deepEqual(res.status, 201);
                 lastWikitextRev = res.body.newrevid;
                 return preq.get({
-                    uri: server.config.labsURL + '/revision/' + lastWikitextRev
+                    uri: server.config.labsBucketURL + '/revision/' + lastWikitextRev
                 });
             })
             .then(function(res) {

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -9,13 +9,12 @@
 var assert = require('../../../utils/assert.js');
 var server = require('../../../utils/server.js');
 var preq   = require('preq');
-var fs     = require('fs');
 
-var revA = '45451075';
-var revB = '623616192';
-var revC = '645915794';
-var title = 'LCX';
-var pageUrl = server.config.bucketURL;
+var revA = '275843';
+var revB = '275844';
+var revC = '275845';
+var title = 'User:Pchelolo%2fOnDemand_Test';
+var pageUrl = server.config.labsBucketURL;
 
 describe('on-demand generation of html and data-parsoid', function() {
     this.timeout(20000);
@@ -207,20 +206,20 @@ describe('on-demand generation of html and data-parsoid', function() {
         .then(function (res) {
             assert.deepEqual(!!res.headers['content-security-policy'], true);
             assert.deepEqual(res.headers['content-security-policy']
-                .indexOf("style-src http://*.wikipedia.org https://*.wikipedia.org 'unsafe-inline'") > 0, true);
+                .indexOf("style-src http://*.wikipedia.beta.wmflabs.org https://*.wikipedia.beta.wmflabs.org 'unsafe-inline'") > 0, true);
         });
     });
 
     it('should honor no-cache on /html/{title} endpoint', function() {
         var testPage = "User:Pchelolo%2fRev_Test";
-        var firstRev = 682093020;
+        var firstRev = 275846;
         // 1. Pull in a non-final revision of a title
         return preq.get({
             uri: pageUrl + '/html/' + testPage + '/' + firstRev
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(/First revision/.test(res.body), true);
+            assert.deepEqual(/First Revision/.test(res.body), true);
             return preq.get({
                 uri: pageUrl + '/html/' + testPage,
                 headers: {
@@ -236,7 +235,7 @@ describe('on-demand generation of html and data-parsoid', function() {
 
     it('should honor no-cache on /html/{title} endpoint with sections', function() {
         var testPage = "User:Pchelolo%2fRev_Section_Test";
-        var firstRev = 682100867;
+        var firstRev = 275848;
         // 1. Pull in a non-final revision of a title
         return preq.get({
             uri: pageUrl + '/html/' + testPage + '/' + firstRev

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -8,8 +8,8 @@ var server = require('../../utils/server.js');
 var preq   = require('preq');
 
 var testPage = {
-    title: 'User:GWicke%2F_restbase_test',
-    revision: '646859921',
+    title: 'User:Pchelolo%2fRestbase_Test',
+    revision: '275854',
     wikitext: '<div id=bar>Selser test'
     // html is fetched dynamically
 };
@@ -21,9 +21,9 @@ describe('transform api', function() {
         return server.start()
         .then(function() {
             return preq.get({
-                uri: server.config.baseURL
-                    + '/page/html/' + testPage.title
-                    + '/' + testPage.revision,
+                uri: server.config.labsBucketURL
+                    + '/html/' + testPage.title
+                    + '/' + testPage.revision
             });
         })
         .then(function (res) {
@@ -35,7 +35,7 @@ describe('transform api', function() {
 
     it('html2html', function () {
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/html/to/html/' + testPage.title
                 + '/' + testPage.revision,
             body: {
@@ -55,7 +55,7 @@ describe('transform api', function() {
 
     it('html2html with body_only', function () {
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/html/to/html/' + testPage.title
                 + '/' + testPage.revision,
             body: {
@@ -76,7 +76,7 @@ describe('transform api', function() {
 
     it('wt2html', function () {
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/wikitext/to/html/User:GWicke%2F_restbase_test',
             body: {
                 wikitext: '== Heading =='
@@ -95,7 +95,7 @@ describe('transform api', function() {
 
     it('wt2html with body_only', function () {
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/wikitext/to/html/User:GWicke%2F_restbase_test',
             body: {
                 wikitext: '== Heading ==',
@@ -116,7 +116,7 @@ describe('transform api', function() {
 
     it('html2wt, no-selser', function () {
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/html/to/wikitext/User:GWicke%2F_restbase_test',
             body: {
                 html: '<body>The modified HTML</body>'
@@ -131,7 +131,7 @@ describe('transform api', function() {
 
     it('html2wt, selser', function () {
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/html/to/wikitext/' + testPage.title
                 + '/' + testPage.revision,
             body: {
@@ -147,7 +147,7 @@ describe('transform api', function() {
 
     it('html2wt with scrub_wikitext', function() {
         return preq.post({
-            uri: server.config.baseURL + '/transform/html/to/wikitext',
+            uri: server.config.labsURL + '/transform/html/to/wikitext',
             body: {
                 html: '<h2></h2>',
                 scrub_wikitext: 1
@@ -161,9 +161,9 @@ describe('transform api', function() {
 
     it('sections2wt, replace', function() {
         var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
-        var pageWithSectionsRev = 669458404;
+        var pageWithSectionsRev = 275834;
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/sections/to/wikitext/'
                 + pageWithSectionsTitle
                 + '/' + pageWithSectionsRev,
@@ -184,9 +184,9 @@ describe('transform api', function() {
 
     it('sections2wt, append', function() {
         var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
-        var pageWithSectionsRev = 669458404;
+        var pageWithSectionsRev = 275834;
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/sections/to/wikitext/'
                 + pageWithSectionsTitle
                 + '/' + pageWithSectionsRev,
@@ -206,9 +206,9 @@ describe('transform api', function() {
 
     it('sections2wt, append, application/json', function() {
         var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
-        var pageWithSectionsRev = 669458404;
+        var pageWithSectionsRev = 275834;
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                 + '/transform/sections/to/wikitext/'
                 + pageWithSectionsTitle
                 + '/' + pageWithSectionsRev,
@@ -235,7 +235,7 @@ describe('transform api', function() {
         var newHtml = testPage.html.replace(/<meta property="mw:TimeUuid" content="([^"]+)"\/?>/,
                 '<meta content="cc8ba6b3-636c-11e5-b601-24b4f65ab671" property="mw:TimeUuid" />');
         return preq.post({
-            uri: server.config.baseURL
+            uri: server.config.labsURL
                     + '/transform/html/to/html/' + testPage.title
                     + '/' + testPage.revision,
             body: {

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -24,7 +24,7 @@ describe('router - misc', function() {
     it('should set a request ID for each sub-request and return it', function() {
         var slice = server.config.logStream.slice();
         return preq.get({
-            uri: server.config.bucketURL + '/html/Foobar',
+            uri: server.config.labsBucketURL + '/html/Foobar',
             headers: {
                 'Cache-Control': 'no-cache'
             }
@@ -45,7 +45,7 @@ describe('router - misc', function() {
         var reqId = 'b6c17ea83d634b31bb28d60aae1caaac';
         var slice = server.config.logStream.slice();
         return preq.get({
-            uri: server.config.bucketURL + '/html/Foobar',
+            uri: server.config.labsBucketURL + '/html/Foobar',
             headers: {
                 'X-Request-Id': reqId
             }
@@ -65,7 +65,7 @@ describe('router - misc', function() {
         var reqId = '9c54ff673d634b31bb28d60aae1cb43c';
         var slice = server.config.logStream.slice();
         return preq.get({
-            uri: server.config.bucketURL + '/foo-bucket/Foobar',
+            uri: server.config.labsBucketURL + '/foo-bucket/Foobar',
             headers: {
                 'X-Request-Id': reqId
             }
@@ -86,7 +86,7 @@ describe('router - misc', function() {
 
     it('should truncate body upon HEAD request', function() {
         return preq.head({
-            uri: server.config.bucketURL + '/html/1912'
+            uri: server.config.labsBucketURL + '/html/Foobar'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);

--- a/test/features/specification/monitoring.js
+++ b/test/features/specification/monitoring.js
@@ -9,7 +9,7 @@ function constructTestCase(title, path, method, request, response) {
     return {
         title: title,
         request: {
-            uri: server.config.baseURL + '/' + (path[0] === '/' ? path.substr(1) : path),
+            uri: path,
             method: method,
             headers: request.headers || {},
             query: request.query,
@@ -45,7 +45,7 @@ function constructTests(spec, defParams) {
         })
         .forEach(function(method) {
             var p = paths[pathStr][method];
-            var uri = new URI(pathStr, {}, true);
+            var uri = new URI(server.config.hostPort + '/{domain}/v1' + pathStr, {}, true);
             if (!p['x-amples']) {
                 throw new Error('Method without examples should decalre x-monitor: false.'
                     + ' Path: ' + pathStr + ' Method: ' + method);
@@ -146,6 +146,8 @@ describe('Monitoring tests', function() {
         })
         .then(function(spec) {
             describe('Monitoring routes', function() {
+                var defaults = spec['x-default-params'] || {};
+                defaults.domain = 'en.wikipedia.beta.wmflabs.org';
                 constructTests(spec, spec['x-default-params'] || {}).forEach(function(testCase) {
                     it(testCase.title, function() {
                         return preq(testCase.request)

--- a/test/features/specification/swagger.js
+++ b/test/features/specification/swagger.js
@@ -12,8 +12,8 @@ var server = require('../../utils/server.js');
     var prereqs = [
         { // transparently create HTML revision id 624484477
             method: 'get',
-            uri: server.config.bucketURL + '/html/Foobar/624484477',
-            body: 'Hello there, this is revision 624484477!'
+            uri: server.config.labsBucketURL + '/html/Foobar/252937',
+            body: 'Hello there, this is revision 252937!'
         }
     ];
 

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -71,7 +71,7 @@ paths:
           description: The domain under which the data resides
           type: string
           required: true
-          default: domain:en.wikipedia.beta.wmflabs.org
+          default: en.wikipedia.beta.wmflabs.org
         - name: title
           in: path
           description: The title of page content

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -30,7 +30,7 @@ paths:
           description: The domain under which the data resides
           type: string
           required: true
-          default: en.wikipedia.org
+          default: en.wikipedia.beta.wmflabs.org
         - name: title
           in: path
           description: The title of page content
@@ -50,7 +50,7 @@ paths:
       x-amples:
         - request:
             params:
-                domain: en.wikipedia.org
+                domain: en.wikipedia.beta.wmflabs.org
                 title: Foobar
           response:
             status: 200
@@ -71,7 +71,7 @@ paths:
           description: The domain under which the data resides
           type: string
           required: true
-          default: en.wikipedia.org
+          default: domain:en.wikipedia.beta.wmflabs.org
         - name: title
           in: path
           description: The title of page content
@@ -91,7 +91,7 @@ paths:
       x-amples:
         - request:
             params:
-                domain: en.wikipedia.org
+                domain: en.wikipedia.beta.wmflabs.org
                 title: Foobar
           response:
             status: 200
@@ -112,7 +112,7 @@ paths:
           description: The domain under which the data resides'
           type: string
           required: true
-          default: en.wikipedia.org
+          default: en.wikipedia.beta.wmflabs.org
         - name: title
           in: path
           description: The title of page content
@@ -141,9 +141,9 @@ paths:
       x-amples:
         - request:
             params:
-                domain: en.wikipedia.org
+                domain: en.wikipedia.beta.wmflabs.org
                 title: Foobar
-                revision: 624484477
+                revision: 252937
           response:
             status: 200
             headers:
@@ -163,7 +163,7 @@ paths:
           description: The domain under which the data resides'
           type: string
           required: true
-          default: en.wikipedia.org
+          default: en.wikipedia.beta.wmflabs.org
         - name: title
           in: path
           description: The title of page content
@@ -192,9 +192,9 @@ paths:
       x-amples:
         - request:
             params:
-                domain: en.wikipedia.org
+                domain: en.wikipedia.beta.wmflabs.org
                 title: Foobar
-                revision: 624484477
+                revision: 252937
           response:
             status: 200
             headers:

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -14,7 +14,8 @@ var hostPort  = 'http://localhost:7231';
 var baseURL   = hostPort + '/en.wikipedia.org/v1';
 var bucketURL = baseURL + '/page';
 var secureURL = hostPort + '/fr.wikipedia.org/v1/page';
-var labsURL   = hostPort + '/en.wikipedia.beta.wmflabs.org/v1/page';
+var labsURL   = hostPort + '/en.wikipedia.beta.wmflabs.org/v1';
+var labsBucketURL = labsURL + '/page';
 
 function loadConfig(path) {
     var confString = fs.readFileSync(path).toString();
@@ -36,6 +37,7 @@ var config = {
     bucketURL: bucketURL,
     secureURL: secureURL,
     labsURL: labsURL,
+    labsBucketURL: labsBucketURL,
     logStream: logStream(),
     conf: loadConfig(__dirname + '/../../config.test.yaml')
 };


### PR DESCRIPTION
Changed tests to use http://parsoid-beta.wmflabs.org/ parsoid endpoint and created required pages in labs wiki. Tests which don't use parsoid were left intact.

Bug: https://phabricator.wikimedia.org/T110711