### PR TITLE
Auth: Fix action api response to be an actual http response

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -73,7 +73,8 @@ var securityDefinitionCreators = {
                 };
                 return restbase.post(checkReq)
                 .then(function(userInfo) {
-                    if (userInfo.rights && Array.isArray(userInfo.rights)) {
+                    userInfo = userInfo.body;
+                    if (userInfo && userInfo.rights && Array.isArray(userInfo.rights)) {
                         permissions.forEach(function(perm) {
                             if (userInfo.rights.indexOf(perm) < 0) {
                                 throw new rbUtil.HTTPError({

--- a/sys/action.js
+++ b/sys/action.js
@@ -152,7 +152,8 @@ function buildQueryResponse(res) {
         };
         return res;
     } else if (res.body.query.userinfo) {
-        return res.body.query.userinfo;
+        res.body = res.body.query.userinfo;
+        return res;
     } else {
         throw apiError({ info: 'Unable to parse PHP action API response.' });
     }


### PR DESCRIPTION
A simple bug-fix: we've used to return `userInfo` object from action module directly, which's not actually an http response, so it breaks new response status validation added by @gwicke in https://github.com/wikimedia/restbase/pull/458

/cc @wikimedia/services 