### PR TITLE
Graphoid: Change the test graph revision/hash

### DIFF
--- a/v1/graphoid.yaml
+++ b/v1/graphoid.yaml
@@ -56,8 +56,8 @@ paths:
             params:
               domain: en.wikipedia.org
               title: User:Pchelolo/Graph
-              revision: 670213569
-              graph_id: 1533aaad45c733dcc7e07614b54cbae4119a6747.png
+              revision: 0
+              graph_id: c1c5d432407bd5fd7435f5edfb6fdb73ffd4bc9e.png
           response:
             status: 200
             headers:


### PR DESCRIPTION
It seems the hashing algorithm has changed recently, causing RESTBase to ask for an invalid graph hash.