### PR TITLE
Parsoid: Switch to V3 api, adapt tests and normalise Content-Type

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -466,9 +466,9 @@ services:
 
 test:
   content_types:
-    html: text/html;profile="mediawiki.org/specs/html/1.1.0";charset=utf-8
-    data-parsoid: application/json;profile="mediawiki.org/specs/data-parsoid/0.0.1"
-    wikitext: text/plain;profile="mediawiki.org/specs/wikitext/1.0.0";charset=utf-8
+    html: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.1.0"
+    data-parsoid: application/json; profile="mediawiki.org/specs/data-parsoid/0.0.1"
+    wikitext: text/plain; charset=utf-8; profile="mediawiki.org/specs/wikitext/1.0.0"
 
 logging:
   name: restbase

--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -10,6 +10,7 @@ var util = require('util');
 var url = require('url');
 var Busboy = require('busboy');
 var uuid = require('cassandra-uuid').TimeUuid;
+var contentType = require('content-type');
 
 var rbUtil = {};
 
@@ -297,6 +298,17 @@ rbUtil.copyForwardedHeaders = function(restbase, req, headers) {
     return req;
 };
 
+/**
+ * Normalizes the order of 'Content-Type' header fields.
+ *
+ * @param res server response
+ */
+rbUtil.normalizeContentType = function(res) {
+    if (res && res.headers && res.headers['content-type']) {
+        res.headers['content-type'] =
+            contentType.format(contentType.parse(res.headers['content-type']));
+    }
+};
 
 /***
  * MediaWiki-specific functions

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "template-expression-compiler": "^0.1.2",
     "htcp-purge": "^0.1.1",
-    "ajv": "^1.4.5"
+    "ajv": "^1.4.5",
+    "content-type": "^1.0.1"
   },
   "devDependencies": {
     "bunyan": "^1.5.1",

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -65,7 +65,7 @@ describe('transform api', function() {
         })
         .then(function (res) {
             assert.deepEqual(res.status, 200);
-            var pattern = /<div id="bar">Selser test<\/div>/;
+            var pattern = /^<div id="bar">Selser test<\/div>$/;
             if (!pattern.test(res.body)) {
                 throw new Error('Expected pattern in response: ' + pattern
                         + '\nSaw: ' + JSON.stringify(res, null, 2));

--- a/test/features/security/security.js
+++ b/test/features/security/security.js
@@ -75,7 +75,7 @@ describe('router - security', function() {
                 cookie: 'test=test_cookie'
             }
         })
-        .get('/v2/fr.wikipedia.org/pagebundle/' + title + '/' + revision)
+        .get('/fr.wikipedia.org/v3/page/pagebundle/' + title + '/' + revision)
         .reply(200, function() {
             return {
                 'html': {

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -96,7 +96,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: text/html;profile="mediawiki.org/specs/html/1.1.0"
+                content-type: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.1.0"
 
   /{domain}/v1/page/html/{title}/{revision}:
     get:
@@ -147,7 +147,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: text/html;profile="mediawiki.org/specs/html/1.1.0"
+                content-type: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.1.0"
 
   /{domain}/v1/page/data-parsoid/{title}/{revision}:
     get:
@@ -198,7 +198,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: application/json;profile="mediawiki.org/specs/data-parsoid/0.0.1"
+                content-type: application/json; profile="mediawiki.org/specs/data-parsoid/0.0.1"
 definitions:
   defaultError:
     required:


### PR DESCRIPTION
Switch RB to use [v3 Parsoid API](https://www.mediawiki.org/wiki/Parsoid/API).

Changes:
- Switch endpoints and adapt `nock` in a security test, which verifies that cookies are passed correctly.
- Don't deal with `body_only` in RESTBase at all, now parsoid supports it, let it handle the flag.
- `Content-Type` formatting. Enforce predictable order of fields in the `Content-Type` header from parsoid. It's arguable we need it right now, but it could be treated as preparation for [this](https://phabricator.wikimedia.org/T116333). Performance impact is fairly low - I get ~350.000 `normalizeContentType` calls per second, while an average request rate is lower that 1000 r/s on my machine. So, we get around 0.2% overhead. In future, apart from plain normalisation, we'd parse the content-type, and in case it's version is different from what's defined in a spec - rerender the stored content.

cc @wikimedia/services @cscott 