### PR TITLE
Validator: Do not validate non-string values

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -122,21 +122,21 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
             return;
         }
         var paramAccessor = 'req.' + inMapping[param.in] + '["' + param.name + '"]';
-        var paramCoercionCode;
+        var paramCoercionCode = 'if (typeof ' + paramAccessor + " === 'string') {\n";
         var errorNotifier;
         switch (param.type) {
             case 'integer':
                 errorNotifier = 'throw new HTTPError({status:400,body:{type:"bad_request",'
                     + ' title:"Invalid parameters", detail: "data.'
                     + inMapping[param.in] + '.' + param.name + ' should be an integer"}});\n';
-                paramCoercionCode = paramAccessor + ' = parseInt(' + paramAccessor + ');\n'
+                paramCoercionCode += paramAccessor + ' = parseInt(' + paramAccessor + ');\n'
                     + 'if (!Number.isInteger(' + paramAccessor + ')) {\n' + errorNotifier + '}\n';
                 break;
             case 'number':
                 errorNotifier = 'throw new HTTPError({status:400,body:{type:"bad_request",'
                     + ' title:"Invalid parameters", detail: "data.'
                     + inMapping[param.in] + '.' + param.name + ' should be a number"}});\n';
-                paramCoercionCode = paramAccessor + ' = parseFloat(' + paramAccessor + ');\n'
+                paramCoercionCode += paramAccessor + ' = parseFloat(' + paramAccessor + ');\n'
                     + 'if (Number.isNaN(' + paramAccessor + ')) {\n' + errorNotifier + '}\n';
                 break;
             case 'boolean':
@@ -144,16 +144,13 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
                     + ' title:"Invalid parameters", detail: "data.'
                     + inMapping[param.in] + '.' + param.name + ' should be a boolean.'
                     + ' true|false|1|0 is accepted as a boolean."}});\n';
-                paramCoercionCode = 'if(!/^true|false|1|0$/.test('
+                paramCoercionCode += 'if(!/^true|false|1|0$/i.test('
                     + paramAccessor + ' + "")) {\n'
                     + errorNotifier + '}\n'
-                    + paramAccessor + ' = /^true|1$/.test('
+                    + paramAccessor + ' = /^true|1$/i.test('
                     + paramAccessor + ' + "");\n';
         }
-
-        if (!paramCoercionCode) {
-            return;
-        }
+        paramCoercionCode += "}\n";
 
         if (!param.required) {
             // If parameter is not required, don't try to coerce "undefined"


### PR DESCRIPTION
Also, perform case-insensitive checks for booleans, since some languages capitalise them.