### PR TITLE
Clarify 404 errors and make room for bigger ints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Dockerfile
 
 # sqlite file (used in testing)
 test.db.sqlite3
+sqlite.db

--- a/mods/pageviews.js
+++ b/mods/pageviews.js
@@ -61,7 +61,9 @@ var tableSchemas = {
             // the hourly timestamp will be stored as YYYYMMDDHH
             timestamp: 'string',
             views: 'int',
-            v: 'long'
+            // store this as a string because it's too big for an int
+            // and long/bigint are not supported in RESTBase at this time
+            v: 'string'
         },
         index: [
             { attribute: 'project', type: 'hash' },
@@ -315,8 +317,14 @@ PJVS.prototype.pageviewsForProjects = function(restbase, req) {
     return dataRequest.then(normalizeResponse).then(function(res) {
         if (res.body.items) {
             res.body.items.forEach(function(item) {
-                // prefer the long column if it's loaded
-                item.views = item.v || item.views;
+                // prefer the v column if it's loaded
+                if (item.v && item.v !== '') {
+                    try {
+                        item.views = parseInt(item.v);
+                    } catch (e) {
+                        item.views = null;
+                    }
+                }
                 delete item.v;
             });
         }

--- a/mods/pageviews.js
+++ b/mods/pageviews.js
@@ -63,7 +63,7 @@ var tableSchemas = {
             views: 'int',
             // store this as a string because it's too big for an int
             // and long/bigint are not supported in RESTBase at this time
-            v: 'string'
+            v: 'long'
         },
         index: [
             { attribute: 'project', type: 'hash' },
@@ -128,17 +128,12 @@ Object.keys(viewCountColumnsForArticleFlat).forEach(function(k) {
 
 var notFoundCatcher = function(e) {
     if (e.status === 404) {
-        throw new rbUtil.HTTPError({
-            status: 404,
-            body: {
-                type: 'error',
-                description: 'The date(s) you used are valid, but we either do ' +
+        e.body.description = 'The date(s) you used are valid, but we either do ' +
                              'not have data for those date(s), or the project ' +
                              'you asked for is not loaded yet.  Please check ' +
                              'https://wikimedia.org/api/rest_v1/?doc for more ' +
-                             'information.'
-            }
-        });
+                             'information.';
+        e.body.type = 'not_found';
     }
     throw e;
 };
@@ -318,9 +313,9 @@ PJVS.prototype.pageviewsForProjects = function(restbase, req) {
         if (res.body.items) {
             res.body.items.forEach(function(item) {
                 // prefer the v column if it's loaded
-                if (item.v && item.v !== '') {
+                if (item.hasOwnProperty('v') && item.v !== null) {
                     try {
-                        item.views = parseInt(item.v);
+                        item.views = parseInt(item.v, 10);
                     } catch (e) {
                         item.views = null;
                     }

--- a/mods/pageviews.js
+++ b/mods/pageviews.js
@@ -23,7 +23,6 @@ function PJVS(options) {
 
 
 var tables = {
-    article: 'pageviews.per.article',
     articleFlat: 'pageviews.per.article.flat',
     project: 'pageviews.per.project',
     tops: 'top.pageviews',
@@ -32,28 +31,6 @@ var tableURI = function(domain, tableName) {
     return new URI([domain, 'sys', 'table', tableName, '']);
 };
 var tableSchemas = {
-    article: {
-        table: tables.article,
-        version: 1,
-        attributes: {
-            project: 'string',
-            article: 'string',
-            access: 'string',
-            agent: 'string',
-            granularity: 'string',
-            // the hourly timestamp will be stored as YYYYMMDDHH
-            timestamp: 'string',
-            views: 'int'
-        },
-        index: [
-            { attribute: 'project', type: 'hash' },
-            { attribute: 'article', type: 'hash' },
-            { attribute: 'access', type: 'hash' },
-            { attribute: 'agent', type: 'hash' },
-            { attribute: 'granularity', type: 'hash' },
-            { attribute: 'timestamp', type: 'range', order: 'asc' },
-        ]
-    },
     articleFlat: {
         table: tables.articleFlat,
         version: 1,
@@ -64,7 +41,7 @@ var tableSchemas = {
             // the hourly timestamp will be stored as YYYYMMDDHH
             timestamp: 'string'
 
-            // The various integer columns that hold view counts are added below
+            // The various int columns that hold view counts are added below
         },
         index: [
             { attribute: 'project', type: 'hash' },
@@ -75,7 +52,7 @@ var tableSchemas = {
     },
     project: {
         table: tables.project,
-        version: 1,
+        version: 2,
         attributes: {
             project: 'string',
             access: 'string',
@@ -83,7 +60,8 @@ var tableSchemas = {
             granularity: 'string',
             // the hourly timestamp will be stored as YYYYMMDDHH
             timestamp: 'string',
-            views: 'int'
+            views: 'int',
+            v: 'long'
         },
         index: [
             { attribute: 'project', type: 'hash' },
@@ -146,6 +124,23 @@ Object.keys(viewCountColumnsForArticleFlat).forEach(function(k) {
     tableSchemas.articleFlat.attributes[viewCountColumnsForArticleFlat[k]] = 'int';
 });
 
+var notFoundCatcher = function(e) {
+    if (e.status === 404) {
+        throw new rbUtil.HTTPError({
+            status: 404,
+            body: {
+                type: 'error',
+                description: 'The date(s) you used are valid, but we either do ' +
+                             'not have data for those date(s), or the project ' +
+                             'you asked for is not loaded yet.  Please check ' +
+                             'https://wikimedia.org/api/rest_v1/?doc for more ' +
+                             'information.'
+            }
+        });
+    }
+    throw e;
+};
+
 /**
  * general handler functions */
 var normalizeResponse = function(res) {
@@ -153,11 +148,6 @@ var normalizeResponse = function(res) {
     res = res || {};
     res.body = res.body || { items: [] };
     res.headers = res.headers || {};
-    // NOTE: We decided to let "data not found" be reported as a 404.  We have a work-around if
-    // consumers complain that they prefer a 204 instead:
-    //   We could catch the 404 and run the same query without the date parameters.  If we find
-    //   results (use limit 1 for efficiency), we could then return a 204 because we'd know the
-    //   dates were the part of the query that wasn't found.
     return res;
 };
 
@@ -275,7 +265,7 @@ PJVS.prototype.pageviewsForArticleFlat = function(restbase, req) {
             }
         }
 
-    });
+    }).catch(notFoundCatcher);
 
     function viewKey(access, agent) {
         var ret = ['views', access, agent].join('_');
@@ -320,9 +310,19 @@ PJVS.prototype.pageviewsForProjects = function(restbase, req) {
             }
         }
 
-    });
+    }).catch(notFoundCatcher);
 
-    return dataRequest.then(normalizeResponse);
+    return dataRequest.then(normalizeResponse).then(function(res) {
+        if (res.body.items) {
+            res.body.items.forEach(function(item) {
+                // prefer the long column if it's loaded
+                item.views = item.v || item.views;
+                delete item.v;
+            });
+        }
+
+        return res;
+    });
 };
 
 PJVS.prototype.pageviewsForTops = function(restbase, req) {
@@ -343,7 +343,7 @@ PJVS.prototype.pageviewsForTops = function(restbase, req) {
             }
         }
 
-    });
+    }).catch(notFoundCatcher);
 
     return dataRequest.then(normalizeResponse);
 };

--- a/mods/pageviews.js
+++ b/mods/pageviews.js
@@ -311,7 +311,7 @@ PJVS.prototype.pageviewsForProjects = function(restbase, req) {
         if (res.body.items) {
             res.body.items.forEach(function(item) {
                 // prefer the v column if it's loaded
-                if (item.hasOwnProperty('v') && item.v !== null) {
+                if (item.v !== null) {
                     try {
                         item.views = parseInt(item.v, 10);
                     } catch (e) {

--- a/mods/pageviews.js
+++ b/mods/pageviews.js
@@ -61,8 +61,6 @@ var tableSchemas = {
             // the hourly timestamp will be stored as YYYYMMDDHH
             timestamp: 'string',
             views: 'int',
-            // store this as a string because it's too big for an int
-            // and long/bigint are not supported in RESTBase at this time
             v: 'long'
         },
         index: [

--- a/specs/analytics/v1/pageviews.yaml
+++ b/specs/analytics/v1/pageviews.yaml
@@ -67,9 +67,9 @@ paths:
           required: true
         - name: granularity
           in: path
-          description: Time granularity of the response data
+          description: Time granularity of the response data (per-article hourly data is too big to fit on our current storage, we're currently working on finding a way to make it available in other ways)
           type: string
-          enum: ['hourly', 'daily']
+          enum: ['daily']
           required: true
         - name: start
           in: path
@@ -127,7 +127,7 @@ paths:
           in: path
           description: Time granularity of the response data
           type: string
-          enum: ['hourly', 'daily']
+          enum: ['hourly', 'daily', 'monthly']
           required: true
         - name: start
           in: path

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -146,7 +146,24 @@ paths:
                   granularity: '{$.request.params.granularity}'
                   timestamp: '{$.request.params.timestamp}'
                   views: '{$.request.params.views}'
-                  v: '{$.request.params.views}'
+      x-monitor: false
+
+  /{module:pageviews}/insert-aggregate-long/{project}/{access}/{agent}/{granularity}/{timestamp}/{v}:
+    post:
+      x-request-handler:
+        - put_to_storage:
+            request:
+              method: 'put'
+              uri: '/{domain}/sys/table/pageviews.per.project/'
+              body:
+                table: 'pageviews.per.project'
+                attributes:
+                  project: '{$.request.params.project}'
+                  access: '{$.request.params.access}'
+                  agent: '{$.request.params.agent}'
+                  granularity: '{$.request.params.granularity}'
+                  timestamp: '{$.request.params.timestamp}'
+                  v: '{$.request.params.v}'
       x-monitor: false
 
   /{module:pageviews}/insert-top/{project}/{access}/{year}/{month}/{day}/{data}:

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -146,6 +146,7 @@ paths:
                   granularity: '{$.request.params.granularity}'
                   timestamp: '{$.request.params.timestamp}'
                   views: '{$.request.params.views}'
+                  v: '{$.request.params.views}'
       x-monitor: false
 
   /{module:pageviews}/insert-top/{project}/{access}/{year}/{month}/{day}/{data}:

--- a/test/features/pageviews/pageviews.js
+++ b/test/features/pageviews/pageviews.js
@@ -108,22 +108,6 @@ describe('pageviews endpoints', function () {
         });
     });
 
-    it('should not die on bad data in the v column', function () {
-        return preq.post({
-            uri: server.config.globalURL +
-                 fix(insertProjectEndpointLong, 'en.wikipedia', '2') +
-                 '/catch'
-        }).then(function() {
-            return preq.get({
-                uri: server.config.globalURL +
-                     fix(projectEndpoint, 'en.wikipedia', '2')
-            });
-        }).then(function(res) {
-            assert.deepEqual(res.body.items.length, 1);
-            assert.deepEqual(res.body.items[0].views, null);
-        });
-    });
-
     it('should parse the v column string into an int', function () {
         return preq.post({
             uri: server.config.globalURL +

--- a/test/features/pageviews/pageviews.js
+++ b/test/features/pageviews/pageviews.js
@@ -21,6 +21,7 @@ describe('pageviews endpoints', function () {
     // Fake data insertion endpoints
     var insertArticleEndpoint = '/pageviews/insert-per-article-flat/en.wikipedia/one/daily/2015070200';
     var insertProjectEndpoint = '/pageviews/insert-aggregate/en.wikipedia/all-access/all-agents/hourly/1970010100';
+    var insertProjectEndpointLong = '/pageviews/insert-aggregate-long/en.wikipedia/all-access/all-agents/hourly/1970010100';
     var insertTopsEndpoint = '/pageviews/insert-top/en.wikipedia/mobile-web/2015/all-months/all-days/';
 
     function fix(b, s, u) { return b.replace(s, s + u); }
@@ -76,10 +77,25 @@ describe('pageviews endpoints', function () {
         });
     });
 
+    // WARNING: the data created in this test is used exactly as created
+    // by the monitoring tests.
     it('should return the expected aggregate data after insertion', function () {
         return preq.post({
+            uri: server.config.globalURL + insertProjectEndpoint + '/0'
+        }).then(function() {
+            return preq.get({
+                uri: server.config.globalURL + projectEndpoint
+            });
+        }).then(function(res) {
+            assert.deepEqual(res.body.items.length, 1);
+            assert.deepEqual(res.body.items[0].views, 0);
+        });
+    });
+
+    it('should return the expected aggregate data after long insertion', function () {
+        return preq.post({
             uri: server.config.globalURL +
-                 fix(insertProjectEndpoint, 'en.wikipedia', '1') +
+                 fix(insertProjectEndpointLong, 'en.wikipedia', '1') +
                  '/0'
         }).then(function() {
             return preq.get({
@@ -95,7 +111,7 @@ describe('pageviews endpoints', function () {
     it('should not die on bad data in the v column', function () {
         return preq.post({
             uri: server.config.globalURL +
-                 fix(insertProjectEndpoint, 'en.wikipedia', '2') +
+                 fix(insertProjectEndpointLong, 'en.wikipedia', '2') +
                  '/catch'
         }).then(function() {
             return preq.get({
@@ -111,7 +127,7 @@ describe('pageviews endpoints', function () {
     it('should parse the v column string into an int', function () {
         return preq.post({
             uri: server.config.globalURL +
-                 fix(insertProjectEndpoint, 'en.wikipedia', '3') +
+                 fix(insertProjectEndpointLong, 'en.wikipedia', '3') +
                  '/9007199254740991'
         }).then(function() {
             return preq.get({


### PR DESCRIPTION
* 404 errors get a more descriptive message
* int was too small for per-project monthly data, increasing to long
* 'hourly' granularity resulted in too much data, removing permanently
from per-article-flat, might add later in a different shape
* 'monthly' is being calculated for per-project, so add it to the query
options

NOTE: do not merge this until support for long columns is added

Bug: T117017