### PR TITLE
Don't retry failed Parsoid POST requests

### DIFF
--- a/mods/parsoid.js
+++ b/mods/parsoid.js
@@ -295,8 +295,7 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
                 },
                 body: body
             });
-        })
-        .catch(function(e) {
+        }, function(e) {
             // Fall back to plain GET
             return restbase.get({ uri: pageBundleUri });
         });


### PR DESCRIPTION
Only fall back to GET if the internal storage request failed, but don't do so
if the Parsoid POST fails. While this catch papers over a Parsoid v3 API
incompatibility right now, it would be nicer to detect such failures more
quickly.

Tests for this patch won't pass until
https://gerrit.wikimedia.org/r/#/c/252575/ or
https://github.com/wikimedia/restbase/pull/406 is merged.