### PR TITLE
Add a rerenderBlacklist option for the parsoid module

### DIFF
--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -99,6 +99,29 @@ paths:
             #purge:
             #  host: '239.128.0.112'
             #  port: 4827
+
+            # A list of pages that we don't currently want to re-render on
+            # each edit. Most of these are huge bot-edited pages, which are
+            # rarely viewed in any case. 
+            rerenderBlacklist:
+              www.wikidata.org:
+                Q21558717: true
+                Q21505108: true
+                Q21481867: true
+                Q21521425: true
+              en.wikipedia.org:
+                Wikipedia:Administrators'_noticeboard/Incidents: true
+                User:JamesR/AdminStats: true
+                User:Kudpung/Dashboard: true
+              ur.wikipedia.org:
+                نام_مقامات_ایل: true
+                نام_مقامات_ڈی: true
+                نام_مقامات_جے: true
+                نام_مقامات_جی: true
+                نام_مقامات_ایچ: true
+                نام_مقامات_ایم: true
+              commons.wikipedia.org:
+                Commons:Quality_images_candidates/candidate_list: true
       /mobileapps:
         - path: sys/mobileapps.yaml
           options: '{{options.mobileapps}}'


### PR DESCRIPTION
A few huge & extremely frequently edited pages are using a disproportionate
amount of resources for re-renders in both storage and Parsoid.  While longer
term improvements like https://phabricator.wikimedia.org/T120171 and Parsoid
performance will make it easier to deal with such (ab)use, in the short term
it is useful to disable job queue triggered updates for specific problematic
pages. Regular access to those pages still works, but tends to be rare for
these pages, leading to substantial savings in overall resource usage.

To be clear: This is not meant as a replacement for performance improvements,
but reduces the impact those few pages have right now until efficient
incremental parsing & chunked storage are implemented.

Task: https://phabricator.wikimedia.org/T120971
Task: https://phabricator.wikimedia.org/T120171
Task: https://phabricator.wikimedia.org/T94121
Task: https://phabricator.wikimedia.org/T120972