### PR TITLE
MobileApps: Switch to key_value and spec modules

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -3,7 +3,6 @@
 info:
   name: restbase
 
-
 templates:
 
   wmf-content-1.0.0: &wp/content/1.0.0
@@ -38,10 +37,15 @@ templates:
     # Override the base path for host-based (proxied) requests. In our case,
     # we proxy https://{domain}/api/rest_v1/ to the API.
     x-host-basePath: /api/rest_v1
+    x-modules:
+      - name: mobileapps-public
+        path: specs/mediawiki/v1/mobileapps
+        type: spec
+        options:
+          host: http://appservice.wmflabs.org
     x-subspecs:
       - mediawiki/v1/content
       - mediawiki/v1/graphoid
-      - mediawiki/v1/mobileapps
       - media/v1/mathoid
     # - mediawiki/v1/revision-scoring
     securityDefinitions: &wp/content-security/1.0.0
@@ -150,165 +154,13 @@ templates:
 
       /{module:mobileapps}:
         x-subspec:
-          info:
-            title: Mobileapps sys API module
           paths:
-            /html/{title}:
-              get:
-                x-setup-handler:
-                  - init:
-                      method: put
-                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html
-                      body:
-                        revisionRetentionPolicy:
-                          type: 'latest'
-                          count: 1
-                          grace_ttl: 86400
-                        valueType: 'json'
-                        version: 1
-                x-request-handler:
-                  - handle_req:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-            /sections/{title}:
-              get:
-                x-setup-handler:
-                  - init:
-                      method: put
-                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections
-                      body:
-                        revisionRetentionPolicy:
-                          type: 'latest'
-                          count: 1
-                          grace_ttl: 86400
-                        valueType: 'json'
-                        version: 1
-                x-request-handler:
-                  - handle_req:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-            /sections-lead/{title}:
-              get:
-                x-setup-handler:
-                  - init:
-                      method: put
-                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections-lead
-                      body:
-                        revisionRetentionPolicy:
-                          type: 'latest'
-                          count: 1
-                          grace_ttl: 86400
-                        valueType: 'json'
-                        version: 1
-                x-request-handler:
-                  - handle_req:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections-lead/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-            /sections-remaining/{title}:
-              get:
-                x-setup-handler:
-                  - init:
-                      method: put
-                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections-remaining
-                      body:
-                        revisionRetentionPolicy:
-                          type: 'latest'
-                          count: 1
-                          grace_ttl: 86400
-                        valueType: 'json'
-                        version: 1
-                x-request-handler:
-                  - handle_req:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections-remaining/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-            /text/{title}:
-              get:
-                x-setup-handler:
-                  - init:
-                      method: put
-                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-text
-                      body:
-                        revisionRetentionPolicy:
-                          type: 'latest'
-                          count: 1
-                          grace_ttl: 86400
-                        valueType: 'json'
-                        version: 1
-                x-request-handler:
-                  - handle_req:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-text/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-            /handling/rev/{route}/{title}:
-              get:
-                x-request-handler:
-                  - get_rev:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/page_revisions/page/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-                  - cache_branch:
-                      request:
-                        method: post
-                        uri: /{domain}/sys/mobileapps/handling/content/{$$.default($.request.headers.cache-control, 'none-given')}/{route}/{title}
-                        body: '{$.get_rev.body}'
-            /handling/content/no-cache/{route}/{title}:
-              post:
-                x-request-handler:
-                  - get_mobileapps:
-                      request:
-                        method: get
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/{route}/{title}
-                        headers:
-                          x-restbase-etag: '{$.request.body.items[0].rev}/{$.request.body.items[0].tid}'
-                  - store:
-                      request:
-                        method: put
-                        uri: /{domain}/sys/key_rev_value/mobileapps.{route}/{title}/{$.request.body.items[0].rev}/{$.request.body.items[0].tid}
-                        headers:
-                          content-type: application/json
-                        body:
-                          headers: '{$$.strip($.get_mobileapps.headers, ["content-length", "content-encoding"])}'
-                          body: '{$.get_mobileapps.body}'
-                      return:
-                        status: 200
-                        headers: '{$$.strip($.get_mobileapps.headers, ["content-length", "content-encoding"])}'
-                        body: '{$.get_mobileapps.body}'
-            /handling/content/{cache-default}/{route}/{title}:
-              post:
-                x-request-handler:
-                  - check_storage:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/key_rev_value/mobileapps.{route}/{title}/{$.request.body.items[0].rev}/{$.request.body.items[0].tid}
-                      return_if:
-                        status: '2xx'
-                      return:
-                        status: 200
-                        headers: '{$.check_storage.body.headers}'
-                        body: '{$.check_storage.body.body}'
-                      catch:
-                        status: 404
-                  - render:
-                      request:
-                        method: post
-                        uri: /{domain}/sys/mobileapps/handling/content/no-cache/{route}/{title}
-                        body: '{$.request.body}'
+            /v1:
+              x-modules:
+                - path: mods/wikimedia/v1/mobileapps
+                  type: spec
+                  options:
+                    host: http://appservice.wmflabs.org
 
 #      /{module:revscore}:
 #        title: Simple revscore service wrapper

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -34,10 +34,15 @@ templates:
       license:
         name: Apache2
         url: http://www.apache.org/licenses/LICENSE-2.0
