### PR TITLE
MobileApps: Test mobile-html-sections instead of mobile-html

### DIFF
--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -40,18 +40,7 @@ paths:
               uri: /{domain}/sys/mobileapps/html/{title}
               headers:
                 cache-control: '{cache-control}'
-      x-monitor: true
-      x-amples:
-        - title: Get MobileApps Main Page from RB storage
-          request:
-            params:
-              domain: en.wikipedia.org
-              title: Main_Page
-          response:
-            status: 200
-            headers:
-              content-type: /text\/html/
-            body: /body/
+      x-monitor: false
 
   /{module:page}/mobile-html-sections/{title}:
     get:
@@ -90,6 +79,16 @@ paths:
               headers:
                 cache-control: '{cache-control}'
       x-monitor: false
+      x-amples:
+        - title: Get MobileApps Foobar page
+          request:
+            params:
+              domain: en.wikipedia.org
+              title: Foobar
+          response:
+            status: 200
+            headers:
+              content-type: /aplication\/json/
 
   /{module:page}/mobile-html-sections-lead/{title}:
     get:


### PR DESCRIPTION
The removal of the mobile-html endpoint has been merged in the MobileApss repository, so test the mobile-html-sections endpoint instead.