### PR TITLE
Make mathoid responses cacheable

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -24,6 +24,8 @@ default_project: &default_project
             host: http://graphoid.wikimedia.org
           mathoid:
             host: http://mathoid-tester.wmflabs.org
+            # 10 days Varnish caching, one day client-side
+            cache-control: s-maxage=864000, max-age=86400
           mobileapps:
             host: http://appservice.wmflabs.org
 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -73,6 +73,7 @@ default_project: &default_project
           - path: v1/mathoid.yaml
             options:
               host: http://mathoid-tester.wmflabs.org
+              cache-control: s-maxage=86400, max-age=86400
 
     /{api:sys}: &default_project_paths_sys
       x-modules: &default_project_paths_sys_modules

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -70,12 +70,12 @@ paths:
       x-request-handler:
         - check_input:
             request:
-              uri: '{{$$.options.host}}/texvcinfo'
+              uri: '{{ options.host }}/texvcinfo'
               headers:
                 content-type: application/json
               body:
-                q: '{{$.request.body.q}}'
-                type: '{{$.request.params.type}}'
+                q: '{{ request.body.q }}'
+                type: '{{ request.params.type }}'
         - post_store:
             request:
               method: put
@@ -83,14 +83,15 @@ paths:
               headers:
                 content-type: application/json
               body:
-                q: '{{$.check_input.body.checked}}'
-                type: '{{$.request.params.type}}'
+                q: '{{ check_input.body.checked }}'
+                type: '{{ request.params.type }}'
             return:
               status: 200
               headers:
                 content-type: application/json
-                x-resource-location: '{{$.post_store.body}}'
-              body: '{$.check_input.body}'
+                cache-control: '{{ options.cache-control }}'
+                x-resource-location: '{{ post_store.body }}'
+              body: '{{ check_input.body }}'
 
   /math/render/{format}/{hash}:
     get:
@@ -149,36 +150,36 @@ paths:
               method: get
               uri: /wikimedia.org/sys/key_value/mathoid.{$.request.params.format}/{$.request.params.hash}
               headers:
-                cache-control: '{cache-control}'
+                cache-control: '{{ cache-control }}'
             catch:
               status: 404
             return_if:
               status: '2xx'
-        - get_post:
+        - postdata:
             request:
               uri: /wikimedia.org/sys/post_data/mathoid.input/{$.request.params.hash}
         - mathoid:
             request:
               method: post
-              uri: '{{$$.options.host}}/complete'
+              uri: '{{options.host}}/complete'
               headers:
                 content-type: application/json
-              body: '{$.get_post.body}'
+              body: '{{postdata.body}}'
         - store_svg:
             request:
               method: put
               uri: /wikimedia.org/sys/key_value/mathoid.svg/{$.request.params.hash}
-              headers: '{$$.merge($.mathoid.body.svg.headers, {"x-resource-location":$.request.params.hash})}'
+              headers: "{{ merge(mathoid.body.svg.headers, { 'x-resource-location': request.params.hash }) }}"
               body: '{$.mathoid.body.svg.body}'
           store_mml:
             request:
               method: put
               uri: /wikimedia.org/sys/key_value/mathoid.mml/{$.request.params.hash}
-              headers: '{$$.merge($.mathoid.body.mml.headers, {"x-resource-location":$.request.params.hash})}'
-              body: '{$.mathoid.body.mml.body}'
+              headers: "{{ merge(mathoid.body.mml.headers, { 'x-resource-location': request.params.hash }) }}"
+              body: '{{ mathoid.body.mml.body }}'
         - return:
             return:
               status: 200
-              headers: '{$$.merge($.mathoid.body[$.request.params.format].headers, {"x-resource-location":$.request.params.hash})}'
-              body: '{$.mathoid.body[$.request.params.format].body}'
+              headers: "{{ merge(mathoid.body[request.params.format].headers, { 'x-resource-location': request.params.hash, 'cache-control': options.cache-control }) }}"
+              body: '{{ mathoid.body[request.params.format].body }}'
 

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -61,6 +61,7 @@ paths:
             headers:
               content-type: /^application\/json/
               x-resource-location: /.+/
+              cache-control: /s-maxage/
             body:
               success: true
               checked: /.+/


### PR DESCRIPTION
Clients will directly hit restbase for SVG renders of mathematical formulas.
The URL contains a hash of the original formula, and the render does not
change very often. For this reason, we can allow Varnish to cache these SVGs
for extended periods of time.

This patch adds a cache-control header to all responses, and makes the actual
value configurable as a module parameter.

Task: https://phabricator.wikimedia.org/T120445