### PR TITLE
Testing: Report Cassandra version when running tests

### DIFF
--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -11,7 +11,7 @@ runTest ( ) {
         rm -f test.db.sqlite3
     else
         echo "Running with Cassandra backend"
-        echo "Cassandra version: `cassandra -v`"
+        echo "Cassandra version: `/usr/local/cassandra/bin/cassandra -v`"
         export RB_TEST_BACKEND=cassandra
         sh ./test/utils/cleandb.sh
     fi

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -11,6 +11,7 @@ runTest ( ) {
         rm -f test.db.sqlite3
     else
         echo "Running with Cassandra backend"
+        echo "Cassandra version: `cassandra -v`"
         export RB_TEST_BACKEND=cassandra
         sh ./test/utils/cleandb.sh
     fi


### PR DESCRIPTION
Currently travis tests are failing due to some cassandra hang. I couldn't find any information on which concrete cassandra version is used in travis, so adding a version output to the test-running script.

This PR is created to experiment with travis a bit and will be closed soon