### PR TITLE
Mathoid: Use POST only for formula check, GET for renders

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -72,10 +72,14 @@ templates:
           # One hour, for now.
           response_cache-control: 'max-age: 3600, s-maxage: 3600'
 
+      - name: mathoid
+        path: specs/media/v1/mathoid
+        type: spec
+        options:
+          host: http://mathoid-tester.wmflabs.org
+
     x-subspecs:
       - mediawiki/v1/content
-      - media/v1/mathoid
-    # - mediawiki/v1/revision-scoring
 
   wmf-sys-1.0.0: &wp/sys/1.0.0
     info:
@@ -158,39 +162,16 @@ templates:
               # For local testing, use:
               # parsoidHost: http://localhost:8000
 
-      /{module:graphoid}/v1/png/{title}/{revision}/{graph_id}:
-        get:
-          x-request-handler:
-            - get_from_graphoid:
-                request:
-                  uri: http://graphoid.wikimedia.org/{domain}/v1/png/{title}/{revision}/{graph_id}
-
       /{module:mobileapps}:
         x-subspec:
           paths:
             /v1:
               x-modules:
-                - path: mods/wikimedia/v1/mobileapps
+                - name: mobileapps-sys
+                  path: mods/wikimedia/v1/mobileapps
                   type: spec
                   options:
                     host: http://appservice.wmflabs.org
-
-#      /{module:revscore}:
-#        title: Simple revscore service wrapper
-#        x-modules:
-#          # Generic revision service interface; Expects requests of the form
-#          # /{title}/{revision}.
-#          # Specific interface documentation (content types etc) at public
-#          # entry point, although we might also want to enforce them
-#          # internally.
-#          - name: restbase-mod-service
-#            version: 1.0.0 # simple service module, to be shared
-#            options:
-#              storage:
-#                uri: /{domain}/sys/key_rev_value/revscore.scores/{title}/{revision}
-#              service: 
-#                uri: http://revscore.wikimedia.org/{domain}/{title}/{revision}
-
 
   global-content: &gb/content/1.0.0
     swagger: '2.0'
@@ -199,8 +180,12 @@ templates:
     # Override the base path for host-based (proxied) requests. In our case,
     # we proxy https://{domain}/api/rest_v1/ to the API.
     x-host-basePath: /api/rest_v1
-    x-subspecs:
-      - media/v1/mathoid
+    x-modules:
+      - name: mathoid
+        path: specs/media/v1/mathoid
+        type: spec
+        options:
+          host: http://mathoid-tester.wmflabs.org
     paths:
       /metrics:
         x-subspecs:
@@ -214,108 +199,6 @@ templates:
       /{module:table}: *wp/sys/table
       /{module:key_value}: *wp/sys/key_value
       /{module:post_data}: *wp/sys/post_data