+    x-modules:
+      - name: mobileapps-public
+        path: specs/mediawiki/v1/mobileapps
+        type: spec
+        options:
+          host: http://appservice.wmflabs.org
     x-subspecs:
       - mediawiki/v1/content
       - mediawiki/v1/graphoid
-      - mediawiki/v1/mobileapps
       - media/v1/mathoid
       - test
     securityDefinitions: &wp/content-security/1.0.0
@@ -145,165 +150,14 @@ templates:
 
       /{module:mobileapps}:
         x-subspec:
-          info:
-            title: Mobileapps sys API module
           paths:
-            /html/{title}:
-              get:
-                x-setup-handler:
-                  - init:
-                      method: put
-                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html
-                      body:
-                        revisionRetentionPolicy:
-                          type: 'latest'
-                          count: 1
-                          grace_ttl: 86400
-                        valueType: 'json'
-                        version: 1
-                x-request-handler:
-                  - handle_req:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-            /sections/{title}:
-              get:
-                x-setup-handler:
-                  - init:
-                      method: put
-                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections
-                      body:
-                        revisionRetentionPolicy:
-                          type: 'latest'
-                          count: 1
-                          grace_ttl: 86400
-                        valueType: 'json'
-                        version: 1
-                x-request-handler:
-                  - handle_req:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-            /sections-lead/{title}:
-              get:
-                x-setup-handler:
-                  - init:
-                      method: put
-                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections-lead
-                      body:
-                        revisionRetentionPolicy:
-                          type: 'latest'
-                          count: 1
-                          grace_ttl: 86400
-                        valueType: 'json'
-                        version: 1
-                x-request-handler:
-                  - handle_req:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections-lead/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-            /sections-remaining/{title}:
-              get:
-                x-setup-handler:
-                  - init:
-                      method: put
-                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-html-sections-remaining
-                      body:
-                        revisionRetentionPolicy:
-                          type: 'latest'
-                          count: 1
-                          grace_ttl: 86400
-                        valueType: 'json'
-                        version: 1
-                x-request-handler:
-                  - handle_req:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-html-sections-remaining/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-            /text/{title}:
-              get:
-                x-setup-handler:
-                  - init:
-                      method: put
-                      uri: /{domain}/sys/key_rev_value/mobileapps.mobile-text
-                      body:
-                        revisionRetentionPolicy:
-                          type: 'latest'
-                          count: 1
-                          grace_ttl: 86400
-                        valueType: 'json'
-                        version: 1
-                x-request-handler:
-                  - handle_req:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/mobileapps/handling/rev/mobile-text/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-            /handling/rev/{route}/{title}:
-              get:
-                x-request-handler:
-                  - get_rev:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/page_revisions/page/{title}
-                        headers:
-                          cache-control: '{cache-control}'
-                  - cache_branch:
-                      request:
-                        method: post
-                        uri: /{domain}/sys/mobileapps/handling/content/{$$.default($.request.headers.cache-control, 'none-given')}/{route}/{title}
-                        body: '{$.get_rev.body}'
-            /handling/content/no-cache/{route}/{title}:
-              post:
-                x-request-handler:
-                  - get_mobileapps:
-                      request:
-                        method: get
-                        uri: http://appservice.wmflabs.org/{domain}/v1/page/{route}/{title}
-                        headers:
-                          x-restbase-etag: '{$.request.body.items[0].rev}/{$.request.body.items[0].tid}'
-                  - store:
-                      request:
-                        method: put
-                        uri: /{domain}/sys/key_rev_value/mobileapps.{route}/{title}/{$.request.body.items[0].rev}/{$.request.body.items[0].tid}
-                        headers:
-                          content-type: application/json
-                        body:
-                          headers: '{$$.strip($.get_mobileapps.headers, ["content-length", "content-encoding"])}'
-                          body: '{$.get_mobileapps.body}'
-                      return:
-                        status: 200
-                        headers: '{$$.strip($.get_mobileapps.headers, ["content-length", "content-encoding"])}'
-                        body: '{$.get_mobileapps.body}'
-            /handling/content/{cache-default}/{route}/{title}:
-              post:
-                x-request-handler:
-                  - check_storage:
-                      request:
-                        method: get
-                        uri: /{domain}/sys/key_rev_value/mobileapps.{route}/{title}/{$.request.body.items[0].rev}/{$.request.body.items[0].tid}
-                      return_if:
-                        status: '2xx'
-                      return:
-                        status: 200
-                        headers: '{$.check_storage.body.headers}'
-                        body: '{$.check_storage.body.body}'
-                      catch:
-                        status: 404
-                  - render:
-                      request:
-                        method: post
-                        uri: /{domain}/sys/mobileapps/handling/content/no-cache/{route}/{title}
-                        body: '{$.request.body}'
+            /v1:
+              x-modules:
+                - name: mobileapps-sys
+                  path: mods/wikimedia/v1/mobileapps
+                  type: spec
+                  options:
+                    host: http://appservice.wmflabs.org
 
   global-content: &gb/content/1.0.0
     swagger: '2.0'

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -404,6 +404,7 @@ templates:
                   status: 200
                   headers: '{$$.merge($.mathoid.body[$.request.params.format].headers,$$.merge($$.strip($.mathoid.headers, ["content-length", "content-encoding"]), {"x-resource-location": $.request.headers.x-resource-location}))}'
                   body: '{$.mathoid.body[$.request.params.format].body}'
