### PR TITLE
Fix nock to 2.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+    # Production runs 0.10.29
+    - "0.10.29"
     - "0.10"
     - "0.12"
     - "4.2"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mocha-jscs": "^4.0.0",
     "mocha-jshint": "^2.2.5",
     "mocha-lcov-reporter": "^1.0.0",
-    "nock": "^2.15.0",
+    "nock": "2.17.0",
     "restbase-mod-table-sqlite": "^0.1.10",
     "swagger-test": "0.2.0",
     "url-template": "^2.0.6"


### PR DESCRIPTION
2.18 seems to have [an ugly bug](https://github.com/pgte/nock/issues/402),
which causes requests to hosts that were previously mocked to time out on node
0.10.

Bug: https://phabricator.wikimedia.org/T118650