### PR TITLE
Specs: Removed test module from the default project

### DIFF
--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -29,8 +29,11 @@ function staticServe(restbase, req) {
         var contentType = 'text/html';
         if (/\.js$/.test(filePath)) {
             contentType = 'text/javascript';
+            body = body.replace(/underscore\-min\.map/, '?doc=&path=lib/underscore-min.map');
         } else if (/\.png/.test(filePath)) {
             contentType = 'image/png';
+        } else if (/\.map$/.test(filePath)) {
+            contentType = 'application/json';
         } else if (/\.css/.test(filePath)) {
             contentType = 'text/css';
             body = body.replace(/\.\.\/(images|fonts)\//g, '?doc&path=$1/');

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -53,7 +53,6 @@ paths:
         # The main content module, defining page/* and transform entry
         # points.
         - path: v1/content.yaml
-        - path: test/test_module.yaml
       /page:
         - path: v1/mobileapps.yaml
           options: '{{options.mobileapps}}'


### PR DESCRIPTION
Obvious bug-fix: the testing spec was mistakenly exported from the `wmf_default` module, exposing internal test-only endpoints to the public.

Additionally, there's an annoying little bug in docs - Safari requests the css source map for underscore, which results in a 404 logging in by RB. I've added a correct routing for the .map file. Nothing serious, just removes that annoying 404 error.