### PR TITLE
Router: Fix a bug with incorrect node.value.path

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -34,7 +34,7 @@ function ApiScope(init) {
     if (!specRoot.definitions) { specRoot.definitions = {}; }
     if (!specRoot.securityDefinitions) { specRoot.securityDefinitions = {}; }
     if (!specRoot['x-default-params']) { specRoot['x-default-params'] = {}; }
-    if (!specRoot.basePath) { specRoot.basePath  = this.prefixPath; }
+    if (specRoot.basePath === undefined) { specRoot.basePath  = this.prefixPath; }
 
     this.globals = init.globals || null;
     this.operations = init.operations || null;

--- a/test/features/pagecontent/rerendering.js
+++ b/test/features/pagecontent/rerendering.js
@@ -23,7 +23,7 @@ describe('page re-rendering', function () {
     var dynamic2 = '/html/User:Pchelolo%2fDate/275851';
 
     function hasTextContentType(res) {
-        assert.contentType(res, 'text/html');
+        assert.contentType(res, server.config.conf.test.content_types.html);
     }
 
     it('should render & re-render independent revisions', function () {

--- a/test/features/router/handlerTemplate.js
+++ b/test/features/router/handlerTemplate.js
@@ -18,7 +18,7 @@ describe('handler template', function () {
     var testPage = server.config.baseURL + '/service/test/User:GWicke%2fDate';
 
     function hasTextContentType(res) {
-        assert.contentType(res, 'text/html');
+        assert.deepEqual(/^text\/html/.test(res.headers['content-type']), true);
     }
 
     var slice;

--- a/test/framework/router/buildTree.js
+++ b/test/framework/router/buildTree.js
@@ -5,6 +5,8 @@
 
 var Router = require('../../../lib/router');
 var assert = require('../utils/assert');
+var fs     = require('fs');
+var yaml   = require('js-yaml');
 
 var fakeRestBase = { rb_config: {} };
 
@@ -107,6 +109,16 @@ describe('Router', function() {
                 { value: 'third' },
                 { value: 'fourth', method: 'get' }
             ]);
+        });
+    });
+
+    it('should not modify top-level spec-root', function() {
+        var spec = yaml.safeLoad(fs.readFileSync(__dirname + '/multi_domain_spec.yaml'));
+        var router = new Router();
+        return router.loadSpec(spec, fakeRestBase)
+        .then(function() {
+            var node = router.route('/test2');
+            assert.deepEqual(node.value.path, '/test2');
         });
     });
 });

--- a/test/framework/router/multi_domain_spec.yaml
+++ b/test/framework/router/multi_domain_spec.yaml
@@ -1,0 +1,16 @@
+domain_paths: &domain_paths
+  swagger: 2.0
+  info:
+    x-is-api-root: true
+  paths:
+    /test:
+      post:
+        x-request-handlers:
+          return_echo:
+            return:
+              status: 200
+              body: '{{$.request.body}}'
+
+paths:
+  /{domain:test1}: *domain_paths
+  /{domain:test2}: *domain_paths

--- a/test/framework/utils/assert.js
+++ b/test/framework/utils/assert.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 function deepEqual(result, expected, message) {
     try {
         if (typeof expected === 'string') {
-            assert.ok(result === expected || (new RegExp(expected).test(result)));
+            assert.ok(result === expected || (new RegExp('^' + expected + '$').test(result)));
         } else {
             assert.deepEqual(result, expected, message);
         }

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -62,7 +62,7 @@ function findParsoidRequest(slice) {
 function isDeepEqual(result, expected, message) {
     try {
         if (typeof expected === 'string') {
-            assert.ok(result === expected || (new RegExp(expected).test(result)), message);
+            assert.ok(result === expected || (new RegExp('^' + expected + '$').test(result)), message);
         } else {
             assert.deepEqual(result, expected, message);
         }
@@ -75,7 +75,7 @@ function isDeepEqual(result, expected, message) {
 function deepEqual(result, expected, message) {
     try {
         if (typeof expected === 'string') {
-            assert.ok(result === expected || (new RegExp(expected).test(result)));
+            assert.ok(result === expected || (new RegExp('^' + expected + '$').test(result)));
         } else {
             assert.deepEqual(result, expected, message);
         }


### PR DESCRIPTION
There's a bug in the router code, that makes `node.value.path` be incorrect at some situations, for example we could see paths like `'en.wikipedia.org/fr.wikipedia.org/v1/etc'`. The problem is that when we are creating child scopes, the `specRoot` is copied by reference, so all modifications, made on the child scope are propagated back to the parent scope. So, when the child scope is created, and the specRoot's basePath is an empty string, which's fine on the first level, it get's overwritten by the child scope's prefix path. So, we need to overwrite it only if it's `undefined`, not an empty string.

Additionally, I've changed the deepEqual semantics for strings in tests, because now it's just checking if there's a matching substring, which could make the tests miss a bug.

cc @wikimedia/services 