### PR TITLE
Public AQS endpoints for global domain

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -204,7 +204,10 @@ templates:
     securityDefinitions: *wp/content-security/1.0.0
     x-subspecs:
       - media/v1/mathoid
-
+    paths:
+      /metrics:
+        x-subspecs:
+          - analytics/v1/pageviews
 
   global-sys: &gb/sys/1.0.0
     info:
@@ -296,6 +299,24 @@ templates:
                   headers: '{$$.merge($.mathoid.body[$.request.params.format].headers,$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location}))}'
                   body: '{$.mathoid.body[$.request.params.format].body}'
 
+      /{module:pageviews}/per-article/{+rest}:
+        get:
+          x-request-handler:
+            - get_from_backend:
+                request:
+                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/{rest}
+      /{module:pageviews}/per-project/{+rest}:
+        get:
+          x-request-handler:
+            - get_from_backend:
+                request:
+                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/aggregate/{rest}
+      /{module:pageviews}/top/{+rest}:
+        get:
+          x-request-handler:
+            - get_from_backend:
+                request:
+                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/top/{rest}
 
   wp-default-1.0.0: &wp/default/1.0.0
     x-subspecs:

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -304,19 +304,19 @@ templates:
           x-request-handler:
             - get_from_backend:
                 request:
-                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/{rest}
+                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/{+rest}
       /{module:pageviews}/per-project/{+rest}:
         get:
           x-request-handler:
             - get_from_backend:
                 request:
-                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/aggregate/{rest}
+                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/aggregate/{+rest}
       /{module:pageviews}/top/{+rest}:
         get:
           x-request-handler:
             - get_from_backend:
                 request:
-                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/top/{rest}
+                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/top/{+rest}
 
   wp-default-1.0.0: &wp/default/1.0.0
     x-subspecs:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -280,7 +280,6 @@ templates:
       /{module:pageviews}:
         x-modules:
           - name: pageviews
-            version: 1.0.0
             type: file
 
   wp-default-1.0.0: &wp/default/1.0.0

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -39,7 +39,6 @@ templates:
       - mediawiki/v1/graphoid
       - mediawiki/v1/mobileapps
       - media/v1/mathoid
-      - analytics/v1/pageviews
       - test
     securityDefinitions: &wp/content-security/1.0.0
       mediawiki_auth:
@@ -179,19 +178,14 @@ templates:
                       request:
                         uri: http://appservice.wmflabs.org/{domain}/v1/page/mobile-text/{title}
 
-      /{module:pageviews}:
-        x-modules:
-          - name: pageviews
-            version: 1.0.0
-            type: file
-
-
   global-content: &gb/content/1.0.0
     swagger: '2.0'
     info: *wp/content-info/1.0.0
     securityDefinitions: *wp/content-security/1.0.0
     x-subspecs:
       - media/v1/mathoid
+      - analytics/v1/pageviews
+      - test
 
 
   global-sys: &gb/sys/1.0.0
@@ -283,7 +277,11 @@ templates:
                   status: 200
                   headers: '{$$.merge($.mathoid.body[$.request.params.format].headers,$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location}))}'
                   body: '{$.mathoid.body[$.request.params.format].body}'
-
+      /{module:pageviews}:
+        x-modules:
+          - name: pageviews
+            version: 1.0.0
+            type: file
 
   wp-default-1.0.0: &wp/default/1.0.0
     x-subspecs:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "preq": "^0.4.4",
     "restbase-mod-table-cassandra": "^0.8.0",
     "service-runner": "^0.2.10",
-    "swagger-router": "^0.2.0",
+    "swagger-router": "^0.2.3",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "tassembly": "^0.2.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",

--- a/specs/analytics/v1/pageviews.yaml
+++ b/specs/analytics/v1/pageviews.yaml
@@ -37,7 +37,6 @@ paths:
     get:
       tags:
         - Pageviews data
-        - per-article
       description: >
         List pageviews for a given article in a project, over a given time period.
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
@@ -97,11 +96,10 @@ paths:
               uri: /{domain}/sys/pageviews/per-article/{project}/{access}/{agent}/{article}/{granularity}/{start}/{end}
       x-monitor: false
 
-  /{module:pageviews}/per-project/{project}/{access}/{agent}/{granularity}/{start}/{end}:
+  /{module:pageviews}/aggregate/{project}/{access}/{agent}/{granularity}/{start}/{end}:
     get:
       tags:
         - Pageviews data
