### PR TITLE
Module option templating

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -122,7 +122,7 @@ templates:
         x-modules:
           - name: action
             type: file
-            options:
+            templates:
               apiRequest:
                 method: post
                 uri: http://{domain}/w/api.php

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -35,15 +35,7 @@ templates:
       license:
         name: Apache2
         url: http://www.apache.org/licenses/LICENSE-2.0
-    # Override the base path for host-based (proxied) requests. In our case,
-    # we proxy https://{domain}/api/rest_v1/ to the API.
-    x-host-basePath: /api/rest_v1
-    x-subspecs:
-      - mediawiki/v1/content
-      - mediawiki/v1/graphoid
-      - mediawiki/v1/mobileapps
-      - media/v1/mathoid
-    # - mediawiki/v1/revision-scoring
+
     securityDefinitions: &wp/content-security/1.0.0
       mediawiki_auth:
         description: Checks permissions using MW api
@@ -59,6 +51,23 @@ templates:
         x-whitelists:
           internal:
             - /^(?:::ffff:)?(?:10|127)\./
+              #
+    # Override the base path for host-based (proxied) requests. In our case,
+    # we proxy https://{domain}/api/rest_v1/ to the API.
+    x-host-basePath: /api/rest_v1
+
+    x-modules:
+      - name: graphoid
+        path: mods/wikimedia/graphoid_v1
+        type: spec
+        options:
+          host: http://graphoid.wikimedia.org
+
+    x-subspecs:
+      - mediawiki/v1/content
+      - mediawiki/v1/mobileapps
+      - media/v1/mathoid
+    # - mediawiki/v1/revision-scoring
 
   wmf-sys-1.0.0: &wp/sys/1.0.0
     info:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -94,7 +94,7 @@ templates:
         x-modules:
           - name: action
             type: file
-            options:
+            templates:
               apiRequest:
                 method: post
                 # XXX: double-check the API URI:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -34,12 +34,7 @@ templates:
       license:
         name: Apache2
         url: http://www.apache.org/licenses/LICENSE-2.0
-    x-subspecs:
-      - mediawiki/v1/content
-      - mediawiki/v1/graphoid
-      - mediawiki/v1/mobileapps
-      - media/v1/mathoid
-      - test
+
     securityDefinitions: &wp/content-security/1.0.0
       mediawiki_auth:
         description: Checks permissions using MW api
@@ -58,6 +53,19 @@ templates:
         x-whitelists:
           internal:
             - /^(?:::ffff:)?(?:10|127)\./
+
+    x-modules:
+      - name: graphoid
+        path: mods/wikimedia/graphoid_v1
+        type: spec
+        options:
+          host: http://graphoid.wikimedia.org
+
+    x-subspecs:
+      - mediawiki/v1/content
+      - mediawiki/v1/mobileapps
+      - media/v1/mathoid
+      - test
 
   wmf-sys-1.0.0: &wp/sys/1.0.0
     info:
@@ -135,13 +143,6 @@ templates:
               parsoidHost: http://parsoid-beta.wmflabs.org
               # For local testing, use:
               # parsoidHost: http://localhost:8000
-
-      /{module:graphoid}:
-        x-modules:
-          - path: specs/graphoid_test
-            type: spec
-            options:
-              host: http://graphoid.wikimedia.org
 
       /{module:mobileapps}:
         x-subspec:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -136,12 +136,12 @@ templates:
               # For local testing, use:
               # parsoidHost: http://localhost:8000
 
-      /{module:graphoid}/v1/png/{title}/{revision}/{graph_id}:
-        get:
-          x-request-handler:
-            - get_from_graphoid:
-                request:
-                  uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
+      /{module:graphoid}:
+        x-modules:
+          - path: graphoid_test
+            type: spec
+            options:
+              host: http://graphoid.wikimedia.org
 
       /{module:mobileapps}:
         x-subspec:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -121,7 +121,7 @@ templates:
         x-modules:
           - name: action
             type: file
