### PR TITLE
Misc: Improve body_only users logging and sync revision update

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -447,14 +447,16 @@ PSP.getFormat = function(format, restbase, req) {
     if (req.headers && /no-cache/i.test(req.headers['cache-control'])) {
         if (!self._okayToRerender(req)) {
             // Still update the revision metadata.
-            self.getRevisionInfo(restbase, req);
-            throw new rbUtil.HTTPError({
-                status: 403,
-                body: {
-                    type: 'rerenders_disabled',
-                    description: "Rerenders for this article are blacklisted "
+            return self.getRevisionInfo(restbase, req)
+            .then(function() {
+                throw new rbUtil.HTTPError({
+                    status: 403,
+                    body: {
+                        type: 'rerenders_disabled',
+                        description: "Rerenders for this article are blacklisted "
                         + "in the config."
-                }
+                    }
+                });
             });
         }
         // Check content generation either way
@@ -924,7 +926,8 @@ PSP.makeTransform = function(from, to) {
             // https://phabricator.wikimedia.org/T114185).
             // Log remaining bodyOnly uses / users
             if (to === 'html' && originalBodyOnly) {
-                self.log('warn/parsoid/bodyonly', req.headers);
+                self.log('warn/parsoid/bodyonly',
+                    restbase._rootReq && restbase._rootReq.headers);
             }
             return res;
         });


### PR DESCRIPTION
Two small changes:
1. When a rerender request comes for a blacklisted title, we update the revisions anyway, but don't wait for the result. Thus any error in the revision update becomes unhanded, which produces [mysterious log messages](https://phabricator.wikimedia.org/T121296). This patch makes us actually wait for the revision update result. 
2. After deprecating body_only, we've made a tacky logging of the remaining users. These logs still show up in log stash, however they don't contain any info about the user, because we are logging the headers of the request to `sys`, which doesn't have all the required info. To identify the users, switch to logging the headers of a root request. A bit tacky, but this code will be removed soon anyway.