### PR TITLE
Add a pageviews_proxy.yaml config & subtree / module sharing fixes

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -43,6 +43,12 @@ spec_root: &spec_root
   title: "The RESTBase root"
   paths:
     /{domain:en.wikipedia.org}: *default_project
+    /{domain:fr.wikipedia.org}: *default_project
+    /{domain:de.wikipedia.org}: *default_project
+    /{domain:es.wikipedia.org}: *default_project
+    /{domain:it.wikipedia.org}: *default_project
+    /{domain:da.wikipedia.org}: *default_project
+    /{domain:sv.wikipedia.org}: *default_project
 
     # global domain
     /{domain:wikimedia.org}: *wikimedia.org

--- a/lib/router.js
+++ b/lib/router.js
@@ -50,6 +50,7 @@ ApiScope.prototype.makeChild = function(overrides) {
 function Router(options) {
     this._options = options || {};
     this._nodes = new Map();
+    this._modules = new Map();
     this.router = new SwaggerRouter();
 }
 
@@ -97,9 +98,17 @@ Router.prototype._buildPath = function route(node, path, value) {
 /**
  * Load and initialize a module
  */
-Router.prototype._loadModule = function(modDef, config) {
+Router.prototype._loadModule = function(modDef, globals) {
 
     var self = this;
+
+    // First, check if we have a copy of this module in the cache, so that we
+    // can share it.
+    var cachedModule = self._modules.get(modDef);
+    if (cachedModule && cachedModule._parentGlobals === globals) {
+        return P.resolve(cachedModule);
+    }
+
     var loadPath;
 
     if (modDef.path && !modDef.type) {
@@ -146,7 +155,7 @@ Router.prototype._loadModule = function(modDef, config) {
         // Protect "templates" property from expansion.
         var templates = modDef.options.templates;
         delete modDef.options.templates;
-        options = new Template(modDef.options).expand(config);
+        options = new Template(modDef.options).expand(globals) || {};
         // Add the original "templates" property back.
         options.templates = templates;
     }
@@ -165,7 +174,10 @@ Router.prototype._loadModule = function(modDef, config) {
             var mod = {
                 spec: spec,
                 globals: { options: options, log: options.log },
+                // Needed to check cache validity.
+                _parentGlobals: globals,
             };
+            self._modules.set(modDef, mod);
             return mod;
         });
     } else {
@@ -188,6 +200,9 @@ Router.prototype._loadModule = function(modDef, config) {
             }
             if (!mod.globals) { mod.globals = {}; }
             mod.globals.log = options.log;
+            // Needed to check cache validity.
+            mod._parentGlobals = globals;
+            self._modules.set(modDef, mod);
             return mod;
         });
     }
@@ -433,7 +448,7 @@ Router.prototype._handlePaths = function(rootNode, spec, scope, optionalPathPref
         // Check if we can share the subtree for the pathspec.
         var subtree = self._nodes.get(pathSpec);
         var specPromise;
-        if (!subtree) {
+        if (!subtree || subtree._parentGlobals !== childScope.globals) {
             var segment = path[path.length - 1];
 
             // Check if the subtree already exists, which can happen when
@@ -457,18 +472,16 @@ Router.prototype._handlePaths = function(rootNode, spec, scope, optionalPathPref
                     // has the same value.
                     branchNode.value = value;
                 }
+
+                if (Object.keys(pathSpec).length === 1 && pathSpec['x-modules']) {
+                    subtree._parentGlobals = childScope.globals;
+                    self._nodes.set(pathSpec, subtree);
+                }
             }
 
 
             // Handle the path spec
-            specPromise = self._handleSwaggerPathSpec(subtree, pathSpec, childScope)
-            .then(function() {
-                // If this is a spec root, register the node for potential
-                // sharing with other references to the same root spec.
-                if (childScope.specRoot === spec) {
-                    self._nodes.set(pathSpec, subtree);
-                }
-            });
+            specPromise = self._handleSwaggerPathSpec(subtree, pathSpec, childScope);
         } else {
             // Share the subtree.
             var origSubtree = subtree;

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -71,4 +71,5 @@ paths:
       /post_data: &sys_post_data
         - path: sys/post_data.js
       /pageviews:
-        - path: sys/pageviews.js
+        - path: sys/pageviews_proxy.yaml
+          options: '{{options.pageviews}}'

--- a/sys/pageviews_proxy.yaml
+++ b/sys/pageviews_proxy.yaml
@@ -1,0 +1,24 @@
+# Simple proxy handler, used by the front-end RESTBase to proxy requests to
+# the AQS backend. Pulled in by projects/wikimedia.org.yaml.
+
+paths:
+  /per-article/{+rest}:
+    get:
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/pageviews/per-article/{+rest}'
+
+  /per-project/{+rest}:
+    get:
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/pageviews/aggregate/{+rest}'
+
+  /top/{+rest}:
+    get:
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/pageviews/top/{+rest}'


### PR DESCRIPTION
The frontend service needs to proxy requests to the AQS service. In the
production config, this is implemented by defining custom /sys/pageviews entry
points directly in the config. In new-style configs. this is now a module
referenced by `projects/wikimedia.org.yaml`.