### PR TITLE
Override cache-control headers from the pageviews backend

### DIFF
--- a/sys/pageviews_proxy.yaml
+++ b/sys/pageviews_proxy.yaml
@@ -10,7 +10,7 @@ paths:
               uri: '{{options.host}}/pageviews/per-article/{+rest}'
             return:
               status: '{{get_from_backend.status}}'
-              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 3600, max-age: 3600"})}}'
+              headers: '{{merge({"cache-control":"s-maxage: 3600, max-age: 3600"}, get_from_backend.headers)}}'
               body: '{{get_from_backend.body}}'
 
   /per-project/{+rest}:
@@ -21,7 +21,7 @@ paths:
               uri: '{{options.host}}/pageviews/aggregate/{+rest}'
             return:
               status: '{{get_from_backend.status}}'
-              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 3600, max-age: 3600"})}}'
+              headers: '{{merge({"cache-control":"s-maxage: 3600, max-age: 3600"}, get_from_backend.headers)}}'
               body: '{{get_from_backend.body}}'
 
   /top/{+rest}:
@@ -32,5 +32,5 @@ paths:
               uri: '{{options.host}}/pageviews/top/{+rest}'
             return:
               status: '{{get_from_backend.status}}'
-              headers: '{{merge(get_from_backend.headers, {"cache-control":"s-maxage: 3600, max-age: 3600"})}}'
+              headers: '{{merge({"cache-control":"s-maxage: 3600, max-age: 3600"}, get_from_backend.headers)}}'
               body: '{{get_from_backend.body}}'


### PR DESCRIPTION
It looks like AQS is emitting cache-control headers of its own, which override
the front-end's private cache-control heders. This patch switches the
precedence to override the backend headers.