### PR TITLE
Allow directly loading JSON

### DIFF
--- a/mods/pageviews.js
+++ b/mods/pageviews.js
@@ -78,15 +78,20 @@ var tableSchemas = {
     },
     tops: {
         table: tables.tops,
-        version: 1,
+        version: 2,
         attributes: {
             project: 'string',
             access: 'string',
             year: 'string',
             month: 'string',
             day: 'string',
-            // format for this is a json array: [{rank: 1, article: <<title>>, views: 123}, ...]
-            articles: 'string'
+            // this is deprecated, it used to be json stringified to look like:
+            // [{\"rank\": 1, \"article\": \"<<title>>\", \"views\": 123}, ...]
+            articles: 'string',
+            // this will be preferred to articles and uses the same format
+            // NOTE: article titles will be decoded in the output JSON
+            // for consistency with other endpoints
+            articlesJSON: 'json'
         },
         index: [
             { attribute: 'project', type: 'hash' },
@@ -365,7 +370,40 @@ PJVS.prototype.pageviewsForTops = function(restbase, req) {
 
     }).catch(notFoundCatcher);
 
-    return dataRequest.then(normalizeResponse);
+    return dataRequest.then(normalizeResponse).then(function(res) {
+        if (res.body.items) {
+            res.body.items.forEach(function(item) {
+                // prefer the articlesJSON column if it's loaded
+                if (item.articlesJSON !== null) {
+                    try {
+                        item.articles = item.articlesJSON.map(function(a) {
+                            a.article = decodeURIComponent(a.article);
+                            return a;
+                        });
+                    } catch (e) {
+                        item.articles = null;
+                    }
+                } else {
+                    try {
+                        item.articles = JSON.parse(item.articles);
+                    } catch (e) {
+                        throw new rbUtil.HTTPError({
+                            status: 500,
+                            body: {
+                                type: 'error',
+                                description: 'This response contained invalid JSON, we are ' +
+                                    'working on fixing the problem, but until then you can ' +
+                                    'try a different date.'
+                            }
+                        });
+                    }
+                }
+                delete item.articlesJSON;
+            });
+        }
+
+        return res;
+    });
 };
 
 

--- a/mods/pageviews.js
+++ b/mods/pageviews.js
@@ -89,8 +89,6 @@ var tableSchemas = {
             // [{\"rank\": 1, \"article\": \"<<title>>\", \"views\": 123}, ...]
             articles: 'string',
             // this will be preferred to articles and uses the same format
-            // NOTE: article titles will be decoded in the output JSON
-            // for consistency with other endpoints
             articlesJSON: 'json'
         },
         index: [
@@ -375,14 +373,7 @@ PJVS.prototype.pageviewsForTops = function(restbase, req) {
             res.body.items.forEach(function(item) {
                 // prefer the articlesJSON column if it's loaded
                 if (item.articlesJSON !== null) {
-                    try {
-                        item.articles = item.articlesJSON.map(function(a) {
-                            a.article = decodeURIComponent(a.article);
-                            return a;
-                        });
-                    } catch (e) {
-                        item.articles = null;
-                    }
+                    item.articles = item.articlesJSON;
                 } else {
                     try {
                         item.articles = JSON.parse(item.articles);

--- a/specs/test.yaml
+++ b/specs/test.yaml
@@ -166,7 +166,7 @@ paths:
                   v: '{$.request.params.v}'
       x-monitor: false
 
-  /{module:pageviews}/insert-top/{project}/{access}/{year}/{month}/{day}/{data}:
+  /{module:pageviews}/insert-top/{project}/{access}/{year}/{month}/{day}:
     post:
       x-request-handler:
         - put_to_storage:
@@ -181,5 +181,5 @@ paths:
                   year: '{$.request.params.year}'
                   month: '{$.request.params.month}'
                   day: '{$.request.params.day}'
-                  articles: '{$.request.params.data}'
+                  articlesJSON: '{$.request.body.articles}'
       x-monitor: false

--- a/test/features/pageviews/pageviews.js
+++ b/test/features/pageviews/pageviews.js
@@ -169,7 +169,7 @@ describe('pageviews endpoints', function () {
                         views: 2000
                     },{
                         rank: 2,
-                        article: 't%22w%22o',
+                        article: 'two\\',
                         views: 1000
                     }
                 ]
@@ -184,7 +184,7 @@ describe('pageviews endpoints', function () {
             assert.deepEqual(res.body.items.length, 1);
             assert.deepEqual(res.body.items[0].articles[0].article, 'o"n"e');
             assert.deepEqual(res.body.items[0].articles[1].views, 1000);
-            assert.deepEqual(res.body.items[0].articles[1].article, 't"w"o');
+            assert.deepEqual(res.body.items[0].articles[1].article, 'two\\');
         });
     });
 });

--- a/test/features/pageviews/pageviews.js
+++ b/test/features/pageviews/pageviews.js
@@ -22,7 +22,7 @@ describe('pageviews endpoints', function () {
     var insertArticleEndpoint = '/pageviews/insert-per-article-flat/en.wikipedia/one/daily/2015070200';
     var insertProjectEndpoint = '/pageviews/insert-aggregate/en.wikipedia/all-access/all-agents/hourly/1970010100';
     var insertProjectEndpointLong = '/pageviews/insert-aggregate-long/en.wikipedia/all-access/all-agents/hourly/1970010100';
-    var insertTopsEndpoint = '/pageviews/insert-top/en.wikipedia/mobile-web/2015/all-months/all-days/';
+    var insertTopsEndpoint = '/pageviews/insert-top/en.wikipedia/mobile-web/2015/all-months/all-days';
 
     function fix(b, s, u) { return b.replace(s, s + u); }
     // Test Article Endpoint
@@ -161,19 +161,30 @@ describe('pageviews endpoints', function () {
 
     it('should return the expected tops data after insertion', function () {
         return preq.post({
-            uri: server.config.globalURL + insertTopsEndpoint + JSON.stringify([{
-                rank: 1,
-                article: 'one',
-                views: 2000
-            }])
+            uri: server.config.globalURL + insertTopsEndpoint,
+            body: {
+                articles: [{
+                        rank: 1,
+                        article: 'o"n"e',
+                        views: 2000
+                    },{
+                        rank: 2,
+                        article: 't%22w%22o',
+                        views: 1000
+                    }
+                ]
+            },
+            headers: { 'content-type': 'application/json' }
+
         }).then(function() {
             return preq.get({
                 uri: server.config.globalURL + topsEndpoint
             });
         }).then(function(res) {
             assert.deepEqual(res.body.items.length, 1);
-            var article = JSON.parse(res.body.items[0].articles)[0];
-            assert.deepEqual(article.views, 2000);
+            assert.deepEqual(res.body.items[0].articles[0].article, 'o"n"e');
+            assert.deepEqual(res.body.items[0].articles[1].views, 1000);
+            assert.deepEqual(res.body.items[0].articles[1].article, 't"w"o');
         });
     });
 });


### PR DESCRIPTION
We were loading a JSON string instead of actual JSON, and we were
running into encoding problems.  This change upgrades the table schema
to support JSON directly.  We'll fix the load and backfill as much as
needed.

Bug: T118931