+
       /{module:pageviews}:
         x-modules:
           - name: pageviews
@@ -467,7 +468,7 @@ services:
 test:
   content_types:
     html: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.1.0"
-    data-parsoid: application/json; profile="mediawiki.org/specs/data-parsoid/0.0.1"
+    data-parsoid: application/json; charset=utf-8; profile="mediawiki.org/specs/data-parsoid/0.0.1"
     wikitext: text/plain; charset=utf-8; profile="mediawiki.org/specs/wikitext/1.0.0"
 
 logging:

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -268,6 +268,7 @@ function isSimpleChain(requestChain) {
             && requestChain[0].length === 1) {
         var requestTemplate = requestChain[0][0];
         return requestTemplate.request
+            && !requestTemplate.return_if
             && !requestTemplate.return
             && !requestTemplate.catch;
     } else {

--- a/lib/router.js
+++ b/lib/router.js
@@ -250,7 +250,7 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec,
                 specRoot.paths[prefixPath][methodName] = method;
             }
 
-            if (node.value.methods[methodName]) {
+            if (node.value.methods.hasOwnProperty(methodName)) {
                 throw new Error('Trying to re-define existing method '
                     + node.value.path + ':' + methodName);
             }

--- a/mods/wikimedia/v1/mobileapps.yaml
+++ b/mods/wikimedia/v1/mobileapps.yaml
@@ -1,0 +1,141 @@
+info:
+  title: Mobileapps sys API module
+paths:
+  /handling/rev/{route}/{title}:
+    get:
+      x-request-handler:
+        - get_rev:
+            request:
+              method: get
+              uri: /{domain}/sys/page_revisions/page/{title}
+              headers:
+                cache-control: '{cache-control}'
+        - cache_branch:
+            request:
+              method: post
+              uri: /{domain}/sys/mobileapps/v1/handling/content/{route}/{$$.default($.request.headers.cache-control, 'none-given')}/{title}
+              headers:
+                content-type: application/json
+              body: '{$.get_rev.body}'
+
+  /handling/content/mobile-sections/no-cache/{title}:
+    post:
+      x-request-handler:
+        - get_mobileapps:
+            request:
+              method: get
+              uri: '{+$$.options.host}/{domain}/v1/page/mobile-sections/{title}'
+              headers:
+                x-restbase-etag: '{$.request.body.items[0].rev}/{$.request.body.items[0].tid}'
+        - store_lead:
+            request:
+              method: put
+              uri: /{domain}/sys/key_value/mobileapps.lead/{title}/{$.request.body.items[0].tid}
+              headers: '{$.get_mobileapps.headers}'
+              body: '{$.get_mobileapps.body.lead}'
+        - store_remaining:
+            request:
+              method: put
+              uri: /{domain}/sys/key_value/mobileapps.remaining/{title}/{$.request.body.items[0].tid}
+              headers: '{$.get_mobileapps.headers}'
+              body: '{$.get_mobileapps.body.remaining}'
+        - return:
+            return:
+              status: 200
+              headers: '{$.get_mobileapps.headers}'
+              body: '{$.get_mobileapps.body}'
+
+  /handling/content/mobile-sections/{cache-default}/{title}:
+    post:
+      x-setup-handler:
+        - init-lead:
+            method: put
+            uri: /{domain}/sys/key_value/mobileapps.lead
+            body:
+              revisionRetentionPolicy:
+                type: latest
+                count: 1
+                grace_ttl: 86400
+              valueType: json
+              updates:
+                pattern: timeseries
+        - init-remaining:
+            method: put
+            uri: /{domain}/sys/key_value/mobileapps.remaining
+            body:
+              revisionRetentionPolicy:
+                type: latest
+                count: 1
+                grace_ttl: 86400
+              valueType: json
+              updates:
+                pattern: timeseries
+      x-request-handler:
+        - check_storage_lead:
+            request:
+              method: get
+              uri: /{domain}/sys/key_value/mobileapps.lead/{title}/{$.request.body.items[0].tid}
+            catch:
+              status: 404
+        - check_storage_remaining:
+            request:
+              method: get
+              uri: /{domain}/sys/key_value/mobileapps.remaining/{title}/{$.request.body.items[0].tid}
+            catch:
+              status: 404
+            return_if:
+              status: '2xx'
+            return:
+              status: 200
+              headers: '{$.check_storage_lead.headers}'
+              body:
+                lead: '{$.check_storage_lead.body}'
+                remaining: '{$.check_storage_remaining.body}'
+        - render:
+            request:
+              method: post
+              uri: /{domain}/sys/mobileapps/v1/handling/content/mobile-sections/no-cache/{title}
+              body: '{$.request.body}'
+
+  /handling/content/mobile-sections-lead/{cache-default}/{title}:
+    post:
+      x-request-handler:
+        - check_storage:
+            request:
+              method: get
+              uri: /{domain}/sys/key_value/mobileapps.lead/{title}/{$.request.body.items[0].tid}
+            return_if:
+              status: '2xx'
+            catch:
+              status: 404
+        - get_sections:
+            request:
+              method: post
+              uri: /{domain}/sys/mobileapps/v1/handling/content/mobile-sections/no-cache/{title}
+              body: '{$.request.body}'
+            return:
+              status: 200
+              headers: '{$.get_sections.headers}'
+              body: '{$.get_sections.body.lead}'
+
+  /handling/content/mobile-sections-remaining/{cache-default}/{title}:
+    post:
+      x-request-handler:
+        - check_storage:
+            request:
+              method: get
+              uri: /{domain}/sys/key_value/mobileapps.remaining/{title}/{$.request.body.items[0].tid}
+            return_if:
+              status: '2xx'
+            catch:
+              status: 404
+        - get_sections:
+            request:
+              method: post
+              uri: /{domain}/sys/mobileapps/v1/handling/content/mobile-sections/no-cache/{title}
+              body: '{$.request.body}'
+            return:
+              status: 200
+              headers: '{$.get_sections.headers}'
+              body: '{$.get_sections.body.remaining}'
+

--- a/specs/mediawiki/v1/mobileapps.yaml
+++ b/specs/mediawiki/v1/mobileapps.yaml
@@ -1,51 +1,10 @@
 # MobileApps page-manipulation service
 
 swagger: 2.0
-x-default-params:
-  domain: en.wikipedia.org
 paths:
-  /{module:page}/mobile-html/{title}:
+  /{module:page}/mobile-sections/{title}:
     get:
       tags:
-        - Page content
-        - Mobile
-      description: >
-        Retrieve the latest HTML for a page title optimised for viewing with
-        native mobile applications.
-
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
-      produces:
-        - text/html
-      parameters:
-        - name: title
-          in: path
-          description: The page title
-          type: string
-          required: true
-      responses:
-        '200':
-          description: The HTML for the given page title.
-        '404':
-          description: Unknown page title
-          schema:
-            $ref: '#/definitions/problem'
-        default:
-          description: Error
-          schema:
-            $ref: '#/definitions/problem'
-      x-request-handler:
-        - get_from_backend:
-            request:
-              method: get
-              uri: /{domain}/sys/mobileapps/html/{title}
-              headers:
-                cache-control: '{cache-control}'
-      x-monitor: false
-
-  /{module:page}/mobile-html-sections/{title}:
-    get:
-      tags:
-        - Page content
         - Mobile
       description: >
         Retrieve the latest HTML for a page title optimised for viewing with
@@ -75,10 +34,10 @@ paths:
         - get_from_backend:
             request:
               method: get
-              uri: /{domain}/sys/mobileapps/sections/{title}
+              uri: /{domain}/sys/mobileapps/v1/handling/rev/mobile-sections/{title}
               headers:
                 cache-control: '{cache-control}'
-      x-monitor: false
+      x-monitor: true
       x-amples:
         - title: Get MobileApps Foobar page
           request:
@@ -88,12 +47,14 @@ paths:
           response:
             status: 200
             headers:
-              content-type: /aplication\/json/
+              content-type: /application\/json/
+            body:
+              lead: /.+/
+              remaining: /.+/
 
-  /{module:page}/mobile-html-sections-lead/{title}:
+  /{module:page}/mobile-sections-lead/{title}:
     get:
       tags:
-        - Page content
         - Mobile
       description: >
         Retrieve the lead section of the latest HTML for a page title optimised
@@ -123,15 +84,14 @@ paths:
         - get_from_backend:
             request:
               method: get
-              uri: /{domain}/sys/mobileapps/sections-lead/{title}
+              uri: /{domain}/sys/mobileapps/v1/handling/rev/mobile-sections-lead/{title}
               headers:
                 cache-control: '{cache-control}'
       x-monitor: false
 
-  /{module:page}/mobile-html-sections-remaining/{title}:
+  /{module:page}/mobile-sections-remaining/{title}:
     get:
       tags:
-        - Page content
         - Mobile
       description: >
         Retrieve the remainder of the latest HTML (without the lead section) for
@@ -162,7 +122,7 @@ paths:
         - get_from_backend:
             request:
               method: get
-              uri: /{domain}/sys/mobileapps/sections-remaining/{title}
+              uri: /{domain}/sys/mobileapps/v1/handling/rev/mobile-sections-remaining/{title}
               headers:
                 cache-control: '{cache-control}'
       x-monitor: false
@@ -170,7 +130,6 @@ paths:
   /{module:page}/mobile-text/{title}:
     get:
       tags:
-        - Page content
         - Mobile
       description: >
         Retrieve the *lite* version of the latest HTML for a page title optimised for viewing with
@@ -200,7 +159,7 @@ paths:
         - get_from_backend:
             request:
               method: get
-              uri: /{domain}/sys/mobileapps/text/{title}
+              uri: '{+$$.options.host}/{domain}/v1/page/mobile-text/{title}'
               headers:
                 cache-control: '{cache-control}'
       x-monitor: false

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -198,7 +198,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: application/json; profile="mediawiki.org/specs/data-parsoid/0.0.1"
+                content-type: application/json; charset=utf-8; profile="mediawiki.org/specs/data-parsoid/0.0.1"
 definitions:
   defaultError:
     required:


### PR DESCRIPTION
This PR brings many changes to the MobileApps endpoints in RESTBase. Firstly, this a disruptive change for the public API:
- `/page/mobile-html` ceases to exist
- `-html` is being dropped from route names of the other endpoints

Secondly, we now store only the latest render for each title, and do so only for the `mobile-sections` endpoint. Two *key_value* buckets are used for that: `mobileapps.lead` and `mobileapps.remaining`, each storing a part of the response, respectively so that they can be served efficiently, being more popular then the main `mobile-sections` route.

Thirdly, with regards to refreshing the content, only the `mobile-sections` route causes content to be regenerated; sending a `no-cache` request to `mobile-sections-lead` and `mobile-sections-remaining` will cause RESTBase to simply return the latest stored content.

Finally, all of the paths have been simplified and moved out of the configuration file into its own spec module.

This PR also brings some improvements and fixes. Namely:
- the *key_value* module now accepts compression and updates settings
- some `Content-Type` checks in tests have the additional (now-required) `charset` component
- in the handler templating code, added `return_if` to the list of components determining if a request is simple or not
- for route loading, use `hasOwnProperty()` to check if a function for a route/method has been defined