### PR TITLE
More explicitly validate the response status

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -313,7 +313,7 @@ RESTBase.prototype._request = function(req) {
                         req: req
                     }
                 });
-            } else if (res.status >= 400 && !(res instanceof Error)) {
+            } else if (!(res.status >= 100 && res.status < 400) && !(res instanceof Error)) {
                 var err = new HTTPError(res);
                 if (res.body && res.body.stack) { err.stack = res.body.stack; }
                 err.innerBody = res.body;


### PR DESCRIPTION
Explicitly check for 100 <= status < 400, and treat other status values
(including non-numeric status values) as an error.