### PR TITLE
Spec modules

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -136,12 +136,12 @@ templates:
               # For local testing, use:
               # parsoidHost: http://localhost:8000
 
-      /{module:graphoid}/v1/png/{title}/{revision}/{graph_id}:
-        get:
-          x-request-handler:
-            - get_from_graphoid:
-                request:
-                  uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
+      /{module:graphoid}:
+        x-modules:
+          - path: graphoid_test
+            type: spec
+            options:
+              host: http://graphoid.wikimedia.org
 
       /{module:mobileapps}:
         x-subspec:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -138,7 +138,7 @@ templates:
 
       /{module:graphoid}:
         x-modules:
-          - path: graphoid_test
+          - path: specs/graphoid_test
             type: spec
             options:
               host: http://graphoid.wikimedia.org

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -173,12 +173,14 @@ function validateSpec(spec) {
 /**
  * Prepares a request chain on startup: compiles request/response templates,
  * creates catch conditions verifiers.
- * @param conf request chain configuration
+ * @param {object} spec request chain configuration
+ * @param {object} conf, an optional config object to be merged into the
+ *                  globals available in template expressions.
  *
  * @returns {Array} an array of prepared steps, each containing a
  *                  request function generator
  */
-function prepareRequestChain(conf) {
+function prepareRequestChain(spec, conf) {
 
     /**
      * Creates a function generator that returns a closure to execute in order to
@@ -192,7 +194,7 @@ function prepareRequestChain(conf) {
     function prepareRequest(requestSpec, requestName, requestConf) {
         var template;
         if (requestConf.request) {
-            template = new Template(requestConf.request);
+            template = new Template(requestConf.request, conf);
             requestSpec.request = function(restbase, context) {
                 var req = template.expand(context);
                 if (!requestConf.request.method) {
@@ -210,7 +212,7 @@ function prepareRequestChain(conf) {
 
     function prepareReturn(requestSpec, requestConf) {
         if (requestConf.return) {
-            var template = new Template(requestConf.return);
+            var template = new Template(requestConf.return, conf);
             var originalRequestHandler = requestSpec.request;
             if (originalRequestHandler) {
                 requestSpec.request = function(restbase, context) {
@@ -248,9 +250,9 @@ function prepareRequestChain(conf) {
         }
     }
 
-    return conf.map(function(stepConf) {
-        return Object.keys(stepConf).map(function(requestName) {
-            var requestConf = stepConf[requestName];
+    return spec.map(function(stepSpec) {
+        return Object.keys(stepSpec).map(function(requestName) {
+            var requestConf = stepSpec[requestName];
             var requestSpec = { name: requestName };
             prepareRequest(requestSpec, requestName, requestConf);
             prepareReturn(requestSpec, requestConf);
@@ -277,11 +279,13 @@ function isSimpleChain(requestChain) {
  * Creates a handler function from the handler spec.
  *
  * @param spec - a request handler spec
+ * @param globals - an object to merge into the globals available in the
+ *                  global handler scope.
  * @returns {Function} a request handler
  */
-function createHandler(spec) {
+function createHandler(spec, conf) {
     validateSpec(spec);
-    var requestChain = prepareRequestChain(spec);
+    var requestChain = prepareRequestChain(spec, conf);
     if (isSimpleChain(requestChain)) {
         var handler = requestChain[0][0].request;
         return function(restbase, req) {
@@ -303,7 +307,7 @@ function createHandler(spec) {
  *
  * @param {object} setupConf an endpoint configuration object
  */
-function parseSetupConfig(setupConf) {
+function parseSetupConfig(setupConf, globals) {
     var result = [];
     if (Array.isArray(setupConf)) {
         setupConf.forEach(function(resourceSpec) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -97,7 +97,6 @@ Router.prototype._loadModule = function(modDef) {
     }
     // Append the log property to module options, if it is not present
     modDef.options = modDef.options || {};
-    modDef.globals = { conf: modDef.options };
     if (!modDef.options.log) {
         modDef.options.log = this._options.log || function() {};
     }
@@ -106,7 +105,7 @@ Router.prototype._loadModule = function(modDef) {
         .then(function(spec) {
             var mod = {
                 spec: spec,
-                globals: modDef.globals,
+                globals: { options: modDef.options },
             };
             self._modules.set(modDef, mod);
             return mod;

--- a/lib/router.js
+++ b/lib/router.js
@@ -88,35 +88,51 @@ Router.prototype._loadModule = function(modDef) {
         case 'npm':
             loadPath = modDef.name;
             break;
+        case 'spec':
+            loadPath = modDef.path;
+            break;
         default:
             throw new Error('unknown module type '
                 + modDef.type + ' (for module ' + modDef.name + ').');
     }
     // Append the log property to module options, if it is not present
     modDef.options = modDef.options || {};
+    modDef.globals = { conf: modDef.options };
     if (!modDef.options.log) {
         modDef.options.log = this._options.log || function() {};
     }
-    // Let the error propagate in case the module cannot be loaded
-    var modObj = require(loadPath);
-    if (!modObj) {
-        return P.reject("Loading module " + loadPath + " failed.");
-    }
-    // Call if it's a function
-    if (modObj instanceof Function) {
-        modObj = modObj(modDef.options);
-    }
-    if (!(modObj instanceof P)) {
-        // Wrap
-        modObj = P.resolve(modObj);
-    }
-    return modObj.then(function(mod) {
-        if (!mod.operations) {
-            throw new Error('No operations exported by module ' + loadPath);
+    if (modDef.type === 'spec') {
+        return self._readSpec(loadPath)
+        .then(function(spec) {
+            var mod = {
+                spec: spec,
+                globals: modDef.globals,
+            };
+            self._modules.set(modDef, mod);
+            return mod;
+        });
+    } else {
+        // Let the error propagate in case the module cannot be loaded
+        var modObj = require(loadPath);
+        if (!modObj) {
+            return P.reject("Loading module " + loadPath + " failed.");
         }
-        self._modules.set(modDef, mod);
-        return mod;
-    });
+        // Call if it's a function
+        if (modObj instanceof Function) {
+            modObj = modObj(modDef.options);
+        }
+        if (!(modObj instanceof P)) {
+            // Wrap
+            modObj = P.resolve(modObj);
+        }
+        return modObj.then(function(mod) {
+            if (!mod.operations) {
+                throw new Error('No operations exported by module ' + loadPath);
+            }
+            self._modules.set(modDef, mod);
+            return mod;
+        });
+    }
 };
 
 /**
@@ -150,7 +166,8 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
             listNode.value = {
                 specRoot: specRoot,
                 methods: {},
-                path: specRoot.basePath + '/'
+                path: specRoot.basePath + '/',
+                globals: {},
             };
             node.setChild('', listNode);
             subSpecs = [subSpec];
@@ -201,7 +218,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
                         });
                     }
                     return self._handleSwaggerSpec(node, module.spec,
-                            module.operations, specRoot, prefixPath);
+                            module.operations, specRoot, prefixPath, module.globals);
                 });
             });
         });
@@ -255,7 +272,8 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
 
             var backendRequest = method && method['x-request-handler'];
             if (backendRequest) {
-                node.value.methods[methodName] = handlerTemplate.createHandler(backendRequest);
+                node.value.methods[methodName] = handlerTemplate.createHandler(backendRequest,
+                        node.value.globals);
             } else if (method.operationId) {
                 var handler = operations[method.operationId];
                 if (handler) {
@@ -276,7 +294,8 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
 /**
  * Process a Swagger spec
  */
-Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specRoot, prefixPath) {
+Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations,
+        specRoot, prefixPath, globals) {
     if (!specRoot) {
         specRoot = spec;
         if (!spec.paths) { spec.paths = {}; }
@@ -316,7 +335,8 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specR
                 specRoot: specRoot,
                 path: undefined,
                 methods: {},
-                resources: []
+                resources: [],
+                globals: globals || {},
             };
 
             // Expected to return
@@ -369,6 +389,7 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specR
                 subtree.value.specRoot = origSubtree.value.specRoot;
                 subtree.value.path = specRoot.basePath + subPrefixPath;
                 subtree.value.resources = origSubtree.value.resources;
+                subtree.value.globals = origSubtree.value.globals;
                 specPromise = P.resolve();
             }
             branchNode.setChild(path[path.length - 1], subtree);

--- a/lib/router.js
+++ b/lib/router.js
@@ -69,27 +69,25 @@ Router.prototype._loadModule = function(modDef) {
     // Determine the module's load path
     switch (modDef.type) {
         case 'file':
+        case 'spec':
             if (modDef.path && /^\//.test(modDef.path)) {
                 // Absolute path
                 loadPath = modDef.path;
             } else {
                 // Relative path or missing
-                loadPath = __dirname + '/../mods/';
+                loadPath = __dirname + '/../';
                 if (modDef.path) {
                     // The path has been provided, use it
                     loadPath += modDef.path;
                 } else {
-                    // No path given, so assume the file
-                    // name matches the module name
-                    loadPath += modDef.name;
+                    // No path given, so assume the file name matches the
+                    // module name & the default 'mods' dir is used.
+                    loadPath += 'mods/' + modDef.name;
                 }
             }
             break;
         case 'npm':
             loadPath = modDef.name;
-            break;
-        case 'spec':
-            loadPath = modDef.path;
             break;
         default:
             throw new Error('unknown module type '
@@ -101,8 +99,12 @@ Router.prototype._loadModule = function(modDef) {
         modDef.options.log = this._options.log || function() {};
     }
     if (modDef.type === 'spec') {
-        return self._readSpec(loadPath)
-        .then(function(spec) {
+        if (!/\.yaml$/.test(loadPath)) {
+            loadPath += '.yaml';
+        }
+        return fs.readFileAsync(loadPath)
+        .then(function(specSrc) {
+            var spec = yaml.safeLoad(specSrc);
             var mod = {
                 spec: spec,
                 globals: { options: modDef.options },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "preq": "^0.4.4",
     "restbase-mod-table-cassandra": "^0.8.7",
     "service-runner": "^0.3.0",
-    "swagger-router": "git+https://github.com/gwicke/swagger-router.git#template_fixes",
+    "swagger-router": "^0.2.7",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "tassembly": "^0.2.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "preq": "^0.4.4",
     "restbase-mod-table-cassandra": "^0.8.7",
     "service-runner": "^0.3.0",
-    "swagger-router": "^0.2.5",
+    "swagger-router": "git+https://github.com/gwicke/swagger-router.git#template_fixes",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "tassembly": "^0.2.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",

--- a/specs/graphoid_test.yaml
+++ b/specs/graphoid_test.yaml
@@ -1,0 +1,7 @@
+paths:
+  /v1/png/{title}/{revision}/{graph_id}:
+      get:
+        x-request-handler:
+          - get_from_graphoid:
+              request:
+                uri: '{+$$.conf.host}/{domain}/v1/png/{title}/{revision}/{graph_id}'

--- a/specs/graphoid_test.yaml
+++ b/specs/graphoid_test.yaml
@@ -4,4 +4,4 @@ paths:
         x-request-handler:
           - get_from_graphoid:
               request:
-                uri: '{+$$.conf.host}/{domain}/v1/png/{title}/{revision}/{graph_id}'
+                uri: '{+$$.options.host}/{domain}/v1/png/{title}/{revision}/{graph_id}'


### PR DESCRIPTION
This patch adds support for loading specs as a special kind of module. Similar
to @mobrovac's PR #413, this makes our config more modular and less verbose.
As with other modules, spec modules can be parametrized with options.

Example config stanza:

```yaml
    /{module:graphoid}:
      x-modules:
        - path: graphoid_test
          type: spec
          options:
            host: http://graphoid.wikimedia.org
            header_whitelist:
              - content-type
              - x-foobar
```

The `options` specified for the module can be referenced in request templates
under `$$.conf`. Example:

```yaml
uri: '{+$$.options.host}/{domain}/...'
headers: '{$$.filter($.request.headers, $$.options.header_whitelist)}'
```
Note that we are passing an array to `$$.filter`, which works as we are
passing around references.

With #417, this can be more cleanly written as:
```yaml
uri: '{{options.host}}/{domain}/...'
headers: '{{ filter(req.headers, options.header_whitelist) }}'
```
Also, `filter` is actually implemented.