### PR TITLE
Added a x-host-basePath to the example wikimedia config

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -35,6 +35,9 @@ templates:
       license:
         name: Apache2
         url: http://www.apache.org/licenses/LICENSE-2.0
+    # Override the base path for host-based (proxied) requests. In our case,
+    # we proxy https://{domain}/api/rest_v1/ to the API.
+    x-host-basePath: /api/rest_v1
     x-subspecs:
       - mediawiki/v1/content
       - mediawiki/v1/graphoid
@@ -328,6 +331,9 @@ templates:
     swagger: '2.0'
     info: *wp/content-info/1.0.0
     securityDefinitions: *wp/content-security/1.0.0
+    # Override the base path for host-based (proxied) requests. In our case,
+    # we proxy https://{domain}/api/rest_v1/ to the API.
+    x-host-basePath: /api/rest_v1
     x-subspecs:
       - media/v1/mathoid
     paths:


### PR DESCRIPTION
Swagger-UI doesn't work for global domain on https://wikimedia.org/api/rest_v1/?doc , because we've forgot to add `x-host-basePath` to the global domain content spec.