### PR TITLE
Back-end services: Strip content-length and content-encoding headers

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -283,11 +283,11 @@ templates:
                         headers:
                           content-type: application/json
                         body:
-                          headers: '{$.get_mobileapps.headers}'
+                          headers: '{$$.strip($.get_mobileapps.headers, ["content-length", "content-encoding"])}'
                           body: '{$.get_mobileapps.body}'
                       return:
                         status: 200
-                        headers: '{$.get_mobileapps.headers}'
+                        headers: '{$$.strip($.get_mobileapps.headers, ["content-length", "content-encoding"])}'
                         body: '{$.get_mobileapps.body}'
             /handling/content/{cache-default}/{route}/{title}:
               post:
@@ -424,7 +424,7 @@ templates:
                   headers:
                     content-type: application/json
                   body:
-                    headers: '{$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location})}'
+                    headers: '{$$.merge($$.strip($.mathoid.headers, ["content-length", "content-encoding"]), {"x-resource-location": $.request.headers.x-resource-location})}'
                     data: '{$.mathoid.body}'
                 return:
                   status: 200

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -278,11 +278,11 @@ templates:
                         headers:
                           content-type: application/json
                         body:
-                          headers: '{$.get_mobileapps.headers}'
+                          headers: '{$$.strip($.get_mobileapps.headers, ["content-length", "content-encoding"])}'
                           body: '{$.get_mobileapps.body}'
                       return:
                         status: 200
-                        headers: '{$.get_mobileapps.headers}'
+                        headers: '{$$.strip($.get_mobileapps.headers, ["content-length", "content-encoding"])}'
                         body: '{$.get_mobileapps.body}'
             /handling/content/{cache-default}/{route}/{title}:
               post:
@@ -398,11 +398,11 @@ templates:
                   headers:
                     content-type: application/json
                   body:
-                    headers: '{$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location})}'
+                    headers: '{$$.merge($$.strip($.mathoid.headers, ["content-length", "content-encoding"]), {"x-resource-location": $.request.headers.x-resource-location})}'
                     data: '{$.mathoid.body}'
                 return:
                   status: 200
-                  headers: '{$$.merge($.mathoid.body[$.request.params.format].headers,$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location}))}'
+                  headers: '{$$.merge($.mathoid.body[$.request.params.format].headers,$$.merge($$.strip($.mathoid.headers, ["content-length", "content-encoding"]), {"x-resource-location": $.request.headers.x-resource-location}))}'
                   body: '{$.mathoid.body[$.request.params.format].body}'
       /{module:pageviews}:
         x-modules:


### PR DESCRIPTION
When storing and returning results from back-end services, such as Mathoid and MobileApps, we store and return all of the headers. Alas, some them pertain only to the request made by RESTBase, not the one made by the client. Such headers include `content-encoding` and `content-length`, so remove them from the response before storing and returning them.

Bug: [T116911](https://phabricator.wikimedia.org/T116911)