-      /{module:mathoid}/v1/request/{format}:
-        post:
-          x-request-handler:
-            - store:
-                request:
-                  method: put
-                  uri: /{domain}/sys/post_data/mathoid.request/
-                  body:
-                    q: '{$.request.body.q}'
-                    type: '{$$.default($.request.body.type, "tex")}'
-            - handle_req:
-                request:
-                  method: post
-                  uri: /{domain}/sys/mathoid/v1/handler/{format}
-                  headers:
-                    cache-control: '{cache-control}'
-                    x-resource-location: '{$.store.body}'
-                  body:
-                    q: '{$.request.body.q}'
-                    type: '{$$.default($.request.body.type, "tex")}'
-
-      /{module:mathoid}/v1/request/{format}/{hash}:
-        get:
-          x-setup-handler:
-            - init:
-                uri: /{domain}/sys/post_data/mathoid.request
-          x-request-handler:
-            - get_from_storage:
-                request:
-                  method: get
-                  uri: /{domain}/sys/post_data/mathoid.request/{hash}
-            - handle_req:
-                request:
-                  method: post
-                  uri: /{domain}/sys/mathoid/v1/handler/{format}
-                  headers:
-                    cache-control: '{cache-control}'
-                    x-resource-location: '{$.request.params.hash}'
-                  body: '{$.get_from_storage.body}'
-
-      /{module:mathoid}/v1/handler/{format}:
-        post:
-          x-setup-handler:
-            - init:
-                uri: /{domain}/sys/key_value/mathoid.data
-                body:
-                  keyType: string
-                  valueType: json
-          x-request-handler:
-            - check_storage:
-                request:
-                  method: get
-                  uri: /{domain}/sys/key_value/mathoid.data/{$.request.headers.x-resource-location}
-                  headers:
-                    cache-control: '{cache-control}'
-                return_if:
-                  status: '2xx'
-                return:
-                  status: 200
-                  headers: '{$$.merge($.check_storage.body.data[$.request.params.format].headers,$.check_storage.body.headers)}'
-                  body: '{$.check_storage.body.data[$.request.params.format].body}'
-                catch:
-                  status: 404
-            - mathoid:
-                request:
-                  method: post
-                  uri: http://mathoid-tester.wmflabs.org/complete
-                  body:
-                    q: '{$.request.body.q}'
-                    type: '{$.request.body.type}'
-            - store:
-                request:
-                  method: put
-                  uri: /{domain}/sys/key_value/mathoid.data/{$.request.headers.x-resource-location}
-                  headers:
-                    content-type: application/json
-                  body:
-                    headers: '{$$.merge($$.strip($.mathoid.headers, ["content-length", "content-encoding"]), {"x-resource-location": $.request.headers.x-resource-location})}'
-                    data: '{$.mathoid.body}'
-                return:
-                  status: 200
-                  headers: '{$$.merge($.mathoid.body[$.request.params.format].headers,$$.merge($.mathoid.headers, {"x-resource-location": $.request.headers.x-resource-location}))}'
-                  body: '{$.mathoid.body[$.request.params.format].body}'
-
-      /{module:pageviews}/per-article/{+rest}:
-        get:
-          x-request-handler:
-            - get_from_backend:
-                request:
-                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/{+rest}
-      /{module:pageviews}/per-project/{+rest}:
-        get:
-          x-request-handler:
-            - get_from_backend:
-                request:
-                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/aggregate/{+rest}
-      /{module:pageviews}/top/{+rest}:
-        get:
-          x-request-handler:
-            - get_from_backend:
-                request:
-                  uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/top/{+rest}
 
   wp-default-1.0.0: &wp/default/1.0.0
     x-subspecs:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -70,9 +70,14 @@ templates:
           # One hour, for now.
           response_cache-control: 'max-age: 3600, s-maxage: 3600'
 
+      - name: mathoid
+        path: specs/media/v1/mathoid
+        type: spec
+        options:
+          host: http://mathoid-tester.wmflabs.org
+
     x-subspecs:
       - mediawiki/v1/content
-      - media/v1/mathoid
       - test
 
   wmf-sys-1.0.0: &wp/sys/1.0.0
@@ -167,8 +172,13 @@ templates:
     swagger: '2.0'
     info: *wp/content-info/1.0.0
     securityDefinitions: *wp/content-security/1.0.0
+    x-modules:
+      - name: mathoid
+        path: specs/media/v1/mathoid
+        type: spec
+        options:
+          host: http://mathoid-tester.wmflabs.org
     x-subspecs:
-      - media/v1/mathoid
       - analytics/v1/pageviews
       - test
 
@@ -181,87 +191,6 @@ templates:
       /{module:table}: *wp/sys/table
       /{module:key_value}: *wp/sys/key_value
       /{module:post_data}: *wp/sys/post_data
