### PR TITLE
Specs: Removed duplicated key from a spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "core-js": "^1.2.6",
     "bluebird": "2.8.2",
     "busboy": "^0.2.12",
-    "js-yaml": "^3.4.6",
+    "js-yaml": "^3.5.2",
     "jsonwebtoken": "^5.4.1",
     "cassandra-uuid": "^0.0.2",
     "preq": "^0.4.7",

--- a/sys/post_data.yaml
+++ b/sys/post_data.yaml
@@ -13,11 +13,9 @@ paths:
   /{bucket}/:
     get:
       operationId: listBucket
+    put:
+      operationId: putRevision
 
   /{bucket}/{key}{/tid}:
     get:
       operationId: getRevision
-
-  /{bucket}/:
-    put:
-      operationId: putRevision


### PR DESCRIPTION
A new version of `js-yaml` package was just released, and it became more strict on duplicated keys in the yaml file - it doesn't merge the objects any more, but fails with an exception. This PR removes dup keys from RESTBase specs.