-            options:
+            templates:
               apiRequest:
                 method: post
                 uri: http://{domain}/w/api.php

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -138,7 +138,7 @@ templates:
 
       /{module:graphoid}:
         x-modules:
-          - path: graphoid_test
+          - path: specs/graphoid_test
             type: spec
             options:
               host: http://graphoid.wikimedia.org

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -173,12 +173,14 @@ function validateSpec(spec) {
 /**
  * Prepares a request chain on startup: compiles request/response templates,
  * creates catch conditions verifiers.
- * @param conf request chain configuration
+ * @param {object} spec request chain configuration
+ * @param {object} conf, an optional config object to be merged into the
+ *                  globals available in template expressions.
  *
  * @returns {Array} an array of prepared steps, each containing a
  *                  request function generator
  */
-function prepareRequestChain(conf) {
+function prepareRequestChain(spec, conf) {
 
     /**
      * Creates a function generator that returns a closure to execute in order to
@@ -192,7 +194,7 @@ function prepareRequestChain(conf) {
     function prepareRequest(requestSpec, requestName, requestConf) {
         var template;
         if (requestConf.request) {
-            template = new Template(requestConf.request);
+            template = new Template(requestConf.request, conf);
             requestSpec.request = function(restbase, context) {
                 var req = template.expand(context);
                 if (!requestConf.request.method) {
@@ -210,7 +212,7 @@ function prepareRequestChain(conf) {
 
     function prepareReturn(requestSpec, requestConf) {
         if (requestConf.return) {
-            var template = new Template(requestConf.return);
+            var template = new Template(requestConf.return, conf);
             var originalRequestHandler = requestSpec.request;
             if (originalRequestHandler) {
                 requestSpec.request = function(restbase, context) {
@@ -248,9 +250,9 @@ function prepareRequestChain(conf) {
         }
     }
 
-    return conf.map(function(stepConf) {
-        return Object.keys(stepConf).map(function(requestName) {
-            var requestConf = stepConf[requestName];
+    return spec.map(function(stepSpec) {
+        return Object.keys(stepSpec).map(function(requestName) {
+            var requestConf = stepSpec[requestName];
             var requestSpec = { name: requestName };
             prepareRequest(requestSpec, requestName, requestConf);
             prepareReturn(requestSpec, requestConf);
@@ -277,11 +279,13 @@ function isSimpleChain(requestChain) {
  * Creates a handler function from the handler spec.
  *
  * @param spec - a request handler spec
+ * @param globals - an object to merge into the globals available in the
+ *                  global handler scope.
  * @returns {Function} a request handler
  */
-function createHandler(spec) {
+function createHandler(spec, conf) {
     validateSpec(spec);
-    var requestChain = prepareRequestChain(spec);
+    var requestChain = prepareRequestChain(spec, conf);
     if (isSimpleChain(requestChain)) {
         var handler = requestChain[0][0].request;
         return function(restbase, req) {
@@ -303,7 +307,7 @@ function createHandler(spec) {
  *
  * @param {object} setupConf an endpoint configuration object
  */
-function parseSetupConfig(setupConf) {
+function parseSetupConfig(setupConf, globals) {
     var result = [];
     if (Array.isArray(setupConf)) {
         setupConf.forEach(function(resourceSpec) {

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -180,7 +180,8 @@ function validateSpec(spec) {
  * @returns {Array} an array of prepared steps, each containing a
  *                  request function generator
  */
-function prepareRequestChain(spec, conf) {
+function prepareRequestChain(spec, options) {
+    options = options || {};
 
     /**
      * Creates a function generator that returns a closure to execute in order to
@@ -194,12 +195,13 @@ function prepareRequestChain(spec, conf) {
     function prepareRequest(requestSpec, requestName, requestConf) {
         var template;
         if (requestConf.request) {
-            template = new Template(requestConf.request, conf);
+            template = new Template(requestConf.request, options.globals);
             requestSpec.request = function(restbase, context) {
                 var req = template.expand(context);
                 if (!requestConf.request.method) {
                     // Do we really want this?
-                    req.method = context.request.method || 'get';
+                    req.method = context.request.method
+                        || options.defaultMethod || 'get';
                 }
                 return restbase.request(req)
                 .then(function(res) {
@@ -212,7 +214,7 @@ function prepareRequestChain(spec, conf) {
 
     function prepareReturn(requestSpec, requestConf) {
         if (requestConf.return) {
-            var template = new Template(requestConf.return, conf);
+            var template = new Template(requestConf.return, options.globals);
             var originalRequestHandler = requestSpec.request;
             if (originalRequestHandler) {
                 requestSpec.request = function(restbase, context) {
@@ -279,13 +281,16 @@ function isSimpleChain(requestChain) {
  * Creates a handler function from the handler spec.
  *
  * @param spec - a request handler spec
- * @param globals - an object to merge into the globals available in the
+ * @param {object} options, with attributes:
+ *          - globals: an object to merge into the globals available in the
  *                  global handler scope.
+ *          - defaultMethod: request method used for templates without an
+ *                  explicit method set; defaults to 'get'.
  * @returns {Function} a request handler
  */
-function createHandler(spec, conf) {
+function createHandler(spec, options) {
     validateSpec(spec);
-    var requestChain = prepareRequestChain(spec, conf);
+    var requestChain = prepareRequestChain(spec, options);
     if (isSimpleChain(requestChain)) {
         var handler = requestChain[0][0].request;
         return function(restbase, req) {
@@ -306,8 +311,13 @@ function createHandler(spec, conf) {
  * Processes an x-setup-handler config and returns all resources
  *
  * @param {object} setupConf an endpoint configuration object
+ * @param {object} options, with attributes:
+ *          - globals: an object to merge into the globals available in the
+ *                  global handler scope.
+ *
+ * TODO: Use createHandler to create a real handler?
  */
-function parseSetupConfig(setupConf, globals) {
+function parseSetupConfig(setupConf, options) {
     var result = [];
     if (Array.isArray(setupConf)) {
         setupConf.forEach(function(resourceSpec) {

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -205,6 +205,10 @@ function prepareRequestChain(spec, options) {
                 }
                 return restbase.request(req)
                 .then(function(res) {
+                    context.responses[requestName] = res;
+                    // Also set in the global context for backwards
+                    // compatibility. TODO: Remove once all specs are
+                    // migrated.
                     context[requestName] = res;
                     return res;
                 });
@@ -295,13 +299,19 @@ function createHandler(spec, options) {
         var handler = requestChain[0][0].request;
         return function(restbase, req) {
             return handler(restbase, {
-                request: req
+                req: req,
+                responses: {},
+                // Old-style long form. TODO: Remove once specs are migrated.
+                request: req,
             });
         };
     } else {
         return function(restbase, req) {
             return generatePromiseChain(restbase, {
-                request: req
+                req: req,
+                responses: {},
+                // Old-style long form. TODO: Remove once specs are migrated.
+                request: req,
             }, requestChain);
         };
     }

--- a/lib/router.js
+++ b/lib/router.js
@@ -273,8 +273,9 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
 
             var backendRequest = method && method['x-request-handler'];
             if (backendRequest) {
-                node.value.methods[methodName] = handlerTemplate.createHandler(backendRequest,
-                        node.value.globals);
+                node.value.methods[methodName] = handlerTemplate.createHandler(backendRequest, {
+                    globals: node.value.globals,
+                });
             } else if (method.operationId) {
                 var handler = operations[method.operationId];
                 if (handler) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -97,7 +97,6 @@ Router.prototype._loadModule = function(modDef) {
     }
     // Append the log property to module options, if it is not present
     modDef.options = modDef.options || {};
-    modDef.globals = { conf: modDef.options };
     if (!modDef.options.log) {
         modDef.options.log = this._options.log || function() {};
     }
@@ -106,7 +105,7 @@ Router.prototype._loadModule = function(modDef) {
         .then(function(spec) {
             var mod = {
                 spec: spec,
-                globals: modDef.globals,
+                globals: { options: modDef.options },
             };
             self._modules.set(modDef, mod);
             return mod;

--- a/lib/router.js
+++ b/lib/router.js
@@ -88,35 +88,51 @@ Router.prototype._loadModule = function(modDef) {
         case 'npm':
             loadPath = modDef.name;
             break;
+        case 'spec':
+            loadPath = modDef.path;
+            break;
         default:
             throw new Error('unknown module type '
                 + modDef.type + ' (for module ' + modDef.name + ').');
     }
     // Append the log property to module options, if it is not present
     modDef.options = modDef.options || {};
+    modDef.globals = { conf: modDef.options };
     if (!modDef.options.log) {
         modDef.options.log = this._options.log || function() {};
     }
-    // Let the error propagate in case the module cannot be loaded
-    var modObj = require(loadPath);
-    if (!modObj) {
-        return P.reject("Loading module " + loadPath + " failed.");
-    }
-    // Call if it's a function
-    if (modObj instanceof Function) {
-        modObj = modObj(modDef.options);
-    }
-    if (!(modObj instanceof P)) {
-        // Wrap
-        modObj = P.resolve(modObj);
-    }
-    return modObj.then(function(mod) {
-        if (!mod.operations) {
-            throw new Error('No operations exported by module ' + loadPath);
+    if (modDef.type === 'spec') {
+        return self._readSpec(loadPath)
+        .then(function(spec) {
+            var mod = {
+                spec: spec,
+                globals: modDef.globals,
+            };
+            self._modules.set(modDef, mod);
+            return mod;
+        });
+    } else {
+        // Let the error propagate in case the module cannot be loaded
+        var modObj = require(loadPath);
+        if (!modObj) {
+            return P.reject("Loading module " + loadPath + " failed.");
         }
-        self._modules.set(modDef, mod);
-        return mod;
-    });
+        // Call if it's a function
+        if (modObj instanceof Function) {
+            modObj = modObj(modDef.options);
+        }
+        if (!(modObj instanceof P)) {
+            // Wrap
+            modObj = P.resolve(modObj);
+        }
+        return modObj.then(function(mod) {
+            if (!mod.operations) {
+                throw new Error('No operations exported by module ' + loadPath);
+            }
+            self._modules.set(modDef, mod);
+            return mod;
+        });
+    }
 };
 
 /**
@@ -150,7 +166,8 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
             listNode.value = {
                 specRoot: specRoot,
                 methods: {},
-                path: specRoot.basePath + '/'
+                path: specRoot.basePath + '/',
+                globals: {},
             };
             node.setChild('', listNode);
             subSpecs = [subSpec];
@@ -201,7 +218,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
                         });
                     }
                     return self._handleSwaggerSpec(node, module.spec,
-                            module.operations, specRoot, prefixPath);
+                            module.operations, specRoot, prefixPath, module.globals);
                 });
             });
         });
@@ -255,7 +272,8 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
 
             var backendRequest = method && method['x-request-handler'];
             if (backendRequest) {
-                node.value.methods[methodName] = handlerTemplate.createHandler(backendRequest);
+                node.value.methods[methodName] = handlerTemplate.createHandler(backendRequest,
+                        node.value.globals);
             } else if (method.operationId) {
                 var handler = operations[method.operationId];
                 if (handler) {
@@ -276,7 +294,8 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
 /**
  * Process a Swagger spec
  */
-Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specRoot, prefixPath) {
+Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations,
+        specRoot, prefixPath, globals) {
     if (!specRoot) {
         specRoot = spec;
         if (!spec.paths) { spec.paths = {}; }
@@ -316,7 +335,8 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specR
                 specRoot: specRoot,
                 path: undefined,
                 methods: {},
-                resources: []
+                resources: [],
+                globals: globals || {},
             };
 
             // Expected to return
@@ -369,6 +389,7 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, operations, specR
                 subtree.value.specRoot = origSubtree.value.specRoot;
                 subtree.value.path = specRoot.basePath + subPrefixPath;
                 subtree.value.resources = origSubtree.value.resources;
+                subtree.value.globals = origSubtree.value.globals;
                 specPromise = P.resolve();
             }
             branchNode.setChild(path[path.length - 1], subtree);

--- a/lib/router.js
+++ b/lib/router.js
@@ -57,7 +57,7 @@ Router.prototype._buildPath = function route(node, path, value) {
 /**
  * Load and initialize a module
  */
-Router.prototype._loadModule = function(modDef) {
+Router.prototype._loadModule = function(modDef, config) {
     var cachedModule = this._modules.get(modDef);
     if (cachedModule) {
         // Found a cached instance. Return it.
@@ -93,10 +93,17 @@ Router.prototype._loadModule = function(modDef) {
             throw new Error('unknown module type '
                 + modDef.type + ' (for module ' + modDef.name + ').');
     }
+
+    // Expand options in the parent context, so that config options can be
+    // passed down the chain.
+    var options = {};
+    if (modDef.options) {
+        options = new Template(modDef.options).expand(config);
+    }
+
     // Append the log property to module options, if it is not present
-    modDef.options = modDef.options || {};
-    if (!modDef.options.log) {
-        modDef.options.log = this._options.log || function() {};
+    if (!options.log) {
+        options.log = this._options.log || function() {};
     }
     if (modDef.type === 'spec') {
         if (!/\.yaml$/.test(loadPath)) {
@@ -107,7 +114,7 @@ Router.prototype._loadModule = function(modDef) {
             var spec = yaml.safeLoad(specSrc);
             var mod = {
                 spec: spec,
-                globals: { options: modDef.options },
+                globals: { options: options },
             };
             self._modules.set(modDef, mod);
             return mod;
@@ -120,7 +127,7 @@ Router.prototype._loadModule = function(modDef) {
         }
         // Call if it's a function
         if (modObj instanceof Function) {
-            modObj = modObj(modDef.options);
+            modObj = modObj(options, modDef.templates);
         }
         if (!(modObj instanceof P)) {
             // Wrap
@@ -202,7 +209,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
         loaderPromise = loaderPromise.then(function() {
             return P.each(restBaseModules, function(m) {
                 // Share modules
-                return self._loadModule(m)
+                return self._loadModule(m, specRoot._config)
                 .then(function(module) {
                     if (!module) {
                         throw new Error('Null return when loading module ' + m.name);
@@ -462,6 +469,9 @@ Router.prototype.loadSpec = function(spec, restbase) {
     }
     return specPromise
     .then(function(spec) {
+        // Hack for now, as we don't have a clean options object that is
+        // passed down the tree. FIXME!
+        spec._config = restbase.rb_config;
         return self._handleSwaggerSpec(rootNode, spec, {});
     })
     .then(function() {

--- a/lib/router.js
+++ b/lib/router.js
@@ -69,27 +69,25 @@ Router.prototype._loadModule = function(modDef) {
     // Determine the module's load path
     switch (modDef.type) {
         case 'file':
+        case 'spec':
             if (modDef.path && /^\//.test(modDef.path)) {
                 // Absolute path
                 loadPath = modDef.path;
             } else {
                 // Relative path or missing
-                loadPath = __dirname + '/../mods/';
+                loadPath = __dirname + '/../';
                 if (modDef.path) {
                     // The path has been provided, use it
                     loadPath += modDef.path;
                 } else {
-                    // No path given, so assume the file
-                    // name matches the module name
-                    loadPath += modDef.name;
+                    // No path given, so assume the file name matches the
+                    // module name & the default 'mods' dir is used.
+                    loadPath += 'mods/' + modDef.name;
                 }
             }
             break;
         case 'npm':
             loadPath = modDef.name;
-            break;
-        case 'spec':
-            loadPath = modDef.path;
             break;
         default:
             throw new Error('unknown module type '
@@ -101,8 +99,12 @@ Router.prototype._loadModule = function(modDef) {
         modDef.options.log = this._options.log || function() {};
     }
     if (modDef.type === 'spec') {
-        return self._readSpec(loadPath)
-        .then(function(spec) {
+        if (!/\.yaml$/.test(loadPath)) {
+            loadPath += '.yaml';
+        }
+        return fs.readFileAsync(loadPath)
+        .then(function(specSrc) {
+            var spec = yaml.safeLoad(specSrc);
             var mod = {
                 spec: spec,
                 globals: { options: modDef.options },

--- a/mods/action.js
+++ b/mods/action.js
@@ -104,11 +104,11 @@ function apiError(apiErr) {
 /**
  * Action module code
  */
-function ActionService(options) {
-    if (!options.apiRequest) {
+function ActionService(options, templates) {
+    if (!templates.apiRequest) {
         throw new Error('The action module needs the apiRequest templating stanza to exist!');
     }
-    this.apiRequestTemplate = new Template(options.apiRequest);
+    this.apiRequestTemplate = new Template(templates.apiRequest);
 }
 
 function buildQueryResponse(res) {
@@ -188,8 +188,8 @@ ActionService.prototype.edit = function(restbase, req) {
 };
 
 
-module.exports = function(options) {
-    var actionService = new ActionService(options);
+module.exports = function(options, templates) {
+    var actionService = new ActionService(options, templates);
     return {
         spec: {
             paths: {

--- a/mods/graphoid_v1.yaml
+++ b/mods/graphoid_v1.yaml
@@ -1,0 +1,64 @@
+paths:
+  /{module:page}/graph/png/{title}/{revision}/{graph_id}:
+    get:
+      tags:
+        - Page content
+      description: >
+        Retrieve PNG graph images embedded in specific revisions of a
+        page. See [the Graphoid
+        documentation](https://www.mediawiki.org/wiki/Extension:Graph#Graphoid_service)
+        for details.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - image/png
+      parameters:
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: The page revision, or 0 for the latest
+          type: integer
+          required: true
+        - name: graph_id
+          in: path
+          description: The graph ID, consisting of a hash and the suffix `.png`.
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The PNG render of the requested graph.
+        '403':
+          description: access to the specific revision is restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '404':
+          description: Unknown page title or revision
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+
+      x-request-handler:
+        - get_from_graphoid:
+            request:
+              uri: '{+ options.host }/{domain}/v1/png/{title}/{revision}/{graph_id}'
+
+      x-monitor: true
+      x-amples:
+        - title: Get a graph from Graphoid
+          request:
+            params:
+              domain: en.wikipedia.org
+              title: User:Pchelolo/Graph
+              revision: 670213569
+              graph_id: 1533aaad45c733dcc7e07614b54cbae4119a6747.png
+          response:
+            status: 200
+            headers:
+              content-type: image/png

--- a/mods/wikimedia/graphoid_v1.yaml
+++ b/mods/wikimedia/graphoid_v1.yaml
@@ -1,7 +1,3 @@
-# Graphoid graph render service
-
-swagger: 2.0
-
 paths:
   /{module:page}/graph/png/{title}/{revision}/{graph_id}:
     get:
@@ -49,11 +45,9 @@ paths:
             $ref: '#/definitions/problem'
 
       x-request-handler:
-        - get_from_backend:
+        - get_from_graphoid:
             request:
-              uri: /{domain}/sys/graphoid/v1/png/{title}/{revision}/{graph_id}
-              headers:
-                cache-control: '{cache-control}'
+              uri: '{+ $$.options.host }/{domain}/v1/png/{title}/{revision}/{graph_id}'
 
       x-monitor: true
       x-amples:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "preq": "^0.4.4",
     "restbase-mod-table-cassandra": "^0.8.7",
     "service-runner": "^0.3.0",
-    "swagger-router": "git+https://github.com/gwicke/swagger-router.git#template_fixes",
+    "swagger-router": "^0.2.7",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "tassembly": "^0.2.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "preq": "^0.4.4",
     "restbase-mod-table-cassandra": "^0.8.7",
     "service-runner": "^0.3.0",
-    "swagger-router": "^0.2.5",
+    "swagger-router": "git+https://github.com/gwicke/swagger-router.git#template_fixes",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "tassembly": "^0.2.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "preq": "^0.4.4",
     "restbase-mod-table-cassandra": "^0.8.7",
     "service-runner": "^0.3.0",
-    "swagger-router": "^0.2.7",
+    "swagger-router": "git+https://github.com/gwicke/swagger-router.git#cleaner_expressions",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "tassembly": "^0.2.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",

--- a/specs/graphoid_test.yaml
+++ b/specs/graphoid_test.yaml
@@ -1,0 +1,7 @@
+paths:
+  /v1/png/{title}/{revision}/{graph_id}:
+      get:
+        x-request-handler:
+          - get_from_graphoid:
+              request:
+                uri: '{+$$.conf.host}/{domain}/v1/png/{title}/{revision}/{graph_id}'

--- a/specs/graphoid_test.yaml
+++ b/specs/graphoid_test.yaml
@@ -1,7 +1,0 @@
-paths:
-  /v1/png/{title}/{revision}/{graph_id}:
-      get:
-        x-request-handler:
-          - get_from_graphoid:
-              request:
-                uri: '{+$$.options.host}/{domain}/v1/png/{title}/{revision}/{graph_id}'

--- a/specs/graphoid_test.yaml
+++ b/specs/graphoid_test.yaml
@@ -4,4 +4,4 @@ paths:
         x-request-handler:
           - get_from_graphoid:
               request:
-                uri: '{+$$.conf.host}/{domain}/v1/png/{title}/{revision}/{graph_id}'
+                uri: '{+$$.options.host}/{domain}/v1/png/{title}/{revision}/{graph_id}'

--- a/test/features/errors/notfound.js
+++ b/test/features/errors/notfound.js
@@ -83,7 +83,7 @@ describe('404 handling', function() {
     it('should set page_deleted on deleted page', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
-            .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+            .paths['/{module:action}']['x-modules'][0].templates.apiRequest.uri;
         apiURI = apiURI.replace('{domain}', 'en.wikipedia.org');
         var title = 'TestingTitle';
         var revision = 12345;

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -11,7 +11,7 @@ var pagingToken = '';
 function generateTests(options) {
 
     var apiRequestTemplate = server.config.conf.templates['wmf-sys-1.0.0']
-                ['paths']['/{module:action}']['x-modules'][0]['options']['apiRequest'];
+                ['paths']['/{module:action}']['x-modules'][0].templates.apiRequest;
     var prevUri = apiRequestTemplate.uri;
     var prevHost = apiRequestTemplate.headers.host;
 

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -25,7 +25,7 @@ describe('page save api', function() {
     var lastETag = '';
     var apiUri = server.config
         .conf.templates['wmf-sys-1.0.0']
-        .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+        .paths['/{module:action}']['x-modules'][0].templates.apiRequest.uri;
     var labsApiURI = apiUri.replace('{domain}', 'en.wikipedia.beta.wmflabs.org');
 
     this.timeout(20000);

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -167,13 +167,15 @@ var nestedSecuritySpec = {
 
 var fullSpec = server.loadConfig('config.example.wikimedia.yaml');
 
+var fakeRestBase = { rb_config: {} };
+
 describe('tree building', function() {
 
     before(function() { server.start(); });
 
     it('should build a simple spec tree', function() {
         var router = new Router();
-        return router.loadSpec(rootSpec)
+        return router.loadSpec(rootSpec, fakeRestBase)
         .then(function() {
             //console.log(JSON.stringify(router.tree, null, 2));
             var handler = router.route('/en.wikipedia.org/v1/page/Foo/html');
@@ -186,7 +188,7 @@ describe('tree building', function() {
 
     it('should fail loading a faulty spec', function() {
         var router = new Router();
-        return router.loadSpec(faultySpec)
+        return router.loadSpec(faultySpec, fakeRestBase)
         .then(function() {
             throw new Error("Should throw an exception!");
         },
@@ -201,7 +203,8 @@ describe('tree building', function() {
         return router.loadSpec(fullSpec.spec, {
             request: function(req) {
                 resourceRequests.push(req);
-            }
+            },
+            rb_config: {},
         })
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/html/Foo');
@@ -214,7 +217,7 @@ describe('tree building', function() {
 
     it('should allow adding methods to existing paths', function() {
         var router = new Router();
-        return router.loadSpec(additionalMethodSpec)
+        return router.loadSpec(additionalMethodSpec, fakeRestBase)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/Foo/html');
             assert.equal(!!handler.value.methods.get, true);
@@ -233,9 +236,9 @@ describe('tree building', function() {
         });
     });
 
-    it('should parse permission along the path to endpoint', function() {
+    it('should pass permission along the path to endpoint', function() {
         var router = new Router();
-        return router.loadSpec(nestedSecuritySpec)
+        return router.loadSpec(nestedSecuritySpec, fakeRestBase)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/secure');
             assert.deepEqual(handler.permissions, [

--- a/test/features/security/security.js
+++ b/test/features/security/security.js
@@ -41,7 +41,7 @@ describe('router - security', function() {
         nock.enableNetConnect();
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
-            .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+            .paths['/{module:action}']['x-modules'][0].templates.apiRequest.uri;
         apiURI = apiURI.replace('{domain}', 'fr.wikipedia.org');
         var api = nock(apiURI, {
             reqheaders: {
@@ -111,7 +111,7 @@ describe('router - security', function() {
     it ('should not send cookies to non-restricted domains', function() {
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
-            .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+            .paths['/{module:action}']['x-modules'][0].templates.apiRequest.uri;
         apiURI = apiURI.replace('{domain}', 'en.wikipedia.org');
         var api = nock(apiURI, {
             badheaders: ['cookie']
@@ -133,7 +133,7 @@ describe('router - security', function() {
         nock.enableNetConnect();
         var apiURI = server.config
             .conf.templates['wmf-sys-1.0.0']
-            .paths['/{module:action}']['x-modules'][0].options.apiRequest.uri;
+            .paths['/{module:action}']['x-modules'][0].templates.apiRequest.uri;
         apiURI = apiURI.replace('{domain}', 'fr.wikipedia.org');
         var title = 'TestingTitle';
         var revision = 12345;


### PR DESCRIPTION
This patch adds the ability to template module options using the familiar
request template syntax. This lets us pass down global options like header
whitelists into individual modules, reducing the need for repetition and copy
& paste.

To accommodate passing in templates as well, an additional 'templates'
property is passed into module constructors verbatim, and the one case where
we pass in an apiRequest template is migrated to it.

In this current implementation, we cheat a little bit by only supporting a
single nesting level, with all option templates being directly evaluated
against the service config. We can consider supporting nested scopes as well,
but will need to clean up the way information is passed down the router trees
first. However, in practice a single module inclusion level is all we have
needed so far, and keeping it that way may be good for our sanity. Lets cross
that bridge when we get to it.

One thing that I noticed while working on this patch is that we are doing some
fairly gross and brittle spec referecing & manipulation in our tests. This
patch should give us tools to get rid of this by moving those variable pieces
into a proper service config.