### PR TITLE
Trivial: Export actual entry point & release v0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "restbase",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "REST storage and service dispatcher",
-  "main": "server.js",
+  "main": "lib/server.js",
   "scripts": {
     "start": "service-runner",
     "test": "sh test/utils/run_tests.sh test",


### PR DESCRIPTION
Service-runner lets us run several services in a single process. To do this,
we reference each as an npm module. The correct entry point for restbase is
lib/server.js, which this patch updates.