### PR TITLE
More features added to the validator

### DIFF
--- a/doc/HandlerConfiguration.md
+++ b/doc/HandlerConfiguration.md
@@ -1,7 +1,7 @@
 # Declarative request handler definition
 
-## General madel
-On each endpont there could be two high-level blocks: `x-setup-handler` and `x-request-handler`. 
+## General model
+On each endpoint there could be two high-level blocks: `x-setup-handler` and `x-request-handler`. 
 The former is run during RESTBase start-up and is optional, while the latter is executed on every 
 incoming request and can be made up of multiple requests (further referred to as request blocks).
 

--- a/doc/Implementation.md
+++ b/doc/Implementation.md
@@ -129,6 +129,14 @@ wikis.
 
 TODO: Actually think this through more thoroughly.
 
+### Request validation
+Swagger spec could contain a specification of request parameters in `parameters` section.
+The list of options is described in 
+[Swagger Specification](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#parameterObject)
+On spec loading, `parameters` sections for each endpoint is picked up and compiled into a
+request validator function, that it called before each request. If the some parameter didn't
+match the specification, HTTP 400 error is returned without execution of a request handler.
+
 ## Internal request & response objects
 ### Request
 ```javascript

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -7,7 +7,8 @@ var inMapping = {
     path: 'params',
     query: 'query',
     header: 'headers',
-    formData: 'body'
+    formData: 'body',
+    body: 'body'
 };
 
 /**
@@ -34,11 +35,28 @@ function convertToJsonSchema(parameters) {
             schema.required = schema.required || [];
             schema.required.push(inMapping[param.in]);
         }
-        var reqPartSchema = schema.properties[inMapping[param.in]];
-        reqPartSchema.properties[param.name] = {};
-        if (param.required) {
-            reqPartSchema.required = reqPartSchema.required || [];
-            reqPartSchema.required.push(param.name);
+        if (param.in !== 'body') {
+            var reqPartSchema = schema.properties[inMapping[param.in]];
+            var paramSchema = {};
+            // We can't type-check directly, because everything come in as a string
+            if (param.type === 'number' || param.type === 'integer') {
+                paramSchema.type = 'string';
+                paramSchema.pattern = '^\\d+$';
+            } else if (param.type === 'boolean') {
+                paramSchema.type = 'string';
+                paramSchema.pattern = '^(?:true)|(?:false)|(?:1)|(?:0)$';
+            } else if (param.type === 'string') {
+                paramSchema.type = 'string';
+                paramSchema.enum = param.enum;
+                paramSchema.maxLength = param.maxLength;
+                paramSchema.minLength = param.minLength;
+                paramSchema.pattern = param.pattern;
+            }
+            reqPartSchema.properties[param.name] = paramSchema;
+            if (param.required) {
+                reqPartSchema.required = reqPartSchema.required || [];
+                reqPartSchema.required.push(param.name);
+            }
         }
     });
 
@@ -52,6 +70,7 @@ var Validator = function(parameters) {
 
 Validator.prototype.validate = function(req) {
     if (!this._validatorFunc(req)) {
+        console.log(ajv.errorsText(this._validatorFunc.errors));
         throw new HTTPError({
             status: 400,
             body: {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -28,7 +28,7 @@ Validator.prototype._convertToJsonSchema = function(parameters) {
         type: 'object',
         properties: {}
     };
-    
+
     parameters.forEach(function(param) {
         if (param.in !== 'body') {
             if (!schema.properties[inMapping[param.in]]) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -124,8 +124,8 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
         var paramAccessor = 'req.' + inMapping[param.in] + '["' + param.name + '"]';
         var paramCoercionCode;
         var errorNotifier = 'throw new HTTPError({status:400,body:{type:"bad_request",'
-                + 'title:"data.' + inMapping[param.in] + '.' + param.name
-                + ' should be ' + param.type + '"}});\n';
+                + ' title:"Invalid parameters", detail: "data.'
+                + inMapping[param.in] + '.' + param.name + ' should be ' + param.type + '"}});\n';
 
         switch (param.type) {
             case 'integer':
@@ -137,10 +137,10 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
                     + 'if (Number.isNaN(' + paramAccessor + ')) {\n' + errorNotifier + '}\n';
                 break;
             case 'boolean':
-                paramCoercionCode = 'if(!/^(?:true)|(?:false)|(?:1)|(?:0)$/.test('
+                paramCoercionCode = 'if(!/^true|false|1|0$/.test('
                     + paramAccessor + '.toString())) {\n'
                     + errorNotifier + '}\n'
-                    + paramAccessor + ' = /^(?:true)|(?:1)$/.test('
+                    + paramAccessor + ' = /^true|1$/.test('
                     + paramAccessor + '.toString());\n';
         }
 
@@ -157,7 +157,7 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
         code += paramCoercionCode;
     });
     if (code && code.trim()) {
-        code += 'return req;\n';
+        code += '\nreturn req;\n';
         /*jshint evil:true */
         return new Function('req', 'HTTPError', code);
     } else {
@@ -178,7 +178,8 @@ Validator.prototype.validate = function(req) {
             status: 400,
             body: {
                 type: 'bad_request',
-                title: this._ajv.errorsText(this._validatorFunc.errors),
+                title: 'Invalid parameters',
+                detail: this._ajv.errorsText(this._validatorFunc.errors),
                 req: req
             }
         });

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -123,25 +123,32 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
         }
         var paramAccessor = 'req.' + inMapping[param.in] + '["' + param.name + '"]';
         var paramCoercionCode;
-        var errorNotifier = 'throw new HTTPError({status:400,body:{type:"bad_request",'
-                + ' title:"Invalid parameters", detail: "data.'
-                + inMapping[param.in] + '.' + param.name + ' should be ' + param.type + '"}});\n';
-
+        var errorNotifier;
         switch (param.type) {
             case 'integer':
+                errorNotifier = 'throw new HTTPError({status:400,body:{type:"bad_request",'
+                    + ' title:"Invalid parameters", detail: "data.'
+                    + inMapping[param.in] + '.' + param.name + ' should be an integer"}});\n';
                 paramCoercionCode = paramAccessor + ' = parseInt(' + paramAccessor + ');\n'
                     + 'if (!Number.isInteger(' + paramAccessor + ')) {\n' + errorNotifier + '}\n';
                 break;
             case 'number':
+                errorNotifier = 'throw new HTTPError({status:400,body:{type:"bad_request",'
+                    + ' title:"Invalid parameters", detail: "data.'
+                    + inMapping[param.in] + '.' + param.name + ' should be a number"}});\n';
                 paramCoercionCode = paramAccessor + ' = parseFloat(' + paramAccessor + ');\n'
                     + 'if (Number.isNaN(' + paramAccessor + ')) {\n' + errorNotifier + '}\n';
                 break;
             case 'boolean':
+                errorNotifier = 'throw new HTTPError({status:400,body:{type:"bad_request",'
+                    + ' title:"Invalid parameters", detail: "data.'
+                    + inMapping[param.in] + '.' + param.name + ' should be a boolean.'
+                    + ' true|false|1|0 is accepted as a boolean."}});\n';
                 paramCoercionCode = 'if(!/^true|false|1|0$/.test('
-                    + paramAccessor + '.toString())) {\n'
+                    + paramAccessor + ' + "")) {\n'
                     + errorNotifier + '}\n'
                     + paramAccessor + ' = /^true|1$/.test('
-                    + paramAccessor + '.toString());\n';
+                    + paramAccessor + ' + "");\n';
         }
 
         if (!paramCoercionCode) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -28,7 +28,7 @@ Validator.prototype._convertToJsonSchema = function(parameters) {
         type: 'object',
         properties: {}
     };
-
+    
     parameters.forEach(function(param) {
         if (param.in !== 'body') {
             if (!schema.properties[inMapping[param.in]]) {
@@ -45,7 +45,10 @@ Validator.prototype._convertToJsonSchema = function(parameters) {
             var reqPartSchema = schema.properties[inMapping[param.in]];
             var paramSchema = {};
             // We can't type-check directly, because everything come in as a string
-            if (param.type === 'number' || param.type === 'integer') {
+            if (param.type === 'number') {
+                paramSchema.type = 'string';
+                paramSchema.pattern = '^\\d+(?:[\\.,]\\d+)?$';
+            } else if (param.type === 'integer') {
                 paramSchema.type = 'string';
                 paramSchema.pattern = '^\\d+$';
             } else if (param.type === 'boolean') {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var HTTPError = require('./rbUtil').HTTPError;
-var ajv = require('ajv')();
+var constructAjv = require('ajv');
 
 var inMapping = {
     path: 'params',
@@ -11,6 +11,11 @@ var inMapping = {
     body: 'body'
 };
 
+var Validator = function(parameters) {
+    this._ajv = constructAjv();
+    this._validatorFunc = this._ajv.compile(this._convertToJsonSchema(parameters));
+};
+
 /**
  * Converts a list of parameters from a swagger spec
  * to JSON-schema for a request
@@ -18,24 +23,25 @@ var inMapping = {
  * @param parameters list of params
  * @returns JSON schema
  */
-function convertToJsonSchema(parameters) {
+Validator.prototype._convertToJsonSchema = function(parameters) {
     var schema = {
         type: 'object',
         properties: {}
     };
 
     parameters.forEach(function(param) {
-        if (!schema.properties[inMapping[param.in]]) {
-            schema.properties[inMapping[param.in]] = {
-                type: 'object',
-                properties: {}
-            };
-            // 'required' array must have at least one element according to json-schema spec,
-            // se we can't preinitialize it.
-            schema.required = schema.required || [];
-            schema.required.push(inMapping[param.in]);
-        }
         if (param.in !== 'body') {
+            if (!schema.properties[inMapping[param.in]]) {
+                schema.properties[inMapping[param.in]] = {
+                    type: 'object',
+                    properties: {}
+                };
+                // 'required' array must have at least one element according to json-schema spec,
+                // se we can't preinitialize it.
+                schema.required = schema.required || [];
+                schema.required.push(inMapping[param.in]);
+            }
+
             var reqPartSchema = schema.properties[inMapping[param.in]];
             var paramSchema = {};
             // We can't type-check directly, because everything come in as a string
@@ -57,25 +63,31 @@ function convertToJsonSchema(parameters) {
                 reqPartSchema.required = reqPartSchema.required || [];
                 reqPartSchema.required.push(param.name);
             }
+        } else {
+            if (param.schema) {
+                schema.properties.body = param.schema;
+            } else {
+                schema.properties.body = {
+                    type: 'object'
+                };
+            }
+            if (param.required) {
+                schema.required = schema.required || [];
+                schema.required.push('body');
+            }
         }
     });
 
     return schema;
-}
-
-var Validator = function(parameters) {
-    this.parameters = parameters;
-    this._validatorFunc = ajv.compile(convertToJsonSchema(parameters));
 };
 
 Validator.prototype.validate = function(req) {
     if (!this._validatorFunc(req)) {
-        console.log(ajv.errorsText(this._validatorFunc.errors));
         throw new HTTPError({
             status: 400,
             body: {
                 type: 'bad_request',
-                title: ajv.errorsText(this._validatorFunc.errors),
+                title: this._ajv.errorsText(this._validatorFunc.errors),
                 req: req
             }
         });

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -3,6 +3,12 @@
 var HTTPError = require('./rbUtil').HTTPError;
 var constructAjv = require('ajv');
 
+/**
+ * Mapping of `param.in` field to the name of a request part.
+ *
+ * @const
+ * @type {{path: string, query: string, header: string, formData: string, body: string}}
+ */
 var inMapping = {
     path: 'params',
     query: 'query',
@@ -11,8 +17,35 @@ var inMapping = {
     body: 'body'
 };
 
+/**
+ * Supported field validators.
+ *
+ * @const
+ * @type {string[]}
+ */
+var supportedValidators = ['maximum',
+    'exclusiveMaximum',
+    'minimum',
+    'exclusiveMinimum',
+    'maxLength',
+    'minLength',
+    'pattern',
+    'maxItems',
+    'minItems',
+    'uniqueItems',
+    'enum',
+    'multipleOf'];
+
+/**
+ * Constructs a request validator, according to swagger parameters specification.
+ * A returned object contains a single `validate(req)` function.
+ *
+ * @param parameters {Array} swagger parameters spec
+ * @constructor
+ */
 var Validator = function(parameters) {
     this._ajv = constructAjv();
+    this._typeCoercionFunc = this._createTypeCoercionFunc(parameters);
     this._validatorFunc = this._ajv.compile(this._convertToJsonSchema(parameters));
 };
 
@@ -21,7 +54,8 @@ var Validator = function(parameters) {
  * to JSON-schema for a request
  *
  * @param parameters list of params
- * @returns JSON schema
+ * @returns {Object} JSON schema
+ * @private
  */
 Validator.prototype._convertToJsonSchema = function(parameters) {
     var schema = {
@@ -39,28 +73,16 @@ Validator.prototype._convertToJsonSchema = function(parameters) {
                 // 'required' array must have at least one element according to json-schema spec,
                 // se we can't preinitialize it.
                 schema.required = schema.required || [];
-                schema.required.push(inMapping[param.in]);
+                if (schema.required.indexOf(inMapping[param.in]) < 0) {
+                    schema.required.push(inMapping[param.in]);
+                }
             }
 
             var reqPartSchema = schema.properties[inMapping[param.in]];
-            var paramSchema = {};
-            // We can't type-check directly, because everything come in as a string
-            if (param.type === 'number') {
-                paramSchema.type = 'string';
-                paramSchema.pattern = '^\\d+(?:[\\.,]\\d+)?$';
-            } else if (param.type === 'integer') {
-                paramSchema.type = 'string';
-                paramSchema.pattern = '^\\d+$';
-            } else if (param.type === 'boolean') {
-                paramSchema.type = 'string';
-                paramSchema.pattern = '^(?:true)|(?:false)|(?:1)|(?:0)$';
-            } else if (param.type === 'string') {
-                paramSchema.type = 'string';
-                paramSchema.enum = param.enum;
-                paramSchema.maxLength = param.maxLength;
-                paramSchema.minLength = param.minLength;
-                paramSchema.pattern = param.pattern;
-            }
+            var paramSchema = { type: param.type };
+            supportedValidators.forEach(function(validator) {
+                paramSchema[validator] = param[validator];
+            });
             reqPartSchema.properties[param.name] = paramSchema;
             if (param.required) {
                 reqPartSchema.required = reqPartSchema.required || [];
@@ -84,7 +106,73 @@ Validator.prototype._convertToJsonSchema = function(parameters) {
     return schema;
 };
 
+/**
+ * Creates a function, that tries to coerce types of parameters in the
+ * incoming request, according to the provided parameters specification.
+ *
+ * @param parameters {Array} parameters swagger specification
+ * @returns {Function(req, HTTPError)} cersion function
+ * @private
+ */
+Validator.prototype._createTypeCoercionFunc = function(parameters) {
+    var code = '';
+    parameters.forEach(function(param) {
+        if (param.type === 'string') {
+            // Don't need to process strings
+            return;
+        }
+        var paramAccessor = 'req.' + inMapping[param.in] + '["' + param.name + '"]';
+        var paramCoercionCode;
+        var errorNotifier = 'throw new HTTPError({status:400,body:{type:"bad_request",'
+                + 'title:"data.' + inMapping[param.in] + '.' + param.name
+                + ' should be ' + param.type + '"}});\n';
+
+        switch (param.type) {
+            case 'integer':
+                paramCoercionCode = paramAccessor + ' = parseInt(' + paramAccessor + ');\n'
+                    + 'if (!Number.isInteger(' + paramAccessor + ')) {\n' + errorNotifier + '}\n';
+                break;
+            case 'number':
+                paramCoercionCode = paramAccessor + ' = parseFloat(' + paramAccessor + ');\n'
+                    + 'if (Number.isNaN(' + paramAccessor + ')) {\n' + errorNotifier + '}\n';
+                break;
+            case 'boolean':
+                paramCoercionCode = 'if(!/^(?:true)|(?:false)|(?:1)|(?:0)$/.test('
+                    + paramAccessor + '.toString())) {\n'
+                    + errorNotifier + '}\n'
+                    + paramAccessor + ' = /^(?:true)|(?:1)$/.test('
+                    + paramAccessor + '.toString());\n';
+        }
+
+        if (!paramCoercionCode) {
+            return;
+        }
+
+        if (!param.required) {
+            // If parameter is not required, don't try to coerce "undefined"
+            paramCoercionCode = 'if (' + paramAccessor + ' !== undefined) {\n'
+                + paramCoercionCode + '}\n';
+        }
+
+        code += paramCoercionCode;
+    });
+    if (code && code.trim()) {
+        code += 'return req;\n';
+        /*jshint evil:true */
+        return new Function('req', 'HTTPError', code);
+    } else {
+        return undefined;
+    }
+};
+
+/**
+ * Validates a request. In case of an error, throws HTTPError with 400 code
+ * @param req {Object} a request object to validate.
+ */
 Validator.prototype.validate = function(req) {
+    if (this._typeCoercionFunc) {
+        req = this._typeCoercionFunc(req, HTTPError);
+    }
     if (!this._validatorFunc(req)) {
         throw new HTTPError({
             status: 400,

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -1127,6 +1127,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       consumes:
+        - application/json
         - multipart/form-data
       produces:
         - text/html; profile="mediawiki.org/specs/html/1.1.0"
@@ -1142,10 +1143,17 @@ paths:
           type: integer
           required: true
         - name: sections
-          in: formData
+          in: body
           description: Sections to transform
           type: string
           required: true
+          schema:
+            type: 'object'
+            properties:
+              sections:
+                example: '{"mwAg":"<h2>First Section replaced</h2><h2>Appended Section</h2>"}'
+            required:
+              - sections
       responses:
         '200':
           description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -81,7 +81,7 @@ describe('page save api', function() {
             throw new Error('Expected an error, but got status: ' + res.status);
         }, function(err) {
             assert.deepEqual(err.status, 400);
-            assert.deepEqual(err.body.title, 'data.body.csrf_token is a required property');
+            assert.deepEqual(err.body.detail, 'data.body.csrf_token is a required property');
         });
     });
 

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -169,4 +169,26 @@ describe('router - misc', function() {
             assert.deepEqual(e.body.title, 'data.body.field2 is a required property');
         }
     });
+    it('Should allow floats in number validator', function() {
+        var validator = new Validator([
+            {
+                name: 'testParam1',
+                in: 'query',
+                type: 'number',
+                required: true
+            },
+            {
+                name: 'testParam2',
+                in: 'query',
+                type: 'number',
+                required: true
+            }
+        ]);
+        validator.validate({
+            query: {
+                testParam1: '27.5',
+                testParam2: '27,5'
+            }
+        });
+    });
 });

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -111,7 +111,7 @@ describe('router - misc', function() {
             throw new Error('Error should be thrown');
         } catch(e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');
-            assert.deepEqual(e.body.title, 'data.body.testParam is a required property');
+            assert.deepEqual(e.body.detail, 'data.body.testParam is a required property');
         }
     });
     it('Should compile validator with no required fields', function() {
@@ -136,7 +136,7 @@ describe('router - misc', function() {
             throw new Error('Error should be thrown');
         } catch(e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');
-            assert.deepEqual(e.body.title, 'data.query.testParam should be integer');
+            assert.deepEqual(e.body.detail, 'data.query.testParam should be integer');
         }
     });
     it('Should validate object schemas', function() {
@@ -166,7 +166,7 @@ describe('router - misc', function() {
             throw new Error('Error should be thrown');
         } catch(e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');
-            assert.deepEqual(e.body.title, 'data.body.field2 is a required property');
+            assert.deepEqual(e.body.detail, 'data.body.field2 is a required property');
         }
     });
     it('Should allow floats in number validator', function() {

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -120,4 +120,53 @@ describe('router - misc', function() {
             in: 'formData'
         }]);
     });
+    it('Should validate integers', function() {
+        var validator = new Validator([{
+            name: 'testParam',
+            in: 'query',
+            type: 'integer',
+            required: true
+        }]);
+        try {
+            validator.validate({
+                query: {
+                    testParam: 'not_an_integer'
+                }
+            });
+            throw new Error('Error should be thrown');
+        } catch(e) {
+            assert.deepEqual(e.constructor.name, 'HTTPError');
+            assert.deepEqual(e.body.title, 'data.query.testParam should match pattern');
+        }
+    });
+    it('Should validate object schemas', function() {
+        var validator = new Validator([{
+            name: 'testParam',
+            in: 'body',
+            schema: {
+                type: 'object',
+                properties: {
+                    field1: {
+                        type: 'string'
+                    },
+                    field2: {
+                        type: 'string'
+                    }
+                },
+                required: ['field1', 'field2']
+            },
+            required: true
+        }]);
+        try {
+            validator.validate({
+                body: {
+                    field1: 'some string'
+                }
+            });
+            throw new Error('Error should be thrown');
+        } catch(e) {
+            assert.deepEqual(e.constructor.name, 'HTTPError');
+            assert.deepEqual(e.body.title, 'data.body.field2 is a required property');
+        }
+    });
 });

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -136,7 +136,7 @@ describe('router - misc', function() {
             throw new Error('Error should be thrown');
         } catch(e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');
-            assert.deepEqual(e.body.title, 'data.query.testParam should match pattern');
+            assert.deepEqual(e.body.title, 'data.query.testParam should be integer');
         }
     });
     it('Should validate object schemas', function() {

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -136,7 +136,7 @@ describe('router - misc', function() {
             throw new Error('Error should be thrown');
         } catch(e) {
             assert.deepEqual(e.constructor.name, 'HTTPError');
-            assert.deepEqual(e.body.detail, 'data.query.testParam should be integer');
+            assert.deepEqual(e.body.detail, 'data.query.testParam should be an integer');
         }
     });
     it('Should validate object schemas', function() {


### PR DESCRIPTION
Added more features:
- Support for type validators. Everything comes in as strings, so we can't use built-in json-schema type validation. Instead, validate with appropriate regex patterns
- Support additional features like `maxLength`, `minLength`, `pattern`, `enum` etc.
- Support for `body` parameters validated against a json-schema

The only problem is [weird api for sections transform](https://phabricator.wikimedia.org/T116336) that allows either form-data or application/json types to be passed in. Until we figure out what to do with that issue, we cannot validate `sections` input against a complete schema, so just validate that it has some field named `sections`. We have tests for both types of input, so backwards compatibility is preserved for now.

Benchmarks show, that, obviously, as more parameters are added and more complex requirements are added, the validator is getting slower, but even with a very complex and long list of params, the overhead is still almost unnoticeable.