### PR TITLE
Summary: wait for a summary update on parsoid rerender

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -338,22 +338,28 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
             return self.wrapContentReq(restbase, req,
                 P.resolve(currentContentRes), format, rp.tid, true);
         } else {
-            // TEMP TEMP TEMP!!!
-            // Need to invalidate summary when a render changes.
-            // In future this should be controlled by dependency tracking system.
-            // return is missed on purpose - we don't want to wait for the result
-            restbase.get({
-                uri: new URI([rp.domain, 'v1', 'page', 'summary', rp.title]),
-                headers: {
-                    'cache-control': 'no-cache'
-                }
-            })
-            .catch(function(e) {
-                self.log('error/summary', e);
-            });
-            // End of temp code block
+            return P.join(
+                self.saveParsoidResult(restbase, req, format, tid, res),
 
-            return self.saveParsoidResult(restbase, req, format, tid, res);
+                // TEMP TEMP TEMP!!!
+                // Need to invalidate summary when a render changes.
+                // In future this should be controlled by dependency tracking system.
+                // return is missed on purpose - we don't want to wait for the result
+                restbase.get({
+                    uri: new URI([rp.domain, 'v1', 'page', 'summary', rp.title]),
+                    headers: {
+                        'cache-control': 'no-cache'
+                    }
+                })
+                .catch(function(e) {
+                    self.log('error/summary', e);
+                }),
+                // End of temp code block
+
+                function(parsoidSaveResult, summaryUpdateResult) {
+                    return parsoidSaveResult;
+                }
+            );
         }
     });
 };

--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -52,15 +52,12 @@ describe('router - misc', function() {
         }).then(function(res) {
             slice.halt();
             assert.deepEqual(res.headers['x-request-id'], reqId, 'Returned request ID does not match the sent one');
-            // TODO: Fix https://phabricator.wikimedia.org/T121414 &
-            // re-enable.
-            //
-            //  slice.get().forEach(function(line) {
-            //      var a = JSON.parse(line);
-            //      if(a.req || a.request_id) {
-            //          assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
-            //      }
-            //  });
+            slice.get().forEach(function(line) {
+                var a = JSON.parse(line);
+                if (a.req || a.request_id) {
+                    assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
+                }
+            });
         });
     });
 
@@ -78,15 +75,12 @@ describe('router - misc', function() {
         }, function(err) {
             slice.halt();
             assert.deepEqual(err.headers['x-request-id'], reqId, 'Returned request ID does not match the sent one');
-            // TODO: Fix https://phabricator.wikimedia.org/T121414 &
-            // re-enable.
-            //
-            // slice.get().forEach(function(line) {
-            //     var a = JSON.parse(line);
-            //     if(a.req || a.request_id) {
-            //         assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
-            //     }
-            // });
+            slice.get().forEach(function(line) {
+                var a = JSON.parse(line);
+                if (a.req || a.request_id) {
+                    assert.deepEqual(a.request_id, reqId, 'Request ID mismatch');
+                }
+            });
         });
     });
 


### PR DESCRIPTION
We've disabled a couple of RB tests because `trace` logs from summary endpoint purging were interfering with the tests. This PR changes the way how we purge summary so the tests will pass again.

Ticket: https://phabricator.wikimedia.org/T121414