### PR TITLE
Define /sys/ as api roots to scope metrics

### DIFF
--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -51,6 +51,9 @@ paths:
         - path: v1/content.yaml
 
   /{api:sys}:
+    swagger: 2.0
+    info:
+      x-is-api-root: true
     x-modules:
       /table:
         - type: npm

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -56,6 +56,9 @@ paths:
         - path: v1/pageviews.yaml
 
   /{api:sys}:
+    swagger: 2.0
+    info:
+      x-is-api-root: true
     x-modules:
       /table:
         - type: npm

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -66,6 +66,9 @@ paths:
           options: '{{options.mathoid}}'
 
   /{api:sys}: &default_project_paths_sys
+    swagger: 2.0
+    info:
+      x-is-api-root: true
     x-modules: &default_project_paths_sys_modules
       /table: &sys_table
         - type: npm


### PR DESCRIPTION
API roots define scopes for both the swagger spec and metrics. As we want to
aggregate metrics at the api level (/sys and /v1), we need to define /sys as
an API root as well.

The current logic requires both swagger and info.x-is-api-root attributes to
establish new API spec roots. It feels like we might be able to improve on
this, but the best I can come up with is moving x-is-api-root to the spec
level, and perhaps renaming it. Other ideas?

In any case, we can now tweak this later without affecting third party user's
configs in the normal case.