### PR TITLE
Patch to remove all-years parameter

### DIFF
--- a/mods/pageviews.js
+++ b/mods/pageviews.js
@@ -228,11 +228,6 @@ var validateYearMonthDay = function(rp) {
 
     stripOrgFromProject(rp);
 
-    if (rp.year === 'all-years' && (rp.month !== 'all-months' || rp.day !== 'all-days')) {
-        errors.push(
-            'month must be "all-months" and day must be "all-days" when passing "all-years"'
-        );
-    }
     if (rp.month === 'all-months' && rp.day !== 'all-days') {
         errors.push('day must be "all-days" when passing "all-months"');
     }
@@ -242,7 +237,7 @@ var validateYearMonthDay = function(rp) {
 
     // fake a timestamp in the YYYYMMDDHH format so we can reuse the validator
     var validDate = validateTimestamp(
-        ((rp.year === 'all-years') ? '2015' : rp.year) +
+        rp.year +
         ((rp.month === 'all-months') ? '01' : rp.month) +
         ((rp.day === 'all-days') ? '01' : rp.day) +
         '00'
@@ -250,7 +245,6 @@ var validateYearMonthDay = function(rp) {
 
     if (!validDate) {
         var invalidPieces = [];
-        if (rp.year !== 'all-years') { invalidPieces.push('year'); }
         if (rp.month !== 'all-months') { invalidPieces.push('month'); }
         if (rp.day !== 'all-days') { invalidPieces.push('day'); }
 

--- a/mods/pageviews.js
+++ b/mods/pageviews.js
@@ -237,10 +237,7 @@ var validateYearMonthDay = function(rp) {
 
     // fake a timestamp in the YYYYMMDDHH format so we can reuse the validator
     var validDate = validateTimestamp(
-<<<<<<< HEAD
         rp.year +
-=======
->>>>>>> 220b21ac9d9805ed4cd02b7969eb3e7030c1cd96
         ((rp.month === 'all-months') ? '01' : rp.month) +
         ((rp.day === 'all-days') ? '01' : rp.day) +
         '00'

--- a/specs/analytics/v1/pageviews.yaml
+++ b/specs/analytics/v1/pageviews.yaml
@@ -199,7 +199,7 @@ paths:
           required: true
         - name: year
           in: path
-          description: The year for which to retrieve top articles [all-years|year].  If you pass all-years, you must pass all-months and all-days or the input is invalid.
+          description: The year for which to retrieve top articles.
           type: string
           required: true
         - name: month

--- a/test/features/pageviews/pageviews.js
+++ b/test/features/pageviews/pageviews.js
@@ -99,6 +99,14 @@ describe('pageviews endpoints', function () {
         });
     });
 
+    it('Should return 400 when all-year is used for the year parameter', function () {
+        return preq.get({
+            uri: server.config.globalURL + topsEndpoint.replace('2015', 'all-years')
+        }).catch(function(res) {
+            assert.deepEqual(res.status, 400);
+        });
+    });
+
     it('should return 400 when tops date is invalid', function () {
         return preq.get({
             uri: server.config.globalURL + topsEndpoint.replace('all-months/all-days', '02/29')


### PR DESCRIPTION
This should remove the all-years parameter entirely from the pageviews side of things (and also adds a unit test to protect against regressions).

There are test failures but given that they're unrelated to the actual patch I'm going to assume they're related to the absence of cassandra.