-      /{module:mathoid}/v1/request/{format}:
-        post:
-          x-request-handler:
-            - store:
-                request:
-                  method: put
-                  uri: /{domain}/sys/post_data/mathoid.request/
-                  body:
-                    q: '{$.request.body.q}'
-                    type: '{$$.default($.request.body.type, "tex")}'
-            - handle_req:
-                request:
-                  method: post
-                  uri: /{domain}/sys/mathoid/v1/handler/{format}
-                  headers:
-                    cache-control: '{cache-control}'
-                    x-resource-location: '{$.store.body}'
-                  body:
-                    q: '{$.request.body.q}'
-                    type: '{$$.default($.request.body.type, "tex")}'
-      /{module:mathoid}/v1/request/{format}/{hash}:
-        get:
-          x-setup-handler:
-            - init:
-                uri: /{domain}/sys/post_data/mathoid.request
-          x-request-handler:
-            - get_from_storage:
-                request:
-                  method: get
-                  uri: /{domain}/sys/post_data/mathoid.request/{hash}
-            - handle_req:
-                request:
-                  method: post
-                  uri: /{domain}/sys/mathoid/v1/handler/{format}
-                  headers:
-                    cache-control: '{cache-control}'
-                    x-resource-location: '{$.request.params.hash}'
-                  body: '{$.get_from_storage.body}'
-      /{module:mathoid}/v1/handler/{format}:
-        post:
-          x-setup-handler:
-            - init:
-                uri: /{domain}/sys/key_value/mathoid.data
-                body:
-                  keyType: string
-                  valueType: json
-          x-request-handler:
-            - check_storage:
-                request:
-                  method: get
-                  uri: /{domain}/sys/key_value/mathoid.data/{$.request.headers.x-resource-location}
-                  headers:
-                    cache-control: '{cache-control}'
-                catch:
-                  status: 404
-                return_if:
-                  status: '2xx'
-                return:
-                  status: 200
-                  headers: '{$$.merge($.check_storage.body.data[$.request.params.format].headers,$.check_storage.body.headers)}'
-                  body: '{$.check_storage.body.data[$.request.params.format].body}'
-            - mathoid:
-                request:
-                  method: post
-                  uri: http://mathoid-tester.wmflabs.org/complete
-                  body:
-                    q: '{$.request.body.q}'
-                    type: '{$.request.body.type}'
-            - store:
-                request:
-                  method: put
-                  uri: /{domain}/sys/key_value/mathoid.data/{$.request.headers.x-resource-location}
-                  headers:
-                    content-type: application/json
-                  body:
-                    headers: '{$$.merge($$.strip($.mathoid.headers, ["content-length", "content-encoding"]), {"x-resource-location": $.request.headers.x-resource-location})}'
-                    data: '{$.mathoid.body}'
-                return:
-                  status: 200
-                  headers: '{$$.merge($.mathoid.body[$.request.params.format].headers,$$.merge($$.strip($.mathoid.headers, ["content-length", "content-encoding"]), {"x-resource-location": $.request.headers.x-resource-location}))}'
-                  body: '{$.mathoid.body[$.request.params.format].body}'
 
       /{module:pageviews}:
         x-modules:

--- a/specs/media/v1/mathoid.yaml
+++ b/specs/media/v1/mathoid.yaml
@@ -3,53 +3,40 @@
 swagger: 2.0
 
 paths:
-  /{module:media}/math/{format}:
+  /{module:media}/math/check/{type}:
     post:
-      tags:
-        - Media
-        - Math
+      tags: ['Math']
       description: >
-        Renders a TeX formula into its mathematic representation in the given
-        format. Available formats are svg and mml. The response contains the
-        `x-resource-location` header which can be used to retrieve the same
-        formula in a different render format. Just append the value of the
-        header to `/media/math/{format}/` and perform a GET request against
-        that URL.
+        Checks the supplied TeX formula for correctness and returns the
+        normalised formula representation as well as information about
+        identifiers. Available types are tex and inline-tex. The response
+        contains the `x-resource-location` header which can be used to retrieve
+        the render of the checked formula in one of the supported rendering
+        formats. Just append the value of the header to `/media/math/{format}/`
+        and perform a GET request against that URL.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
       produces:
-        - image/svg+xml
-        - application/mathml+xml
         - application/json
       parameters:
-        - name: format
-          in: path
-          description: The output format; can be svg or mml
-          type: string
-          required: true
-          enum:
-            - svg
-            - mml
-        - name: q
-          in: formData
-          description: The formula to render
-          type: string
-          required: true
         - name: type
-          in: formData
-          description: The input type of the given formula; can be tex, inline-tex, mml or ascii
+          in: path
+          description: The input type of the given formula; can be tex or inline-tex
           type: string
-          required: false
+          required: true
           enum:
             - tex
             - inline-tex
-            - mml
-            - ascii
+        - name: q
+          in: formData
+          description: The formula to check
+          type: string
+          required: true
       responses:
         '200':
-          description: The rendered formula
+          description: Information about the checked formula
         '400':
-          description: Invalid format or type
+          description: Invalid type
           schema:
             $ref: '#/definitions/problem'
         default:
@@ -61,60 +48,64 @@ paths:
             - header: 'x-client-ip'
               patterns:
                 - internal
-      x-request-handler:
-        - do_post:
-            request:
-              method: post
-              uri: /wikimedia.org/sys/mathoid/v1/request/{format}
-              headers:
-                cache-control: '{cache-control}'
-              body: '{$.request.body}'
       x-monitor: true
       x-amples:
-        - title: Mathoid - test formula
+        - title: Mathoid - check test formula
           request:
             params:
-              domain: en.wikipedia.org
-              format: svg
-            body:
-              q: E=mc^2
               type: tex
+            body:
+              q: E=mc^{2}
           response:
             status: 200
             headers:
