### PR TITLE
Router refactoring: detect API spec based on the 'api' prefix

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -25,7 +25,7 @@ function RESTBase(options, req) {
         this._parent = par;
         // Remember the request that led to this child instance at each level, so
         // that we can provide nice error reporting and tracing.
-        this._req = par._req;
+        this._req = req;
         this._recursionDepth = par._recursionDepth + 1;
         this._priv = par._priv;
         this.rb_config = this._priv.options.conf;
@@ -173,54 +173,28 @@ RESTBase.prototype.defaultWebRequestHandler = function(req) {
     return P.resolve(preq(req));
 };
 
-
 RESTBase.prototype._isSysRequest = function(req) {
     return ((req.uri.params && req.uri.params.api === 'sys')
         // TODO: Remove once params.api is reliable
-            || (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys'));
+    || (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys'));
 };
 
-// Process one request
-RESTBase.prototype.request = function(req) {
-    // Protect the sys api from direct access
-    // Could consider opening this up with a specific permission later.
-    if (this._recursionDepth === 0 && this._isSysRequest(req)) {
-        return P.reject(new HTTPError({
-            status: 403,
-            body: {
-                type: 'access_denied#sys',
-                title: 'Access to the /{domain}/sys/ hierarchy is restricted to system users.'
-            }
-        }));
-    }
-
-    if (req.method) {
-        req.method = req.method.toLowerCase();
-    }
-
-    return this._request(req);
-};
-
-
-// Internal request handler
-RESTBase.prototype._request = function(req) {
-    var self = this;
-
-    // Special handling for https? requests
-    if (req.uri.constructor === String && /^https?:\/\//.test(req.uri)
-            || req.uri.urlObj) {
-        return this.defaultWebRequestHandler(req);
-    }
-
-    var priv = this._priv;
-    if (this._recursionDepth > priv.options.maxDepth) {
+/**
+ * Checks if the maximum recursion depth has been exceeded by the request.
+ * If yes, the 500 error is thrown, othervise this is a no-op
+ *
+ * @param {Object} req - a current request object
+ * @private
+ */
+RESTBase.prototype._checkMaxRecursionDepth = function(req) {
+    if (this._recursionDepth > this._priv.options.maxDepth) {
         var parents = [];
         var rb = this._parent;
         while (rb) {
             parents.push(rb._req);
             rb = rb._parent;
         }
-        return P.resolve({
+        throw new HTTPError({
             status: 500,
             body: {
                 type: 'request_recursion_depth_exceeded',
@@ -232,22 +206,117 @@ RESTBase.prototype._request = function(req) {
             }
         });
     }
+};
+
+/**
+ * Protects /sys APIs from the direct access.
+ *
+ * @param {Object} req - an original request
+ * @param {Object} match - a found request handler
+ * @private
+ */
+RESTBase.prototype._checkInternalApiRequest = function(req, match) {
+    if (this._recursionDepth === 0 &&
+            (match && match.params && match.params.api === 'sys'
+            // Fallback to protect against accidentally exposing system routes in RESTBase
+            || req.uri.path.length > 1 && req.uri.path[1] === 'sys')) {
+        throw new HTTPError({
+            status: 403,
+            body: {
+                type: 'access_denied#sys',
+                title: 'Access to the /sys hierarchy is restricted to system users.'
+            }
+        });
+    }
+};
+
+RESTBase.prototype.request = function(req) {
+    if (req.method) {
+        req.method = req.method.toLowerCase();
+    }
+    return this._request(req);
+};
+
+RESTBase.prototype._wrapInMetrics = function(handlerPromise, match, req) {
+    var self = this;
+    // Remove the /{domain}/ prefix, as it's not very useful in stats
+    var statName = match.value.path.replace(/\/[^\/]+\//, '')
+            + '.' + req.method.toUpperCase() + '.';
+    // Normalize invalid chars
+    statName = self.metrics.normalizeName(statName);
+    // Start timer
+    var startTime = Date.now();
+
+    return handlerPromise.then(function(res) {
+        // Record request metrics & log
+        var statusClass = Math.floor(res.status / 100) + 'xx';
+        self.metrics.endTiming([statName + statusClass, statName + 'ALL'], startTime);
+        return res;
+    },
+    function(err) {
+        var statusClass = '5xx';
+        if (err && err.status) {
+            statusClass = Math.floor(err.status / 100) + 'xx';
+        }
+        self.metrics.endTiming([statName + statusClass, statName + 'ALL'], startTime);
+        throw err;
+    });
+};
+
+RESTBase.prototype._wrapInAccessCheck = function(handlerPromise, match, childReq) {
+    var self = this;
+    // Don't need to check access restrictions on /sys requests,
+    // as these endpoints are internal, so can be accessed only
+    // within RESTBase. (See RESTBase.prototype.request) All required
+    // checks should be added and made at the root of the request chain,
+    // at /v1 level
+    if (!this._isSysRequest(req)
+            && match.permissions
+            && Array.isArray(match.permissions)
+            && match.permissions.length) {
+        self._authService = self._authService || new AuthService(match.value.specRoot);
+        self._authService.addRequirements(match.permissions);
+        if (childReq.method === 'get' || childReq.method === 'head') {
+            return P.all([
+                handlerPromise,
+                self._authService.checkPermissions(self, childReq)
+            ])
+            .then(function(res) { return res[0]; });
+        } else {
+            return self._authService.checkPermissions(self, childReq)
+            .then(function() { return handlerPromise; });
+        }
+    } else {
+        return handlerPromise;
+    }
+};
+
+// Process one request
+RESTBase.prototype._request = function(req) {
+    var self = this;
+
+    // Special handling for https? requests
+    if (req.uri.constructor === String && /^https?:\/\//.test(req.uri) || req.uri.urlObj) {
+        return self.defaultWebRequestHandler(req);
+    }
+
+    self._checkMaxRecursionDepth(req);
 
     // Make sure we have a sane & uniform request object that doesn't change
     // (at least at the top level) under our feet.
     var childReq = rbUtil.cloneRequest(req);
-
-    var match = priv.router.route(childReq.uri);
+    var match = this._priv.router.route(childReq.uri);
     var methods = match && match.value && match.value.methods;
     var handler = methods && (
             (self._rootReq && self._rootReq.method === 'head' && methods.head)
-            || methods[childReq.method]
-            || methods.all);
+            || methods[childReq.method] || methods.all);
     if (!handler &&
             (req.method === 'head'
             || self._rootReq && self._rootReq.method === 'head')) {
         handler = methods && methods.get;
     }
+
+    self._checkInternalApiRequest(req, match);
 
     if (match && !handler
             && childReq.method === 'get'
@@ -261,34 +330,9 @@ RESTBase.prototype._request = function(req) {
     }
 
     if (handler) {
-        // Remove the /{domain}/ prefix, as it's not very useful in stats
-        var statName = match.value.path.replace(/\/[^\/]+\//, '')
-            + '.' + req.method.toUpperCase() + '.';
-        // Normalize invalid chars
-        statName = self.metrics.normalizeName(statName);
-
-        // Start timer
-        var startTime = Date.now();
-
         // Prepare to call the handler with a child restbase instance
         var childRESTBase = this.makeChild(req);
         childReq.params = match.params;
-
-        // Don't need to check access restrictions on /sys requests,
-        // as these endpoints are internal, so can be accessed only
-        // within RESTBase. (See RESTBase.prototype.request) All required
-        // checks should be added and made at the root of the request chain,
-        // at /v1 level
-        var accessRestricted = !this._isSysRequest(req)
-                && match.permissions
-                && Array.isArray(match.permissions)
-                && match.permissions.length > 0;
-        if (accessRestricted) {
-            if (!childRESTBase._authService) {
-                childRESTBase._authService = new AuthService(match.value.specRoot);
-            }
-            childRESTBase._authService.addRequirements(match.permissions);
-        }
 
         // Call the handler with P.try to catch synchronous exceptions.
         var reqHandlerPromise;
@@ -302,11 +346,9 @@ RESTBase.prototype._request = function(req) {
         } else {
             reqHandlerPromise = P.try(handler, [childRESTBase, childReq]);
         }
-        reqHandlerPromise = reqHandlerPromise.then(function(res) {
-            // Record request metrics & log
-            var statusClass = Math.floor(res.status / 100) + 'xx';
-            self.metrics.endTiming([statName + statusClass, statName + 'ALL'], startTime);
 
+        reqHandlerPromise = self._wrapInMetrics(reqHandlerPromise, match, req)
+        .then(function(res) {
             self.log('trace', {
                 req: req,
                 res: res,
@@ -322,7 +364,7 @@ RESTBase.prototype._request = function(req) {
                         req: req
                     }
                 });
-            } else if (!(res.status >= 100 && res.status < 400) && !(res instanceof Error)) {
+            } else if (res.status >= 400 && !(res instanceof Error)) {
                 var err = new HTTPError(res);
                 if (res.body && res.body.stack) { err.stack = res.body.stack; }
                 err.innerBody = res.body;
@@ -331,37 +373,12 @@ RESTBase.prototype._request = function(req) {
             } else {
                 return res;
             }
-        },
-        function(err) {
-            var statusClass = '5xx';
-            if (err && err.status) {
-                statusClass = Math.floor(err.status / 100) + 'xx';
-            }
-            self.metrics.endTiming([statName + statusClass, statName + 'ALL'], startTime);
-            throw err;
         });
 
-        if (accessRestricted) {
-            if (req.method === 'get' || req.method === 'head') {
-                return P.all([
-                    reqHandlerPromise,
-                    childRESTBase._authService.checkPermissions(childRESTBase, childReq)
-                ])
-                .then(function(res) {
-                    return res[0];
-                });
-            } else {
-                return childRESTBase._authService.checkPermissions(childRESTBase, childReq)
-                .then(function() {
-                    return reqHandlerPromise;
-                });
-            }
-        } else {
-            return reqHandlerPromise;
-        }
+        return childRESTBase._wrapInAccessCheck(reqHandlerPromise, match, childReq);
     } else {
         // No handler found.
-        return P.reject(new HTTPError({
+        throw new HTTPError({
             status: 404,
             body: {
                 type: 'not_found#route',
@@ -370,7 +387,7 @@ RESTBase.prototype._request = function(req) {
                 method: req.method,
                 depth: self._recursionDepth
             }
-        }));
+        });
     }
 };
 

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -176,7 +176,7 @@ RESTBase.prototype.defaultWebRequestHandler = function(req) {
 RESTBase.prototype._isSysRequest = function(req) {
     return ((req.uri.params && req.uri.params.api === 'sys')
         // TODO: Remove once params.api is reliable
-        || (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys'));
+            || (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys'));
 };
 
 /**
@@ -292,7 +292,8 @@ RESTBase.prototype._request = function(req) {
     var self = this;
 
     // Special handling for https? requests
-    if (req.uri.constructor === String && /^https?:\/\//.test(req.uri) || req.uri.urlObj) {
+    if (req.uri.constructor === String && /^https?:\/\//.test(req.uri)
+            || req.uri.urlObj) {
         return self.defaultWebRequestHandler(req);
     }
 
@@ -305,10 +306,11 @@ RESTBase.prototype._request = function(req) {
     var methods = match && match.value && match.value.methods;
     var handler = methods && (
             (self._rootReq && self._rootReq.method === 'head' && methods.head)
-                || methods[childReq.method] || methods.all);
+                || methods[childReq.method]
+                || methods.all);
     if (!handler &&
             (req.method === 'head'
-                || self._rootReq && self._rootReq.method === 'head')) {
+            || self._rootReq && self._rootReq.method === 'head')) {
         handler = methods && methods.get;
     }
 
@@ -362,7 +364,7 @@ RESTBase.prototype._request = function(req) {
                         req: req
                     }
                 });
-            } else if (res.status >= 400 && !(res instanceof Error)) {
+            } else if (!(res.status >= 100 && res.status < 400) && !(res instanceof Error)) {
                 var err = new HTTPError(res);
                 if (res.body && res.body.stack) { err.stack = res.body.stack; }
                 err.innerBody = res.body;

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -176,7 +176,7 @@ RESTBase.prototype.defaultWebRequestHandler = function(req) {
 RESTBase.prototype._isSysRequest = function(req) {
     return ((req.uri.params && req.uri.params.api === 'sys')
         // TODO: Remove once params.api is reliable
-    || (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys'));
+        || (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys'));
 };
 
 /**
@@ -212,14 +212,10 @@ RESTBase.prototype._checkMaxRecursionDepth = function(req) {
  * Protects /sys APIs from the direct access.
  *
  * @param {Object} req - an original request
- * @param {Object} match - a found request handler
  * @private
  */
-RESTBase.prototype._checkInternalApiRequest = function(req, match) {
-    if (this._recursionDepth === 0 &&
-            (match && match.params && match.params.api === 'sys'
-            // Fallback to protect against accidentally exposing system routes in RESTBase
-            || req.uri.path.length > 1 && req.uri.path[1] === 'sys')) {
+RESTBase.prototype._checkInternalApiRequest = function(req) {
+    if (this._recursionDepth === 0 && this._isSysRequest(req)) {
         throw new HTTPError({
             status: 403,
             body: {
@@ -270,7 +266,7 @@ RESTBase.prototype._wrapInAccessCheck = function(handlerPromise, match, childReq
     // within RESTBase. (See RESTBase.prototype.request) All required
     // checks should be added and made at the root of the request chain,
     // at /v1 level
-    if (!this._isSysRequest(req)
+    if (!this._isSysRequest(childReq)
             && match.permissions
             && Array.isArray(match.permissions)
             && match.permissions.length) {
@@ -309,14 +305,12 @@ RESTBase.prototype._request = function(req) {
     var methods = match && match.value && match.value.methods;
     var handler = methods && (
             (self._rootReq && self._rootReq.method === 'head' && methods.head)
-            || methods[childReq.method] || methods.all);
+                || methods[childReq.method] || methods.all);
     if (!handler &&
             (req.method === 'head'
-            || self._rootReq && self._rootReq.method === 'head')) {
+                || self._rootReq && self._rootReq.method === 'head')) {
         handler = methods && methods.get;
     }
-
-    self._checkInternalApiRequest(req, match);
 
     if (match && !handler
             && childReq.method === 'get'
@@ -329,10 +323,14 @@ RESTBase.prototype._request = function(req) {
         };
     }
 
+    if (match) {
+        childReq.params = match.params;
+        self._checkInternalApiRequest(childReq);
+    }
+
     if (handler) {
         // Prepare to call the handler with a child restbase instance
-        var childRESTBase = this.makeChild(req);
-        childReq.params = match.params;
+        var childRESTBase = this.makeChild(childReq);
 
         // Call the handler with P.try to catch synchronous exceptions.
         var reqHandlerPromise;

--- a/lib/router.js
+++ b/lib/router.js
@@ -607,7 +607,6 @@ Router.prototype.loadSpec = function(spec, restbase) {
  *   for URIs ending in `/`.
  */
 Router.prototype.route = function(uri) {
-    var a = this.router.lookup(uri);
     return this.router.lookup(uri);
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -326,7 +326,7 @@ Router.prototype._registerPaths = function(node, pathspec, scope) {
 /**
  * Process a Swagger path spec object
  */
-Router.prototype._handleSwaggerPathSpec = function(node, pathspec, scope) {
+Router.prototype._handleSwaggerPathSpec = function(node, pathspec, scope, parentSegment) {
     var self = this;
     if (!pathspec) {
         return P.resolve();
@@ -339,41 +339,40 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec, scope) {
 
     // Load sub-spec
     var loaderPromise = P.resolve();
-    // XXX: find a better way to detect this?
-    if (pathspec.swagger) {
-        if (pathspec.info && pathspec.info['x-is-api-root']) {
-            // This is a new API at a path like /en.wikipedia.org/v1, so create a
-            // new specRoot.
-            var specRoot = Object.assign({}, pathspec);
-            specRoot.paths = {};
-            specRoot.definitions = {};
-            specRoot.securityDefinitions = {};
-            specRoot['x-default-params'] = {};
-            specRoot.basePath = (scope.specRoot.basePath || '') + scope.prefixPath;
-            // XXX: The basePath is incorrect when shared between domains. Set
-            // it dynamically for each request instead?
-            specRoot.basePath = scope.prefixPath;
-            scope = scope.makeChild({
-                specRoot: specRoot,
-                operations: {},
-                prefixPath: '',
-            });
+    if (parentSegment && parentSegment.name === 'api') {
+        // This is a new API at a path like /en.wikipedia.org/v1, so create a new specRoot.
+        var specRoot = Object.assign({}, pathspec);
+        specRoot.swagger = specRoot.swagger || '2.0';
+        specRoot.paths = {};
+        specRoot.definitions = {};
+        specRoot.securityDefinitions = {};
+        specRoot['x-default-params'] = {};
+        specRoot.basePath = (scope.specRoot.basePath || '') + scope.prefixPath;
+        // XXX: The basePath is incorrect when shared between domains. Set
+        // it dynamically for each request instead?
+        specRoot.basePath = scope.prefixPath;
+        scope = scope.makeChild({
+            specRoot: specRoot,
+            operations: {},
+            prefixPath: '',
+        });
 
-            var listNode = new Node();
-            listNode.value = {
-                specRoot: specRoot,
-                methods: {},
-                path: specRoot.basePath + '/',
-                globals: node.value.globals,
-            };
-            node.setChild('', listNode);
-            loaderPromise = loaderPromise.then(function() {
-                return self._handleSwaggerSpec(node, pathspec, scope);
-            });
-        } else {
-            // We are loading a sub-spec.
-            loaderPromise = self._handleSwaggerSpec(node, pathspec, scope);
-        }
+        var listNode = new Node();
+        listNode.value = {
+            specRoot: specRoot,
+            methods: {},
+            path: specRoot.basePath + '/',
+            globals: node.value.globals,
+        };
+        node.setChild('', listNode);
+
+        loaderPromise = loaderPromise.then(function() {
+            return self._handleSwaggerSpec(node, pathspec, scope);
+        });
+    } else {
+        loaderPromise = loaderPromise.then(function() {
+            return self._handlePaths(node, pathspec, scope);
+        });
     }
 
     // Load modules
@@ -482,7 +481,7 @@ Router.prototype._handlePaths = function(rootNode, spec, scope, optionalPathPref
 
 
             // Handle the path spec
-            specPromise = self._handleSwaggerPathSpec(subtree, pathSpec, childScope);
+            specPromise = self._handleSwaggerPathSpec(subtree, pathSpec, childScope, segment);
         } else {
             // Share the subtree.
             var origSubtree = subtree;
@@ -608,6 +607,7 @@ Router.prototype.loadSpec = function(spec, restbase) {
  *   for URIs ending in `/`.
  */
 Router.prototype.route = function(uri) {
+    var a = this.router.lookup(uri);
     return this.router.lookup(uri);
 };
 

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -18,15 +18,12 @@
 
 # First, we define some project templates. These are referenced / shared
 # between domains in the root_spec further down.
-swagger: '2.0'
 paths:
   /{api:v1}:
-    swagger: '2.0'
     info:
       version: 1.0.0-beta
       title: Wikimedia REST API
       description: Welcome to your RESTBase API.
-      x-is-api-root: true
 
     securityDefinitions:
       mediawiki_auth:
@@ -51,9 +48,6 @@ paths:
         - path: v1/content.yaml
 
   /{api:sys}:
-    swagger: 2.0
-    info:
-      x-is-api-root: true
     x-modules:
       /table:
         - type: npm

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -1,7 +1,5 @@
-swagger: '2.0'
 paths:
   /{api:v1}: &default_project_paths_v1
-    swagger: '2.0'
     # swagger options, overriding the shared ones from the merged specs (?)
     info:
       version: 1.0.0-beta
@@ -26,7 +24,6 @@ paths:
       license:
         name: Apache2
         url: http://www.apache.org/licenses/LICENSE-2.0
-      x-is-api-root: true
 
     securityDefinitions: &wp/content-security/1.0.0
       mediawiki_auth:
@@ -56,9 +53,6 @@ paths:
         - path: v1/pageviews.yaml
 
   /{api:sys}:
-    swagger: 2.0
-    info:
-      x-is-api-root: true
     x-modules:
       /table:
         - type: npm

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -1,7 +1,5 @@
-swagger: '2.0'
 paths:
   /{api:v1}: &default_project_paths_v1
-    swagger: '2.0'
     # swagger options, overriding the shared ones from the merged specs (?)
     info:
       version: 1.0.0-beta
@@ -26,7 +24,6 @@ paths:
       license:
         name: Apache2
         url: http://www.apache.org/licenses/LICENSE-2.0
-      x-is-api-root: true
 
     securityDefinitions: &wp/content-security/1.0.0
       mediawiki_auth:
@@ -67,9 +64,6 @@ paths:
           options: '{{options.mathoid}}'
 
   /{api:sys}: &default_project_paths_sys
-    swagger: 2.0
-    info:
-      x-is-api-root: true
     x-modules: &default_project_paths_sys_modules
       /table: &sys_table
         - type: npm


### PR DESCRIPTION
Several changes and refactoring incorporated in this PR:

- Now we detect the API root by the `api` prefix in the path spec. This is way cleaner than detecting it based on the `swagger` and `x-is-api-root` stanza.
- The `/sys` access protection is done on the basis of `params.api` not by the "second element in the path" rule. This gives framework users ability to specify the internal sys APIs on any level. In future I want to make an `x-internal-api` stanza, or, maybe, use special `api_private` prefix to detect private API roots - this will give even more flexibility, but it's a subject to a different PR
- General refactoring of the request handler code - the function was to big, so I've split it into several pieces with clear responsibilities.
- Fixed a bug in restbase child creation - we were trying to inherit the `_req` property and never assigned one, so it was always `null`.

This is a part of framework-separation work.

Further refactoring is possible, but it's a subject to another PR as more drastic changes needed, and that should be done together with authentication modules refactoring.

IMPORTANT: I've found more bugs in the router, so please treat this as WIP until further notice.