### PR TITLE
Page revisions: Bug fix: Check array length difference correctly

### DIFF
--- a/mods/page_revisions.js
+++ b/mods/page_revisions.js
@@ -203,8 +203,9 @@ PRS.prototype._checkSameRev = function(firstRev, secondRev) {
                         return true;
                     }
                 }
+                return false;
             }
-            return false;
+            return true;
         }
         return firstVal !== secondVal;
     });


### PR DESCRIPTION
Follow-up on https://github.com/wikimedia/restbase/pull/392

I took it up, because I thought there's something wrong in a page_deletion test/logic, as it pass with that bug in place, but actually all is fine there. 

Also, why don't we use [https://lodash.com](lodash) in RESTBase, it would greatly simplify some common operations, like array equality check etc. 