-        - per-project
       description: >
         List pageviews for a given project, over a given time period.
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
@@ -154,13 +152,35 @@ paths:
         - get_from_backend:
             request:
               uri: /{domain}/sys/pageviews/per-project/{project}/{access}/{agent}/{granularity}/{start}/{end}
-      x-monitor: false
+      x-monitor: true
+      x-amples:
+        - title: Get aggregate page views
+          request:
+            params:
+              project: en.wikipedia
+              access: mobile-app
+              agent: spider
+              granularity: hourly
+              start: 2015070100
+              end: 2015070102
+          response:
+            status: 200
+            headers:
+              content-type: application/json
+            body:
+              count: 1
+              items:
+                - project: en.wikipedia
+                  access: mobile-app
+                  agent: spider
+                  granularity: hourly
+                  timestamp: 2015070101
+                  views: 1000
 
   /{module:pageviews}/top/{project}/{access}/{year}/{month}/{day}:
     get:
       tags:
         - Pageviews data
-        - Top articles
       description: >
         List the 1000 most viewed articles for a given project, for all time, or during a specific year, month, or day.
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
@@ -207,7 +227,6 @@ paths:
             request:
               uri:  /{domain}/sys/pageviews/top/{project}/{access}/{year}/{month}/{day}
       x-monitor: false
-
 
 definitions:
   # A https://tools.ietf.org/html/draft-nottingham-http-problem

--- a/specs/analytics/v1/pageviews.yaml
+++ b/specs/analytics/v1/pageviews.yaml
@@ -168,7 +168,6 @@ paths:
             headers:
               content-type: application/json
             body:
-              count: 1
               items:
                 - project: en.wikipedia
                   access: mobile-app

--- a/specs/analytics/v1/pageviews.yaml
+++ b/specs/analytics/v1/pageviews.yaml
@@ -158,11 +158,11 @@ paths:
           request:
             params:
               project: en.wikipedia
-              access: mobile-app
-              agent: spider
+              access: all-access
+              agent: all-agents
               granularity: hourly
-              start: 2015070100
-              end: 2015070102
+              start: 1970010100
+              end: 1970010100
           response:
             status: 200
             headers:
@@ -170,11 +170,11 @@ paths:
             body:
               items:
                 - project: en.wikipedia
-                  access: mobile-app
-                  agent: spider
+                  access: all-access
+                  agent: all-agents
                   granularity: hourly
-                  timestamp: 2015070101
-                  views: 1000
+                  timestamp: 1970010100
+                  views: 0
 
   /{module:pageviews}/top/{project}/{access}/{year}/{month}/{day}:
     get:

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -117,7 +117,7 @@ paths:
                   views: '{$.request.params.views}'
       x-monitor: false
 
-  /{module:pageviews}/insert-per-project/{project}/{access}/{agent}/{granularity}/{timestamp}/{views}:
+  /{module:pageviews}/insert-aggregate/{project}/{access}/{agent}/{granularity}/{timestamp}/{views}:
     post:
       x-request-handler:
         - put_to_storage:

