### PR TITLE
Tests: Covered swagger-ui usages with tests

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -36,8 +36,8 @@ function ApiScope(init) {
     if (!specRoot['x-default-params']) { specRoot['x-default-params'] = {}; }
     if (specRoot.basePath === undefined) { specRoot.basePath  = this.prefixPath; }
 
-    this.globals = init.globals || null;
-    this.operations = init.operations || null;
+    this.globals = init.globals || {};
+    this.operations = init.operations || {};
 }
 
 ApiScope.prototype.makeChild = function(overrides) {

--- a/test/framework/router/buildTree.js
+++ b/test/framework/router/buildTree.js
@@ -35,6 +35,16 @@ var additionalMethodSpec = {
     }
 };
 
+var noHandlerSpec = {
+    paths: {
+        '/test': {
+            get: {
+                operationId: 'unknown'
+            }
+        }
+    }
+};
+
 var overlappingMethodSpec = {
     paths: {
         '/{domain:en.wikipedia.org}/v1': {
@@ -72,8 +82,9 @@ describe('Router', function() {
         .then(function() {
             throw new Error("Should throw an exception!");
         },
-        function() {
-            // exception thrown as expected
+        function(e) {
+            assert.deepEqual(e.message,
+                'x-subspec and x-subspecs is no longer supported! Use x-modules instead.');
         });
     });
 
@@ -89,12 +100,12 @@ describe('Router', function() {
 
     it('should error on overlapping methods on the same path', function() {
         var router = new Router();
-        return router.loadSpec(overlappingMethodSpec)
+        return router.loadSpec(overlappingMethodSpec, fakeRestBase)
         .then(function() {
             throw new Error("Should throw an exception!");
         },
-        function() {
-            // exception thrown as expected
+        function(e) {
+            assert.deepEqual(/^Trying to re-define existing metho/.test(e.message), true);
         });
     });
 
@@ -109,6 +120,17 @@ describe('Router', function() {
                 { value: 'third' },
                 { value: 'fourth', method: 'get' }
             ]);
+        });
+    });
+    it('should fail when no handler found for method', function() {
+        var router = new Router();
+        return router.loadSpec(noHandlerSpec, fakeRestBase)
+        .then(function() {
+            throw new Error("Should throw an exception!");
+        },
+        function(e) {
+            assert.deepEqual(e.message,
+                'No known handler associated with operationId unknown');
         });
     });
 


### PR DESCRIPTION
Just a "get into coding mode on Monday morning" patch with a couple of additional tests, covering how swagger-ui is handled and API and domain listings.

Also, I've found several test-bugs - the tests were passing, but didn't actually test the feature they're supposed to test.

cc @wikimedia/services 