### PR TITLE
Fix cache-control header in stored mathoid responses

### DIFF
--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -156,6 +156,10 @@ paths:
               status: 404
             return_if:
               status: '2xx'
+            return:
+              status: 200
+              headers: "{{ merge({ 'cache-control': options.cache-control }, check_storage.headers) }}"
+              body: '{{ check_storage.body }}'
         - postdata:
             request:
               uri: /wikimedia.org/sys/post_data/mathoid.input/{$.request.params.hash}


### PR DESCRIPTION
The previous code did not set a proper cache-control header for stored
responses. This caused clients to unnecessarily reload math renders, and
disallowed Varnish caching altogether.