### PR TITLE
JSCS: switch off the new 'else after return' check

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -17,6 +17,7 @@
   "requireTrailingComma": null,
   "disallowTrailingComma": null,
   "requireSpacesInsideObjectBrackets": "all",
+  "requireEarlyReturn": false,
 
   "excludeFiles": [
     "node_modules/**",


### PR DESCRIPTION
JSCS updated and now marks contracts with else after return illegal. Switch that check off.
See https://github.com/wikimedia/restbase-mod-table-cassandra/pull/174

cc @wikimedia/services 