### PR TITLE
Parsoid: Add a message for bodyOnly warnings

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -927,6 +927,7 @@ PSP.makeTransform = function(from, to) {
             // Log remaining bodyOnly uses / users
             if (to === 'html' && originalBodyOnly) {
                 self.log('warn/parsoid/bodyonly', {
+                    msg: 'Client-supplied bodyOnly flag encountered',
                     req_headers: restbase._rootReq && restbase._rootReq.headers
                 });
             }


### PR DESCRIPTION
Bug: [T121852](https://phabricator.wikimedia.org/T121852)

Note: this is a follow-up to #451 