### PR TITLE
Log the bodyOnly warning headers properly

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -926,8 +926,9 @@ PSP.makeTransform = function(from, to) {
             // https://phabricator.wikimedia.org/T114185).
             // Log remaining bodyOnly uses / users
             if (to === 'html' && originalBodyOnly) {
-                self.log('warn/parsoid/bodyonly',
-                    restbase._rootReq && restbase._rootReq.headers);
+                self.log('warn/parsoid/bodyonly', {
+                    req_headers: restbase._rootReq && restbase._rootReq.headers
+                });
             }
             return res;
         });


### PR DESCRIPTION
Bug: [T121852](https://phabricator.wikimedia.org/T121852)