### PR TITLE
Bugfix: Wrong comparasion of revision info

### DIFF
--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -190,15 +190,15 @@ PRS.prototype._checkSameRev = function(firstRev, secondRev) {
             var value = rev[key];
             // Ignore the tid attribute
             if (key !== 'tid') {
-                if (!value || (Array.isArray(value) && !value.length)) {
-                    // treat all falsy values, as well as an empty array equally - as null.
-                    result[key] = null;
-                } else if (key === 'timestamp') {
+                if (key === 'timestamp') {
                     // 'timestamp' fields need to be parsed because Cassandra
                     // returns a ISO8601 ts which includes milliseconds, while
                     // the ts returned by MW API does not
                     result[key] = Date.parse(value);
+                } else if (value && (!Array.isArray(value) || value.length)) {
+                    result[key] = value;
                 }
+                // ignore all falsy values, as well as an empty array
             }
         });
         return result;

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -187,7 +187,7 @@ PRS.prototype._checkSameRev = function(firstRev, secondRev) {
         var firstVal = firstRev[attrName];
         var secondVal = secondRev[attrName];
         // We don't really care if an empty value is null, or undefined, or other falsy
-        if (!firstVal || !secondVal || attrName === 'tid') {
+        if ((!firstVal && !secondVal) || attrName === 'tid') {
             return false;
         } else if (attrName === 'timestamp') {
             // 'timestamp' fields need to be parsed because Cassandra

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -14,6 +14,7 @@
 var rbUtil = require('../lib/rbUtil.js');
 var URI = require('swagger-router').URI;
 var uuid = require('cassandra-uuid').TimeUuid;
+var stringify = require('json-stable-stringify');
 
 // TODO: move to module
 var fs = require('fs');
@@ -183,32 +184,26 @@ PRS.prototype.listTitles = function(restbase, req, options) {
  * @private
  */
 PRS.prototype._checkSameRev = function(firstRev, secondRev) {
-    return !Object.keys(firstRev).some(function(attrName) {
-        var firstVal = firstRev[attrName];
-        var secondVal = secondRev[attrName];
-        // We don't really care if an empty value is null, or undefined, or other falsy
-        if ((!firstVal && !secondVal) || attrName === 'tid') {
-            return false;
-        } else if (attrName === 'timestamp') {
-            // 'timestamp' fields need to be parsed because Cassandra
-            // returns a ISO8601 ts which includes milliseconds, while
-            // the ts returned by MW API does not
-            return Date.parse(firstVal) !== Date.parse(secondVal);
-        } else if (Array.isArray(firstVal) || Array.isArray(secondVal)) {
-            // we need a special case for arrays (the 'restrictions' attribute)
-            if (Array.isArray(firstVal) && Array.isArray(secondVal)
-                    && firstVal.length === secondVal.length) {
-                for (var idx = 0; idx < firstVal.length; idx++) {
-                    if (firstVal[idx] !== secondVal[idx]) {
-                        return true;
-                    }
+    function normalizeRev(rev) {
+        var result = {};
+        Object.keys(rev).forEach(function(key) {
+            var value = rev[key];
+            // Ignore the tid attribute
+            if (key !== 'tid') {
+                if (!value || (Array.isArray(value) && !value.length)) {
+                    // treat all falsy values, as well as an empty array equally - as null.
+                    result[key] = null;
+                } else if (key === 'timestamp') {
+                    // 'timestamp' fields need to be parsed because Cassandra
+                    // returns a ISO8601 ts which includes milliseconds, while
+                    // the ts returned by MW API does not
+                    result[key] = Date.parse(value);
                 }
-                return false;
             }
-            return true;
-        }
-        return firstVal !== secondVal;
-    });
+        });
+        return result;
+    }
+    return stringify(normalizeRev(firstRev)) === stringify(normalizeRev(secondRev));
 };
 
 PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
@@ -253,6 +248,7 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
         var restrictions = Object.keys(apiRev).filter(function(key) {
             return /hidden$/.test(key);
         });
+
 
         // Get the redirect property, it's inclusion means true
         var redirect = dataResp.redirect !== undefined;

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -189,16 +189,18 @@ PRS.prototype._checkSameRev = function(firstRev, secondRev) {
         Object.keys(rev).forEach(function(key) {
             var value = rev[key];
             // Ignore the tid attribute
-            if (key !== 'tid') {
-                if (key === 'timestamp') {
-                    // 'timestamp' fields need to be parsed because Cassandra
-                    // returns a ISO8601 ts which includes milliseconds, while
-                    // the ts returned by MW API does not
-                    result[key] = Date.parse(value);
-                } else if (value && (!Array.isArray(value) || value.length)) {
-                    result[key] = value;
-                }
-                // ignore all falsy values, as well as an empty array
+            // Ignore all falsy values, as well as an empty array
+            if (key === 'tid' || !value || (Array.isArray(value) && !value.length)) {
+                return;
+            }
+
+            if (key === 'timestamp') {
+                // 'timestamp' fields need to be parsed because Cassandra
+                // returns a ISO8601 ts which includes milliseconds, while
+                // the ts returned by MW API does not
+                result[key] = Date.parse(value);
+            } else {
+                result[key] = value;
             }
         });
         return result;


### PR DESCRIPTION
We're comparing old&new revision info on update to avoid storing identical revision info objects. We treat all falsy values as identical, but we do it in a wrong way - if old is falsy and new is not, we still treat them as equal.