### PR TITLE
Add cache headers in pageviews responses

### DIFF
--- a/sys/pageviews_proxy.yaml
+++ b/sys/pageviews_proxy.yaml
@@ -10,7 +10,7 @@ paths:
               uri: '{{options.host}}/pageviews/per-article/{+rest}'
             return:
               status: '{{get_from_backend.status}}'
-              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 86400, max-age: 86400"})}}'
+              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 3600, max-age: 3600"})}}'
               body: '{{get_from_backend.body}}'
 
   /per-project/{+rest}:
@@ -21,7 +21,7 @@ paths:
               uri: '{{options.host}}/pageviews/aggregate/{+rest}'
             return:
               status: '{{get_from_backend.status}}'
-              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 86400, max-age: 86400"})}}'
+              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 3600, max-age: 3600"})}}'
               body: '{{get_from_backend.body}}'
 
   /top/{+rest}:
@@ -32,5 +32,5 @@ paths:
               uri: '{{options.host}}/pageviews/top/{+rest}'
             return:
               status: '{{get_from_backend.status}}'
-              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 86400, max-age: 86400"})}}'
+              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 3600, max-age: 3600"})}}'
               body: '{{get_from_backend.body}}'

--- a/sys/pageviews_proxy.yaml
+++ b/sys/pageviews_proxy.yaml
@@ -8,6 +8,10 @@ paths:
         - get_from_backend:
             request:
               uri: '{{options.host}}/pageviews/per-article/{+rest}'
+            return:
+              status: '{{get_from_backend.status}}'
+              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 86400, max-age: 86400"})}}'
+              body: '{{get_from_backend.body}}'
 
   /per-project/{+rest}:
     get:
@@ -15,6 +19,10 @@ paths:
         - get_from_backend:
             request:
               uri: '{{options.host}}/pageviews/aggregate/{+rest}'
+            return:
+              status: '{{get_from_backend.status}}'
+              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 86400, max-age: 86400"})}}'
+              body: '{{get_from_backend.body}}'
 
   /top/{+rest}:
     get:
@@ -22,3 +30,7 @@ paths:
         - get_from_backend:
             request:
               uri: '{{options.host}}/pageviews/top/{+rest}'
+            return:
+              status: '{{get_from_backend.status}}'
+              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 86400, max-age: 86400"})}}'
+              body: '{{get_from_backend.body}}'


### PR DESCRIPTION
Per Nuria, the analitics team is planning to publish a blog post on pageviews
next week, and would like to have caching active before then. They don't have
time to implement this in AQS, so I'm adding those headers in the
pageviews_proxy response.

Task: https://phabricator.wikimedia.org/T119886