-              content-type: /^image\/svg/
-            body: /.+/
-        - title: Mathoid - test formula from storage (global domain)
-          request:
-            params:
-              domain: wikimedia.org
-              format: mml
+              content-type: /^application\/json/
+              x-resource-location: /.+/
             body:
-              q: E=mc^2
-              type: tex
-          response:
-            status: 200
-            headers:
-              content-type: /^application\/mathml/
-            body: /.+/
+              success: true
+              checked: /.+/
+      x-setup-handler:
+        - init:
+            uri: /wikimedia.org/sys/post_data/mathoid.input
+      x-request-handler:
+        - check_input:
+            request:
+              uri: '{{$$.options.host}}/texvcinfo'
+              headers:
+                content-type: application/json
+              body:
+                q: '{{$.request.body.q}}'
+                type: '{{$.request.params.type}}'
+        - post_store:
+            request:
+              method: put
+              uri: /wikimedia.org/sys/post_data/mathoid.input/
+              headers:
+                content-type: application/json
+              body:
+                q: '{{$.check_input.body.checked}}'
+                type: '{{$.request.params.type}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json
+                x-resource-location: '{{$.post_store.body}}'
+              body: '{$.check_input.body}'
 
-  /{module:media}/math/{format}/{hash}:
+  /{module:media}/math/render/{format}/{hash}:
     get:
-      tags:
-        - Media
-        - Math
+      tags: ['Math']
       description: >
         Given a request hash, renders a TeX formula into its mathematic
         representation in the given format. When a request is issued to the
-        `/media/math/{format}` POST endpoint, the response contains the
+        `/media/math/check/{format}` POST endpoint, the response contains the
         `x-resource-location` header denoting the hash ID of the POST data. Once
-        obtained, this endpoint may be used to avoid sending the payload.
+        obtained, this endpoint has to be used to obtain the actual render.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
       produces:
         - image/svg+xml
         - application/mathml+xml
-        - application/json
       parameters:
         - name: format
           in: path
@@ -133,19 +124,61 @@ paths:
         '200':
           description: The rendered formula
         '404':
-          description: Unknown hash ID
+          description: Unknown format or hash ID
           schema:
             $ref: '#/definitions/problem'
         default:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+      x-monitor: false
+      x-setup-handler:
+        - init_svg:
+            uri: /wikimedia.org/sys/key_value/mathoid.svg
+            body:
+              keyType: string
+              valueType: string
+        - init_mml:
+            uri: /wikimedia.org/sys/key_value/mathoid.mml
+            body:
+              keyType: string
+              valueType: string
       x-request-handler:
-        - stored_post:
+        - check_storage:
             request:
               method: get
-              uri: /wikimedia.org/sys/mathoid/v1/request/{format}/{hash}
+              uri: /wikimedia.org/sys/key_value/mathoid.{$.request.params.format}/{$.request.params.hash}
               headers:
                 cache-control: '{cache-control}'
-      x-monitor: false
+            catch:
+              status: 404
+            return_if:
+              status: '2xx'
+        - get_post:
+            request:
+              uri: /wikimedia.org/sys/post_data/mathoid.input/{$.request.params.hash}
+        - mathoid:
+            request:
+              method: post
+              uri: '{{$$.options.host}}/complete'
+              headers:
+                content-type: application/json
+              body: '{$.get_post.body}'
+        - store_svg:
+            request:
+              method: put
+              uri: /wikimedia.org/sys/key_value/mathoid.svg/{$.request.params.hash}
+              headers: '{$$.merge($.mathoid.body.svg.headers, {"x-resource-location":$.request.params.hash})}'
+              body: '{$.mathoid.body.svg.body}'
+          store_mml:
+            request:
+              method: put
+              uri: /wikimedia.org/sys/key_value/mathoid.mml/{$.request.params.hash}
+              headers: '{$$.merge($.mathoid.body.mml.headers, {"x-resource-location":$.request.params.hash})}'
+              body: '{$.mathoid.body.mml.body}'
+        - return:
+            return:
+              status: 200
+              headers: '{$$.merge($.mathoid.body[$.request.params.format].headers, {"x-resource-location":$.request.params.hash})}'
+              body: '{$.mathoid.body[$.request.params.format].body}'
 


### PR DESCRIPTION
The new textvcinfo endpoint in Mathoid is able to check TeX formulae for correctness and normalised them. The endpoint is rather cheap and quick, so call only this one for POST requests. The normalised response is stored into post storage and hashed. As usual, the hash is returned in the `x-resource-location` header, which can then be used to issue GET requests to `/media/math/render/{format}/{hash}` to obtain an actual render.