### PR TITLE
Don't coerce types in JSON body

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -45,7 +45,12 @@ var supportedValidators = ['maximum',
  */
 var Validator = function(parameters) {
     this._ajv = constructAjv();
-    this._typeCoercionFunc = this._createTypeCoercionFunc(parameters);
+    this._paramCoercionFunc = this._createTypeCoercionFunc(parameters.filter(function(p) {
+        return p.name !== 'body';
+    }));
+    this._bodyCoercionFunc = this._createTypeCoercionFunc(parameters.filter(function(p) {
+        return p.name === 'body';
+    }));
     this._validatorFunc = this._ajv.compile(this._convertToJsonSchema(parameters));
 };
 
@@ -122,7 +127,7 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
             return;
         }
         var paramAccessor = 'req.' + inMapping[param.in] + '["' + param.name + '"]';
-        var paramCoercionCode = 'if (typeof ' + paramAccessor + " === 'string') {\n";
+        var paramCoercionCode = '';
         var errorNotifier;
         switch (param.type) {
             case 'integer':
@@ -150,11 +155,14 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
                     + paramAccessor + ' = /^true|1$/i.test('
                     + paramAccessor + ' + "");\n';
         }
-        paramCoercionCode += "}\n";
 
-        if (!param.required) {
-            // If parameter is not required, don't try to coerce "undefined"
-            paramCoercionCode = 'if (' + paramAccessor + ' !== undefined) {\n'
+        if (paramCoercionCode) {
+            var wrapperConditions = 'typeof ' + paramAccessor + " === 'string'";
+            if (!param.required) {
+                // If parameter is not required, don't try to coerce "undefined"
+                wrapperConditions += ' && ' + paramAccessor + ' !== undefined';
+            }
+            paramCoercionCode = 'if (' + wrapperConditions + ') {\n'
                 + paramCoercionCode + '}\n';
         }
 
@@ -174,8 +182,12 @@ Validator.prototype._createTypeCoercionFunc = function(parameters) {
  * @param req {Object} a request object to validate.
  */
 Validator.prototype.validate = function(req) {
-    if (this._typeCoercionFunc) {
-        req = this._typeCoercionFunc(req, HTTPError);
+    if (this._paramCoercionFunc) {
+        req = this._paramCoercionFunc(req, HTTPError);
+    }
+    if (this._bodyCoercionFunc
+            && !/^ *application\/json/i.test(req.headers['content-type'])) {
+        req = this._bodyCoercionFunc(req, HTTPError);
     }
     if (!this._validatorFunc(req)) {
         throw new HTTPError({


### PR DESCRIPTION
We need to coerce from string when processing multipart/form-data and
urlencoded posts, but should resist the temptation to guess when processing
JSON posts. Reasons in favor of being strict for JSON:

- We want users to send JSON requests conforming to the documented schema.
  Trying to fix up some classes of errors & not others would be confusing.
- Our type coercion currently only applies to top-level properties. In a JSON
  POST, this having this coercion only happen at the top level would be fairly
  confusing for users.
- Running the coercion on large JSON bodies adds unnecessary overhead.

Task: https://phabricator.wikimedia.org/T118470