### PR TITLE
Travis: Install custom cassandra version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ sudo: required
 
 before_install:
   - sudo rm -rf /var/lib/cassandra/*
-  - wget https://archive.apache.org/dist/cassandra/2.1.8/apache-cassandra-2.1.8-bin.tar.gz
-  - tar -xzf apache-cassandra-2.1.8-bin.tar.gz
-  - sudo sh apache-cassandra-2.1.8/bin/cassandra > /dev/null
+  - sudo mkdir /var/lib/cassandra-code
+  - sudo wget -O /var/lib/cassandra-code/cassandra.tar.gz https://archive.apache.org/dist/cassandra/2.1.8/apache-cassandra-2.1.8-bin.tar.gz
+  - sudo tar -xzf /var/lib/cassandra-code/cassandra.tar.gz -C /var/lib/cassandra-code/ --strip-components 1
+  - sudo sh /var/lib/cassandra-code/bin/cassandra > /dev/null
 
 before_script:
   - while [ `nc localhost 9042 < /dev/null; echo $?` != 0 ] ; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
+group: dev
 language: node_js
 node_js:
     - "0.10"
     - "0.12"
     - "4.2"
 
-sudo: false
+sudo: required
 
-services:
-    - cassandra
+before_install:
+  - sudo sh -c "echo 'JVM_OPTS=\"\${JVM_OPTS} -Djava.net.preferIPv4Stack=false\"' >> /usr/local/cassandra/conf/cassandra-env.sh"
+  - sudo service cassandra start
+
+before_script:
+  - while [ `nc localhost 9042 < /dev/null; echo $?` != 0 ] ; do
+      echo 'waiting for cassandra...' ;
+      sleep 1 ;
+    done
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-group: dev
 language: node_js
 node_js:
     - "0.10"
@@ -8,8 +7,10 @@ node_js:
 sudo: required
 
 before_install:
-  - sudo sh -c "echo 'JVM_OPTS=\"\${JVM_OPTS} -Djava.net.preferIPv4Stack=false\"' >> /usr/local/cassandra/conf/cassandra-env.sh"
-  - sudo service cassandra start
+  - sudo rm -rf /var/lib/cassandra/*
+  - wget https://archive.apache.org/dist/cassandra/2.1.8/apache-cassandra-2.1.8-bin.tar.gz
+  - tar -xzf apache-cassandra-2.1.8-bin.tar.gz
+  - sudo sh apache-cassandra-2.1.8/bin/cassandra > /dev/null
 
 before_script:
   - while [ `nc localhost 9042 < /dev/null; echo $?` != 0 ] ; do


### PR DESCRIPTION
I've contacted travis support and asked how can I use the newer version of cassandra in travis. 
This PR is created to test their suggestions. 

The first suggestion was to try setting `group: dev` in the beginning of the travis.yam script, however, it doesn't work - neither in container-based environment, nor with sudo. 

So, this PR is pulling a custom cassandra version, installing it and running the tests against it. We loose nice container-based environment, but it's better not to special-case tests as much as possible