### PR TITLE
Do not DOS ourselves by re-rendering the same title in monitoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
     - "0.10"
     - "0.12"
     - "4.2"
-    - "iojs-v2.5.0"
 
 sudo: false
 

--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -42,18 +42,6 @@ paths:
                 cache-control: '{cache-control}'
       x-monitor: true
       x-amples:
-        - title: Get MobileApps Main Page
-          request:
-            params:
-              domain: en.wikipedia.org
-              title: Main_Page
-            headers:
-              cache-control: no-cache
-          response:
-            status: 200
-            headers:
-              content-type: /text\/html/
-            body: /body/
         - title: Get MobileApps Main Page from RB storage
           request:
             params:


### PR DESCRIPTION
Somehow we managed to repeat the earlier mistake of re-generating the same
title over & over again. At sufficiently high rates (hundreds of re-renders
per hour), this will overwhelm retention policies (once queries fail), and
then lead to extremely wide partitions, timeouts and OOM on query.