### PR TITLE
Support stashing of new page content & empty bodies

### DIFF
--- a/lib/rbUtil.js
+++ b/lib/rbUtil.js
@@ -221,7 +221,7 @@ rbUtil.cloneRequest = function(req) {
         method: req.method || 'get',
         headers: req.headers || {},
         query: req.query || {},
-        body: req.body || null,
+        body: req.body !== undefined ? req.body : null,
         params: req.params || {}
     };
 };

--- a/specs/mediawiki/v1/content.yaml
+++ b/specs/mediawiki/v1/content.yaml
@@ -959,8 +959,8 @@ paths:
       tags:
         - Transforms
       description: >
-        Transform wikitext to HTML. Note that if set `stash: true`, you need to
-        supply both the title and the revision ID.
+        Transform wikitext to HTML. Note that if you set `stash: true`, you
+          also need to supply the title.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       consumes:


### PR DESCRIPTION
- Accept requests with an empty body.
- Fix a bug in rbUtil.cloneRequest() that replaced an empty-string body with
  null.
- Accept stash requests without a version, or with a fake '0' version.

See also: https://phabricator.wikimedia.org/T118070