### PR TITLE
Temporarily disable sub-request id check until failure is investigated

### DIFF
--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -52,12 +52,15 @@ describe('router - misc', function() {
         }).then(function(res) {
             slice.halt();
             assert.deepEqual(res.headers['x-request-id'], reqId, 'Returned request ID does not match the sent one');
-            slice.get().forEach(function(line) {
-                var a = JSON.parse(line);
-                if(a.req || a.request_id) {
-                    assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
-                }
-            });
+            // TODO: Fix https://phabricator.wikimedia.org/T121414 &
+            // re-enable.
+            //
+            //  slice.get().forEach(function(line) {
+            //      var a = JSON.parse(line);
+            //      if(a.req || a.request_id) {
+            //          assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
+            //      }
+            //  });
         });
     });
 
@@ -75,12 +78,15 @@ describe('router - misc', function() {
         }, function(err) {
             slice.halt();
             assert.deepEqual(err.headers['x-request-id'], reqId, 'Returned request ID does not match the sent one');
-            slice.get().forEach(function(line) {
-                var a = JSON.parse(line);
-                if(a.req || a.request_id) {
-                    assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
-                }
-            });
+            // TODO: Fix https://phabricator.wikimedia.org/T121414 &
+            // re-enable.
+            //
+            // slice.get().forEach(function(line) {
+            //     var a = JSON.parse(line);
+            //     if(a.req || a.request_id) {
+            //         assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
+            //     }
+            // });
         });
     });
 


### PR DESCRIPTION
Bug: https://phabricator.wikimedia.org/T121414