### PR TITLE
Set up a testing db name for sqlite testing mode

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -75,6 +75,7 @@ templates:
             # See: https://github.com/wikimedia/restbase-mod-table-cassandra/blob/master/Readme.md#configuration
             options: # Passed to the module constructor
               conf:
+                dbname: test.db.sqlite3 # ignored in cassandra, but useful in SQLite testing
                 hosts: [localhost]
                 keyspace: system
                 username: cassandra

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -8,7 +8,7 @@ runTest ( ) {
     if [ "$1" = "sqlite" ]; then
         echo "Running with SQLite backend"
         export RB_TEST_BACKEND=sqlite
-        rm -f restbase
+        rm -f test.db.sqlite3
     else
         echo "Running with Cassandra backend"
         export RB_TEST_BACKEND=cassandra


### PR DESCRIPTION
Super-minor: don't rely on default DB name for SQLite testing mode.