### PR TITLE
Added a .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+coverage
+node_modules


### PR DESCRIPTION
We need a `.dockerignore` to be able to test/build restbase with docker