### PR TITLE
Configs: remove page_revisions sys module from the global domain config

### DIFF
--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -66,8 +66,6 @@ paths:
         - path: sys/key_value.js
       /key_rev_value:
         - path: sys/key_rev_value.js
-      /page_revisions:
-        - path: sys/page_revisions.js
       /post_data: &sys_post_data
         - path: sys/post_data.js
       /pageviews:


### PR DESCRIPTION
Obviously we don't need a `page_revisions` module on the global domain.