### PR TITLE
Don't modify the original spec

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -111,17 +111,18 @@ Router.prototype._loadModule = function(modDef, globals) {
 
     var loadPath;
 
-    if (modDef.path && !modDef.type) {
+    var modType = modDef.type;
+    if (modDef.path && !modType) {
         // infer the type from the path
         if (/\.js$/.test(modDef.path)) {
-            modDef.type = 'file';
+            modType = 'file';
         } else if (/\.yaml$/.test(modDef.path)) {
-            modDef.type = 'spec';
+            modType = 'spec';
         }
     }
 
     // Determine the module's load path
-    switch (modDef.type) {
+    switch (modType) {
         case 'file':
         case 'spec':
             if (modDef.path && /^\//.test(modDef.path)) {
@@ -164,7 +165,7 @@ Router.prototype._loadModule = function(modDef, globals) {
     if (!options.log) {
         options.log = this._options.log || function() {};
     }
-    if (modDef.type === 'spec') {
+    if (modType === 'spec') {
         if (!/\.yaml$/.test(loadPath)) {
             loadPath += '.yaml';
         }


### PR DESCRIPTION
The module loading code would fill in the type property if it was missing,
which modifies the original spec object. It's cleaner not to do so, so this
patch moves the type to a local variable.