### PR TITLE
Configs: make example and test config less different

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -1,171 +1,64 @@
 # RESTBase test config, used in integration tests.
 
-# First, we define some project templates. These are referenced / shared
-# between domains in the root_spec further down.
+# Load some project templates. These are referenced / shared between domains
+# in the root_spec further down.
 default_project: &default_project
-  swagger: '2.0'
-  paths:
-    /{api:v1}: &default_project_paths_v1
-      # Spec root, resulting in an aggregated public spec & docs.
-      swagger: '2.0'
-      info:
-        version: 1.0.0-beta
-        title: Wikimedia REST API
-        description: >
-            This API aims to provide coherent and low-latency access to
-            Wikimedia content and services. It is currently in beta testing, so
-            things aren't completely locked down yet. Each entry point has
-            explicit stability markers to inform you about development status
-            and change policy, according to [our API version
-            policy](https://www.mediawiki.org/wiki/API_versioning).
-
-            ### High-volume access
-              - Don't perform more than 500 requests/s to this API.
-              - Set a unique `User-Agent` header that allows us to contact you
-                quickly. Email addresses or URLs of contact pages work well.
-
-        termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
-        contact:
-          name: the Wikimedia Services team
-          url: http://mediawiki.org/wiki/RESTBase
-        license:
-          name: Apache2
-          url: http://www.apache.org/licenses/LICENSE-2.0
-        x-is-api-root: true
-
-      securityDefinitions:
-        mediawiki_auth:
-          description: Checks permissions using MW api
-          type: apiKey
-          in: header
-          name: cookie
-          x-internal-request-whitelist:
-            - https://en.wikipedia.org/w/api.php
-            - https://fr.wikipedia.org/w/api.php
-            - http://en.wikipedia.beta.wmflabs.org/w/api.php
-            # Left as a regex for test purpose
-            - /http:\/\/parsoid\-beta\.wmflabs\.org/
-        header_match:
-          description: Checks client ip against one of the predefined whitelists
-          x-error-message: This client is not allowed to use the endpoint
-          x-whitelists:
-            internal:
-              - /^(?:::ffff:)?(?:10|127)\./
-          x-is-api: true
-
-      x-modules: &default_project_paths_v1_modules
-        /: 
-          # The main content module, defining page/* and transform entry
-          # points.
-          - path: v1/content.yaml
-          - path: test/test_module.yaml
-        /page:
-          - path: v1/mobileapps.yaml
-            options:
-              host: http://appservice.wmflabs.org
-          - path: v1/graphoid.yaml
-            options:
-              host: http://graphoid.wikimedia.org
-          - path: v1/summary.js
-            options:
-              response_cache-control: 'max-age: 3600, s-maxage: 3600'
-        /media:
-          - path: v1/mathoid.yaml
-            options:
-              host: http://mathoid-tester.wmflabs.org
-              cache-control: s-maxage=86400, max-age=86400
-
-    /{api:sys}: &default_project_paths_sys
-      x-modules: &default_project_paths_sys_modules
-        /table: &sys_table
-          - type: npm
-            name: restbase-mod-table-cassandra
-            # See: 
-            # https://github.com/wikimedia/restbase-mod-table-cassandra/blob/master/Readme.md#configuration
-            options:
-              conf:
-                dbname: test.db.sqlite3 # ignored in cassandra, but useful in SQLite testing
-                hosts: [localhost]
-                keyspace: system
-                username: cassandra
-                password: cassandra
-                defaultConsistency: one # or 'one' for single-node testing
-                storage_groups:
-                  - name: test.group.local
-                    domains: /./
-        /key_value: &sys_key_value
-          - path: sys/key_value.js
-        /key_rev_value:
-          - path: sys/key_rev_value.js
-        /page_revisions:
-          - path: sys/page_revisions.js
-        /post_data: &sys_post_data
-          - path: sys/post_data.js
-        /action:
-          - path: sys/action.js
-            options:
-              apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
-        /page_save:
-          - path: sys/page_save.js
-        /parsoid:
-          - path: sys/parsoid.js
-            options:
-              parsoidHost: http://parsoid-beta.wmflabs.org
-              # For local testing, use:
-              # parsoidHost: http://localhost:8000
-        /mobileapps:
-          - path: sys/mobileapps.yaml
-            options:
-              host: http://appservice.wmflabs.org
+  x-modules:
+    /:
+      - path: test/test_module.yaml
+      - path: projects/wmf_default.yaml
+        options: &default_options
+          table:
+            hosts: [localhost]
+            keyspace: system
+            username: cassandra
+            password: cassandra
+            defaultConsistency: one # or 'localQuorum' for production
+            storage_groups:
+              - name: test.group.local
+                domains: /./
+            dbname: test.db.sqlite3 # ignored in cassandra, but useful in SQLite testing
+          parsoid:
+            host: http://parsoid-beta.wmflabs.org
+          action:
+            apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
+          graphoid:
+            host: http://graphoid.wikimedia.org
+          mathoid:
+            host: http://mathoid-tester.wmflabs.org
+            # 10 days Varnish caching, one day client-side
+            cache-control: s-maxage=864000, max-age=86400
+          mobileapps:
+            host: http://appservice.wmflabs.org
 
 labs_project: &labs_project
-  swagger: '2.0'
-  paths:
-    /{api:v1}: *default_project_paths_v1
-    /{api:sys}:
-      x-modules:
-        <<: *default_project_paths_sys_modules
-        # Override the action API config to use http
-        /action:
-          - path: sys/action.js
-            options:
-              apiUriTemplate: "{{'http://{domain}/w/api.php'}}"
+  x-modules:
+    /:
+      - path: test/test_module.yaml
+      - path: projects/wmf_default.yaml
+        options:
+          <<: *default_options
+          action:
+            apiUriTemplate: "{{'http://{domain}/w/api.php'}}"
 
+# A different project template, sharing configuration options.
 wikimedia.org: &wikimedia.org
-  swagger: '2.0'
-  paths:
-    /{api:v1}:
-      <<: *default_project_paths_v1
-      # Override x-modules
-      x-modules:
-        /:
-          - path: test/test_module.yaml
-        /media:
-          - path: v1/mathoid.yaml
-            options:
-              host: http://mathoid-tester.wmflabs.org
-        /metrics:
-          - path: v1/pageviews.yaml
+  x-modules:
+    /:
+      - path: test/test_module.yaml
+      - path: projects/wikimedia.org.yaml
+        options:
+          <<: *default_options
+          pageviews:
+            host: https://wikimedia.org/api/rest_v1/metrics
 
-    /{api:sys}:
-      x-modules:
-        /table: *sys_table
-        /key_value: *sys_key_value
-        /post_data: *sys_post_data
-        /pageviews:
-          - path: sys/pageviews.js
-
-private_project: &private_project
-  swagger: '2.0'
-  paths:
-    /{api:v1}:
-      # Merge in the default project v1 paths
-      <<: *default_project_paths_v1
-      # Tighten down security for everything below /v1/.
-      security:
-        - mediawiki_auth:
-          - read
-    /{api:sys}: *default_project_paths_sys
+# A synthetic domain to test pageviews module data
+aqs.wikimedia.org: &aqs.wikimedia.org
+  x-modules:
+    /:
+      - path: test/aqs_test_module.yaml
+      - path: projects/aqs_default.yaml
+        options: *default_options
 
 # Hacky way to parametrize RESTBase tests. TODO: Move to config?
 test:
@@ -187,9 +80,14 @@ spec_root: &spec_root
 
     # labs, used for most tests
     /{domain:en.wikipedia.beta.wmflabs.org}: *labs_project
+    /{domain:aqs.wikimedia.org}: *aqs.wikimedia.org
 
     # For security testing we rely on mocks, so it's OK to use French wiki.
-    /{domain:fr.wikipedia.org}: *private_project
+    /{domain:fr.wikipedia.org}:
+      <<: *default_project
+      security:
+        - mediawiki_auth:
+            - read
 
     # global domain
     /{domain:wikimedia.org}: *wikimedia.org

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -174,14 +174,17 @@ RESTBase.prototype.defaultWebRequestHandler = function(req) {
 };
 
 
+RESTBase.prototype._isSysRequest = function(req) {
+    return ((req.uri.params && req.uri.params.api === 'sys')
+        // TODO: Remove once params.api is reliable
+            || (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys'));
+};
+
 // Process one request
 RESTBase.prototype.request = function(req) {
     // Protect the sys api from direct access
     // Could consider opening this up with a specific permission later.
-    if (this._recursionDepth === 0 &&
-            ((req.uri.params && req.uri.params.api === 'sys')
-             // TODO: Remove once params.api is reliable
-             || (req.uri.path.length > 1 && req.uri.path[1] === 'sys'))) {
+    if (this._recursionDepth === 0 && this._isSysRequest(req)) {
         return P.reject(new HTTPError({
             status: 403,
             body: {
@@ -271,7 +274,8 @@ RESTBase.prototype._request = function(req) {
         var childRESTBase = this.makeChild(req);
         childReq.params = match.params;
 
-        var accessRestricted = match.permissions
+        var accessRestricted = !this._isSysRequest(req)
+                && match.permissions
                 && Array.isArray(match.permissions)
                 && match.permissions.length > 0;
         if (accessRestricted) {

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -274,6 +274,11 @@ RESTBase.prototype._request = function(req) {
         var childRESTBase = this.makeChild(req);
         childReq.params = match.params;
 
+        // Don't need to check access restrictions on /sys requests,
+        // as these endpoints are internal, so can be accessed only
+        // within RESTBase. (See RESTBase.prototype.request) All required
+        // checks should be added and made at the root of the request chain,
+        // at /v1 level
         var accessRestricted = !this._isSysRequest(req)
                 && match.permissions
                 && Array.isArray(match.permissions)

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "nock": "^3.3.2",
     "restbase-mod-table-sqlite": "^0.1.13",
     "swagger-test": "0.2.0",
-    "url-template": "^2.0.6"
+    "url-template": "^2.0.6",
+    "temp": "^0.8.3"
   }
 }

--- a/projects/aqs_default.yaml
+++ b/projects/aqs_default.yaml
@@ -1,0 +1,30 @@
+swagger: '2.0'
+paths:
+  /{api:v1}: &default_project_paths_v1
+    swagger: '2.0'
+    # swagger options, overriding the shared ones from the merged specs (?)
+    info:
+      version: 1.0.0-beta
+      title: Analytics REST API
+      description: >
+          Sample project for AQS RESTBase setup
+      x-is-api-root: true
+
+    x-host-basePath: /api/rest_v1
+
+    x-modules:
+      /metrics:
+        - path: v1/pageviews.yaml
+
+  /{api:sys}:
+    swagger: 2.0
+    info:
+      x-is-api-root: true
+    x-modules:
+      /table:
+        - type: npm
+          name: restbase-mod-table-cassandra
+          options:
+            conf: '{{options.table}}'
+      /pageviews:
+        - path: sys/pageviews.js

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -35,8 +35,9 @@ paths:
         in: header
         name: cookie
         x-internal-request-whitelist:
-          - /http:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
+          - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
           - http://parsoid-lb.eqiad.wikimedia.org
+          - http://parsoid-beta.wmflabs.org
       header_match:
         description: Checks client ip against one of the predefined whitelists
         x-error-message: This client is not allowed to use the endpoint

--- a/test/aqs_test_module.yaml
+++ b/test/aqs_test_module.yaml
@@ -1,0 +1,96 @@
+# Simple test spec
+
+swagger: 2.0
+paths:
+  /{api:v1}:
+    swagger: '2.0'
+    info:
+      version: 1.0.0-beta
+      title: Wikimedia testing APIs
+      x-is-api-root: true
+    paths:
+      /metrics/pageviews/insert-per-article-flat/{project}/{article}/{granularity}/{timestamp}/{views}:
+        post:
+          x-request-handler:
+            - put_to_storage:
+                request:
+                  method: 'put'
+                  uri: '/{domain}/sys/table/pageviews.per.article.flat/'
+                  body:
+                    table: 'pageviews.per.article.flat'
+                    attributes:
+                      project: '{$.request.params.project}'
+                      article: '{$.request.params.article}'
+                      granularity: '{$.request.params.granularity}'
+                      timestamp: '{$.request.params.timestamp}'
+                      aa:  '{$.request.params.views}1'
+                      ab:  '{$.request.params.views}2'
+                      as:  '{$.request.params.views}3'
+                      au:  '{$.request.params.views}4'
+                      da:  '{$.request.params.views}5'
+                      db:  '{$.request.params.views}6'
+                      ds:  '{$.request.params.views}7'
+                      du:  '{$.request.params.views}8'
+                      maa: '{$.request.params.views}9'
+                      mab: '{$.request.params.views}10'
+                      mas: '{$.request.params.views}11'
+                      mau: '{$.request.params.views}12'
+                      mwa: '{$.request.params.views}13'
+                      mwb: '{$.request.params.views}14'
+                      mws: '{$.request.params.views}15'
+                      mwu: '{$.request.params.views}16'
+          x-monitor: false
+
+      /metrics/pageviews/insert-aggregate/{project}/{access}/{agent}/{granularity}/{timestamp}/{views}:
+        post:
+          x-request-handler:
+            - put_to_storage:
+                request:
+                  method: 'put'
+                  uri: '/{domain}/sys/table/pageviews.per.project/'
+                  body:
+                    table: 'pageviews.per.project'
+                    attributes:
+                      project: '{$.request.params.project}'
+                      access: '{$.request.params.access}'
+                      agent: '{$.request.params.agent}'
+                      granularity: '{$.request.params.granularity}'
+                      timestamp: '{$.request.params.timestamp}'
+                      views: '{$.request.params.views}'
+          x-monitor: false
+
+      /metrics/pageviews/insert-aggregate-long/{project}/{access}/{agent}/{granularity}/{timestamp}/{v}:
+        post:
+          x-request-handler:
+            - put_to_storage:
+                request:
+                  method: 'put'
+                  uri: '/{domain}/sys/table/pageviews.per.project/'
+                  body:
+                    table: 'pageviews.per.project'
+                    attributes:
+                      project: '{$.request.params.project}'
+                      access: '{$.request.params.access}'
+                      agent: '{$.request.params.agent}'
+                      granularity: '{$.request.params.granularity}'
+                      timestamp: '{$.request.params.timestamp}'
+                      v: '{$.request.params.v}'
+          x-monitor: false
+
+      /metrics/pageviews/insert-top/{project}/{access}/{year}/{month}/{day}:
+        post:
+          x-request-handler:
+            - put_to_storage:
+                request:
+                  method: 'put'
+                  uri: '/{domain}/sys/table/top.pageviews/'
+                  body:
+                    table: 'top.pageviews'
+                    attributes:
+                      project: '{$.request.params.project}'
+                      access: '{$.request.params.access}'
+                      year: '{$.request.params.year}'
+                      month: '{$.request.params.month}'
+                      day: '{$.request.params.day}'
+                      articlesJSON: '{$.request.body.articles}'
+          x-monitor: false

--- a/test/features/pageviews/pageviews.js
+++ b/test/features/pageviews/pageviews.js
@@ -29,7 +29,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when per article parameters are wrong', function () {
         return preq.get({
-            uri: server.config.globalURL + articleEndpoint.replace('20150703', '201507a3')
+            uri: server.config.aqsURL + articleEndpoint.replace('20150703', '201507a3')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -39,10 +39,10 @@ describe('pageviews endpoints', function () {
         return preq.post({
             // the way we have configured the test insert-per-article endpoint
             // means views_desktop_spider will be 1007 when we pass /100
-            uri: server.config.globalURL + insertArticleEndpoint + '/100'
+            uri: server.config.aqsURL + insertArticleEndpoint + '/100'
         }).then(function() {
             return preq.get({
-                uri: server.config.globalURL + articleEndpoint
+                uri: server.config.aqsURL + articleEndpoint
             });
         }).then(function(res) {
             assert.deepEqual(res.body.items.length, 1);
@@ -55,7 +55,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when aggregate parameters are wrong', function () {
         return preq.get({
-            uri: server.config.globalURL + projectEndpoint.replace('1971010100', '20150701000000')
+            uri: server.config.aqsURL + projectEndpoint.replace('1971010100', '20150701000000')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -63,7 +63,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when start is before end', function () {
         return preq.get({
-            uri: server.config.globalURL + projectEndpoint.replace('1969010100', '2016070100')
+            uri: server.config.aqsURL + projectEndpoint.replace('1969010100', '2016070100')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -71,7 +71,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when timestamp is invalid', function () {
         return preq.get({
-            uri: server.config.globalURL + projectEndpoint.replace('1971010100', '2015022900')
+            uri: server.config.aqsURL + projectEndpoint.replace('1971010100', '2015022900')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -81,10 +81,10 @@ describe('pageviews endpoints', function () {
     // by the monitoring tests.
     it('should return the expected aggregate data after insertion', function () {
         return preq.post({
-            uri: server.config.globalURL + insertProjectEndpoint + '/0'
+            uri: server.config.aqsURL + insertProjectEndpoint + '/0'
         }).then(function() {
             return preq.get({
-                uri: server.config.globalURL + projectEndpoint
+                uri: server.config.aqsURL + projectEndpoint
             });
         }).then(function(res) {
             assert.deepEqual(res.body.items.length, 1);
@@ -94,12 +94,12 @@ describe('pageviews endpoints', function () {
 
     it('should return the expected aggregate data after long insertion', function () {
         return preq.post({
-            uri: server.config.globalURL +
+            uri: server.config.aqsURL +
                  fix(insertProjectEndpointLong, 'en.wikipedia', '1') +
                  '/0'
         }).then(function() {
             return preq.get({
-                uri: server.config.globalURL +
+                uri: server.config.aqsURL +
                      fix(projectEndpoint, 'en.wikipedia', '1')
             });
         }).then(function(res) {
@@ -110,12 +110,12 @@ describe('pageviews endpoints', function () {
 
     it('should parse the v column string into an int', function () {
         return preq.post({
-            uri: server.config.globalURL +
+            uri: server.config.aqsURL +
                  fix(insertProjectEndpointLong, 'en.wikipedia', '3') +
                  '/9007199254740991'
         }).then(function() {
             return preq.get({
-                uri: server.config.globalURL +
+                uri: server.config.aqsURL +
                      fix(projectEndpoint, 'en.wikipedia', '3')
             });
         }).then(function(res) {
@@ -129,7 +129,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when tops parameters are wrong', function () {
         return preq.get({
-            uri: server.config.globalURL + topsEndpoint.replace('all-months', 'all-monthz')
+            uri: server.config.aqsURL + topsEndpoint.replace('all-months', 'all-monthz')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -137,7 +137,7 @@ describe('pageviews endpoints', function () {
 
     it('Should return 400 when all-year is used for the year parameter', function () {
         return preq.get({
-            uri: server.config.globalURL + topsEndpoint.replace('2015', 'all-years')
+            uri: server.config.aqsURL + topsEndpoint.replace('2015', 'all-years')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -145,7 +145,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when tops date is invalid', function () {
         return preq.get({
-            uri: server.config.globalURL + topsEndpoint.replace('all-months/all-days', '02/29')
+            uri: server.config.aqsURL + topsEndpoint.replace('all-months/all-days', '02/29')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -153,7 +153,7 @@ describe('pageviews endpoints', function () {
 
     it('should return 400 when tops parameters are using "all-months" wrong', function () {
         return preq.get({
-            uri: server.config.globalURL + topsEndpoint.replace('all-days', '01')
+            uri: server.config.aqsURL + topsEndpoint.replace('all-days', '01')
         }).catch(function(res) {
             assert.deepEqual(res.status, 400);
         });
@@ -161,7 +161,7 @@ describe('pageviews endpoints', function () {
 
     it('should return the expected tops data after insertion', function () {
         return preq.post({
-            uri: server.config.globalURL + insertTopsEndpoint,
+            uri: server.config.aqsURL + insertTopsEndpoint,
             body: {
                 articles: [{
                         rank: 1,
@@ -178,7 +178,7 @@ describe('pageviews endpoints', function () {
 
         }).then(function() {
             return preq.get({
-                uri: server.config.globalURL + topsEndpoint
+                uri: server.config.aqsURL + topsEndpoint
             });
         }).then(function(res) {
             assert.deepEqual(res.body.items.length, 1);

--- a/test/test_module.yaml
+++ b/test/test_module.yaml
@@ -1,187 +1,115 @@
 # Simple test spec
 
 swagger: 2.0
-
 paths:
-  /service/test/{title}{/revision}:
-    get:
-      x-setup-handler:
-        - init_storage:
-            uri: /{domain}/sys/key_value/testservice.test
+  /{api:v1}:
+    swagger: '2.0'
+    info:
+      version: 1.0.0-beta
+      title: Wikimedia testing APIs
+      x-is-api-root: true
+    securityDefinitions: &wp/content-security/1.0.0
+      header_match:
+        description: Checks client ip against one of the predefined whitelists
+        x-error-message: This client is not allowed to use the endpoint
+        x-whitelists:
+          internal:
+            - /^(?:::ffff:)?(?:10|127)\./
+        x-is-api: true
+    paths:
+      /service/test/{title}{/revision}:
+        get:
+          x-setup-handler:
+            - init_storage:
+                uri: /{domain}/sys/key_value/testservice.test
 
-      x-request-handler:
-        - get_from_storage:
-            request:
-              uri: /{domain}/sys/key_value/testservice.test/{title}
-              headers:
-                'cache-control': '{{cache-control}}'
-            catch:
-              status: 404
-            return_if:
-              status: 200
-        - get_from_api:
-            request:
-              uri: http://en.wikipedia.org/wiki/{+title}
-              body: '{{request.body}}'
-        - store:
-            request:
-              method: put
-              uri: /{domain}/sys/key_value/testservice.test/{title}
-              headers: '{{get_from_api.headers}}'
-              body: '{{get_from_api.body}}'
-        - return_response:
-            return:
-              status: '{$.get_from_api.status}'
-              headers:
-                'content-type': '{$.get_from_api.headers.content-type}'
-                'etag': '{$.store.headers.etag}'
-              body: '{$.get_from_api.body}'
+          x-request-handler:
+            - get_from_storage:
+                request:
+                  uri: /{domain}/sys/key_value/testservice.test/{title}
+                  headers:
+                    'cache-control': '{{cache-control}}'
+                catch:
+                  status: 404
+                return_if:
+                  status: 200
+            - get_from_api:
+                request:
+                  uri: http://en.wikipedia.org/wiki/{+title}
+                  body: '{{request.body}}'
+            - store:
+                request:
+                  method: put
+                  uri: /{domain}/sys/key_value/testservice.test/{title}
+                  headers: '{{get_from_api.headers}}'
+                  body: '{{get_from_api.body}}'
+            - return_response:
+                return:
+                  status: '{$.get_from_api.status}'
+                  headers:
+                    'content-type': '{$.get_from_api.headers.content-type}'
+                    'etag': '{$.store.headers.etag}'
+                  body: '{$.get_from_api.body}'
 
-      x-monitor: false
+          x-monitor: false
 
-  /service/test_parallel/{key1}/{key2}:
-    get:
-      x-request-handler:
-        - get_from_api1:
-            request:
-              uri: http://en.wikipedia.org/wiki/{+key1}
-          get_from_api2:
-            request:
-              uri: http://en.wikipedia.org/wiki/{+key2}
-        - return_response:
-            return:
-              status: 200
-              body:
-                first: '{{global.get_from_api1}}'
-                second: '{{global.get_from_api2}}'
-      x-monitor: true
-      x-amples:
-        - title: Retreives parallel content with simple service
-          request:
-            params:
-              key1: User:GWicke/Date
-              key2: User:GWicke/Date
-          response:
-            status: 200
-            body:
-              first:
+      /service/test_parallel/{key1}/{key2}:
+        get:
+          x-request-handler:
+            - get_from_api1:
+                request:
+                  uri: http://en.wikipedia.org/wiki/{+key1}
+              get_from_api2:
+                request:
+                  uri: http://en.wikipedia.org/wiki/{+key2}
+            - return_response:
+                return:
+                  status: 200
+                  body:
+                    first: '{{global.get_from_api1}}'
+                    second: '{{global.get_from_api2}}'
+          x-monitor: true
+          x-amples:
+            - title: Retreives parallel content with simple service
+              request:
+                params:
+                  key1: User:GWicke/Date
+                  key2: User:GWicke/Date
+              response:
                 status: 200
-                headers:
-                  content-type: /^text\/html.+/
-              second:
-                status: 200
-                headers:
-                  content-type: /^text\/html.+/
+                body:
+                  first:
+                    status: 200
+                    headers:
+                      content-type: /^text\/html.+/
+                  second:
+                    status: 200
+                    headers:
+                      content-type: /^text\/html.+/
 
-  /post_data/:
-    post:
-      security:
-        - header_match:
-            - header: 'x-client-ip'
-              patterns:
-                - internal
-      x-request-handler:
-        - put_to_storage:
-            request:
-              method: put
-              uri: /{domain}/sys/post_data/post.test/
-              headers: '{$.request.headers}'
-              body: '{$.request.body}'
-      x-monitor: false
+      /post_data/:
+        post:
+          security:
+            - header_match:
+                - header: 'x-client-ip'
+                  patterns:
+                    - internal
+          x-request-handler:
+            - put_to_storage:
+                request:
+                  method: put
+                  uri: /{domain}/sys/post_data/post.test/
+                  headers: '{$.request.headers}'
+                  body: '{$.request.body}'
+          x-monitor: false
 
-  /post_data/{hash}:
-    get:
-      x-setup-handler:
-        - init_storage:
-            uri: /{domain}/sys/post_data/post.test
-      x-request-handler:
-        - get_from_storage:
-            request:
-              uri: /{domain}/sys/post_data/post.test/{hash}
-      x-monitor: false
-
-  /metrics/pageviews/insert-per-article-flat/{project}/{article}/{granularity}/{timestamp}/{views}:
-    post:
-      x-request-handler:
-        - put_to_storage:
-            request:
-              method: 'put'
-              uri: '/{domain}/sys/table/pageviews.per.article.flat/'
-              body:
-                table: 'pageviews.per.article.flat'
-                attributes:
-                  project: '{$.request.params.project}'
-                  article: '{$.request.params.article}'
-                  granularity: '{$.request.params.granularity}'
-                  timestamp: '{$.request.params.timestamp}'
-                  aa:  '{$.request.params.views}1'
-                  ab:  '{$.request.params.views}2'
-                  as:  '{$.request.params.views}3'
-                  au:  '{$.request.params.views}4'
-                  da:  '{$.request.params.views}5'
-                  db:  '{$.request.params.views}6'
-                  ds:  '{$.request.params.views}7'
-                  du:  '{$.request.params.views}8'
-                  maa: '{$.request.params.views}9'
-                  mab: '{$.request.params.views}10'
-                  mas: '{$.request.params.views}11'
-                  mau: '{$.request.params.views}12'
-                  mwa: '{$.request.params.views}13'
-                  mwb: '{$.request.params.views}14'
-                  mws: '{$.request.params.views}15'
-                  mwu: '{$.request.params.views}16'
-      x-monitor: false
-
-  /metrics/pageviews/insert-aggregate/{project}/{access}/{agent}/{granularity}/{timestamp}/{views}:
-    post:
-      x-request-handler:
-        - put_to_storage:
-            request:
-              method: 'put'
-              uri: '/{domain}/sys/table/pageviews.per.project/'
-              body:
-                table: 'pageviews.per.project'
-                attributes:
-                  project: '{$.request.params.project}'
-                  access: '{$.request.params.access}'
-                  agent: '{$.request.params.agent}'
-                  granularity: '{$.request.params.granularity}'
-                  timestamp: '{$.request.params.timestamp}'
-                  views: '{$.request.params.views}'
-      x-monitor: false
-
-  /metrics/pageviews/insert-aggregate-long/{project}/{access}/{agent}/{granularity}/{timestamp}/{v}:
-    post:
-      x-request-handler:
-        - put_to_storage:
-            request:
-              method: 'put'
-              uri: '/{domain}/sys/table/pageviews.per.project/'
-              body:
-                table: 'pageviews.per.project'
-                attributes:
-                  project: '{$.request.params.project}'
-                  access: '{$.request.params.access}'
-                  agent: '{$.request.params.agent}'
-                  granularity: '{$.request.params.granularity}'
-                  timestamp: '{$.request.params.timestamp}'
-                  v: '{$.request.params.v}'
-      x-monitor: false
-
-  /metrics/pageviews/insert-top/{project}/{access}/{year}/{month}/{day}:
-    post:
-      x-request-handler:
-        - put_to_storage:
-            request:
-              method: 'put'
-              uri: '/{domain}/sys/table/top.pageviews/'
-              body:
-                table: 'top.pageviews'
-                attributes:
-                  project: '{$.request.params.project}'
-                  access: '{$.request.params.access}'
-                  year: '{$.request.params.year}'
-                  month: '{$.request.params.month}'
-                  day: '{$.request.params.day}'
-                  articlesJSON: '{$.request.body.articles}'
-      x-monitor: false
+      /post_data/{hash}:
+        get:
+          x-setup-handler:
+            - init_storage:
+                uri: /{domain}/sys/post_data/post.test
+          x-request-handler:
+            - get_from_storage:
+                request:
+                  uri: /{domain}/sys/post_data/post.test/{hash}
+          x-monitor: false


### PR DESCRIPTION
Recently we've had several bugs in production which were not caught by the tests because of the difference between our test and example config. This PR reduces the difference to minimum. Changes:
- Reuse project files in test config
- Reorganise the test_module config so that it could be 'mounted' on the config level, not project level
- Make a separate AQS project
- Separate RB and AQS parts of the test_module
- Reorganise security a bit  - do not check `/sys` routes and mount security one level up.