--- a/test/features/pageviews/pageviews.js
+++ b/test/features/pageviews/pageviews.js
@@ -15,12 +15,12 @@ describe('pageviews endpoints', function () {
     before(function () { return server.start(); });
 
     var articleEndpoint = '/pageviews/per-article/en.wikipedia/desktop/spider/one/daily/2015070100/2015070300';
-    var projectEndpoint = '/pageviews/aggregate/en.wikipedia/mobile-app/spider/hourly/2015070100/2015070102';
+    var projectEndpoint = '/pageviews/aggregate/en.wikipedia/all-access/all-agents/hourly/1969010100/1971010100';
     var topsEndpoint = '/pageviews/top/en.wikipedia/mobile-web/2015/all-months/all-days';
 
     // Fake data insertion endpoints
     var insertArticleEndpoint = '/pageviews/insert-per-article/en.wikipedia/desktop/spider/one/daily/2015070200';
-    var insertProjectEndpoint = '/pageviews/insert-aggregate/en.wikipedia/mobile-app/spider/hourly/2015070101';
+    var insertProjectEndpoint = '/pageviews/insert-aggregate/en.wikipedia/all-access/all-agents/hourly/1970010100';
     var insertTopsEndpoint = '/pageviews/insert-top/en.wikipedia/mobile-web/2015/all-months/all-days/';
 
     // Test Article Endpoint
@@ -51,7 +51,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when aggregate parameters are wrong', function () {
         return preq.get({
-            uri: server.config.globalURL + projectEndpoint.replace('2015070100', '20150701000000')
+            uri: server.config.globalURL + projectEndpoint.replace('1971010100', '20150701000000')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -59,7 +59,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when start is before end', function () {
         return preq.get({
-            uri: server.config.globalURL + projectEndpoint.replace('2015070100', '2016070100')
+            uri: server.config.globalURL + projectEndpoint.replace('1969010100', '2016070100')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -67,7 +67,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when timestamp is invalid', function () {
         return preq.get({
-            uri: server.config.globalURL + projectEndpoint.replace('2015070100', '2015022900')
+            uri: server.config.globalURL + projectEndpoint.replace('1971010100', '2015022900')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -75,14 +75,14 @@ describe('pageviews endpoints', function () {
 
     it('should return the expected aggregate data after insertion', function () {
         return preq.post({
-            uri: server.config.globalURL + insertProjectEndpoint + '/1000'
+            uri: server.config.globalURL + insertProjectEndpoint + '/0'
         }).then(function() {
             return preq.get({
                 uri: server.config.globalURL + projectEndpoint
             });
         }).then(function(res) {
             assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0].views, 1000);
+            assert.deepEqual(res.body.items[0].views, 0);
         });
     });
 

--- a/test/features/pageviews/pageviews.js
+++ b/test/features/pageviews/pageviews.js
@@ -15,19 +15,19 @@ describe('pageviews endpoints', function () {
     before(function () { return server.start(); });
 
     var articleEndpoint = '/pageviews/per-article/en.wikipedia/desktop/spider/one/daily/2015070100/2015070300';
-    var projectEndpoint = '/pageviews/per-project/en.wikipedia/mobile-app/spider/hourly/2015070100/2015070102';
+    var projectEndpoint = '/pageviews/aggregate/en.wikipedia/mobile-app/spider/hourly/2015070100/2015070102';
     var topsEndpoint = '/pageviews/top/en.wikipedia/mobile-web/2015/all-months/all-days';
 
     // Fake data insertion endpoints
     var insertArticleEndpoint = '/pageviews/insert-per-article/en.wikipedia/desktop/spider/one/daily/2015070200';
-    var insertProjectEndpoint = '/pageviews/insert-per-project/en.wikipedia/mobile-app/spider/hourly/2015070101';
+    var insertProjectEndpoint = '/pageviews/insert-aggregate/en.wikipedia/mobile-app/spider/hourly/2015070101';
     var insertTopsEndpoint = '/pageviews/insert-top/en.wikipedia/mobile-web/2015/all-months/all-days/';
 
     // Test Article Endpoint
 
     it('should return 400 when per article parameters are wrong', function () {
         return preq.get({
-            uri: server.config.baseURL + articleEndpoint.replace('2015070300', '201507a300')
+            uri: server.config.globalURL + articleEndpoint.replace('2015070300', '201507a300')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -35,10 +35,10 @@ describe('pageviews endpoints', function () {
 
     it('should return the expected per article data after insertion', function () {
         return preq.post({
-            uri: server.config.baseURL + insertArticleEndpoint + '/100'
+            uri: server.config.globalURL + insertArticleEndpoint + '/100'
         }).then(function() {
             return preq.get({
-                uri: server.config.baseURL + articleEndpoint
+                uri: server.config.globalURL + articleEndpoint
             });
         }).then(function(res) {
             assert.deepEqual(res.body.items.length, 1);
@@ -49,9 +49,9 @@ describe('pageviews endpoints', function () {
 
     // Test Project Endpoint
 
-    it('should return 400 when per project parameters are wrong', function () {
+    it('should return 400 when aggregate parameters are wrong', function () {
         return preq.get({
-            uri: server.config.baseURL + projectEndpoint.replace('2015070100', '20150701000000')
+            uri: server.config.globalURL + projectEndpoint.replace('2015070100', '20150701000000')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -59,7 +59,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when start is before end', function () {
         return preq.get({
-            uri: server.config.baseURL + projectEndpoint.replace('2015070100', '2016070100')
+            uri: server.config.globalURL + projectEndpoint.replace('2015070100', '2016070100')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -67,18 +67,18 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when timestamp is invalid', function () {
         return preq.get({
-            uri: server.config.baseURL + projectEndpoint.replace('2015070100', '2015022900')
+            uri: server.config.globalURL + projectEndpoint.replace('2015070100', '2015022900')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
     });
 
-    it('should return the expected per project data after insertion', function () {
+    it('should return the expected aggregate data after insertion', function () {
         return preq.post({
-            uri: server.config.baseURL + insertProjectEndpoint + '/1000'
+            uri: server.config.globalURL + insertProjectEndpoint + '/1000'
         }).then(function() {
             return preq.get({
-                uri: server.config.baseURL + projectEndpoint
+                uri: server.config.globalURL + projectEndpoint
             });
         }).then(function(res) {
             assert.deepEqual(res.body.items.length, 1);
@@ -91,7 +91,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when tops parameters are wrong', function () {
         return preq.get({
-            uri: server.config.baseURL + topsEndpoint.replace('all-months', 'all-monthz')
+            uri: server.config.globalURL + topsEndpoint.replace('all-months', 'all-monthz')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -99,7 +99,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when tops date is invalid', function () {
         return preq.get({
-            uri: server.config.baseURL + topsEndpoint.replace('all-months/all-days', '02/29')
+            uri: server.config.globalURL + topsEndpoint.replace('all-months/all-days', '02/29')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -107,7 +107,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when tops parameters are using "all-months" wrong', function () {
         return preq.get({
-            uri: server.config.baseURL + topsEndpoint.replace('all-days', '01')
+            uri: server.config.globalURL + topsEndpoint.replace('all-days', '01')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -115,14 +115,14 @@ describe('pageviews endpoints', function () {
 
     it('should return the expected tops data after insertion', function () {
         return preq.post({
-            uri: server.config.baseURL + insertTopsEndpoint + JSON.stringify([{
+            uri: server.config.globalURL + insertTopsEndpoint + JSON.stringify([{
                 rank: 1,
                 article: 'one',
                 views: 2000
             }])
         }).then(function() {
             return preq.get({
-                uri: server.config.baseURL + topsEndpoint
+                uri: server.config.globalURL + topsEndpoint
             });
         }).then(function(res) {
             assert.deepEqual(res.body.items.length, 1);

--- a/test/features/specification/monitoring.js
+++ b/test/features/specification/monitoring.js
@@ -157,7 +157,11 @@ describe('Monitoring tests', function() {
             .then(function(spec) {
                 describe('Monitoring routes, ' + options.domain + ' domain', function() {
                     var defaults = spec['x-default-params'] || {};
-                    defaults.domain = options.domain;
+                    if (options.domain === 'en.wikipedia.org') {
+                        defaults.domain = 'en.wikipedia.beta.wmflabs.org';
+                    } else {
+                        defaults.domain = options.domain;
+                    }
                     constructTests(spec, defaults).forEach(function(testCase) {
                         it(testCase.title, function() {
                             return preq(testCase.request)

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -12,6 +12,7 @@ var yaml      = require('js-yaml');
 
 var hostPort  = 'http://localhost:7231';
 var baseURL   = hostPort + '/en.wikipedia.org/v1';
+var globalURL = hostPort + '/wikimedia.org/v1';
 var bucketURL = baseURL + '/page';
 var secureURL = hostPort + '/fr.wikipedia.org/v1/page';
 var labsURL   = hostPort + '/en.wikipedia.beta.wmflabs.org/v1';
@@ -34,6 +35,7 @@ function loadConfig(path) {
 var config = {
     hostPort: hostPort,
     baseURL: baseURL,
+    globalURL: globalURL,
     bucketURL: bucketURL,
     secureURL: secureURL,
     labsURL: labsURL,


### PR DESCRIPTION
1. Introduced `/metrics/pageviews` endpoints for global domain
2. Renamed `per-project` to `aggregate`
3. Moved pageviews module testing from `en.wikipedia.org` to global domain, so that it's fake data could be used in monitoring tests, and because in backend RB it's used on a global domain.
4. Introduced an `x-ample` for one of the page views endpoints
5. Made monitoring tests run for `wikimedia.org` domain as well as for `en.wikipedia.org`
6. Removed `per-article`, `per-project` and `tops` tags from page views endpoints. Swagger gives it's own section for each tag and it looks really ugly to have all these tags with a single endpoint. Could be added back when needed.

Note: in `config.example.wikimedia.yaml` the endpoints are proxied to frontend RESTBase, so testing pageviews endpoints manually with curl wouldn't be possible until this is deployed. It's kinda cyclic reference..

CC @wikimedia/services @milimetric 