### PR TITLE
API: Added definitions enpoint for wiktionary domains

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -36,6 +36,11 @@ wikimedia.org: &wikimedia.org
       - path: projects/wikimedia.org.yaml
         options: *default_options
 
+wiktionary_project: &wiktionary_project
+  x-modules:
+    /:
+      - path: projects/wmf_wiktionary.yaml
+        options: *default_options
 
 # The root of the spec tree. Domains tend to share specs by referencing them
 # using YAML references.
@@ -49,6 +54,9 @@ spec_root: &spec_root
     /{domain:it.wikipedia.org}: *default_project
     /{domain:da.wikipedia.org}: *default_project
     /{domain:sv.wikipedia.org}: *default_project
+
+    # Example for wiktionary
+    /{domain:en.wiktionary.org}: *wiktionary_project
 
     # global domain
     /{domain:wikimedia.org}: *wikimedia.org

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -52,6 +52,12 @@ wikimedia.org: &wikimedia.org
           pageviews:
             host: https://wikimedia.org/api/rest_v1/metrics
 
+wiktionary_project: &wiktionary_project
+  x-modules:
+    /:
+      - path: projects/wmf_wiktionary.yaml
+        options: *default_options
+
 # A synthetic domain to test pageviews module data
 aqs.wikimedia.org: &aqs.wikimedia.org
   x-modules:
@@ -91,6 +97,9 @@ spec_root: &spec_root
 
     # global domain
     /{domain:wikimedia.org}: *wikimedia.org
+
+    # Wiktionary has some specific endpoints
+    /{domain:en.wiktionary.org}: *wiktionary_project
 
 # Finally, a standard service-runner config.
 info:

--- a/lib/router.js
+++ b/lib/router.js
@@ -33,7 +33,6 @@ function ApiScope(init) {
     if (!specRoot.paths) { specRoot.paths = {}; }
     if (!specRoot.definitions) { specRoot.definitions = {}; }
     if (!specRoot.securityDefinitions) { specRoot.securityDefinitions = {}; }
-    if (!specRoot['x-default-params']) { specRoot['x-default-params'] = {}; }
     if (specRoot.basePath === undefined) { specRoot.basePath  = this.prefixPath; }
 
     this.globals = init.globals || {};
@@ -515,9 +514,6 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, scope, optionalPa
     if (spec.securityDefinitions) {
         // Merge security definitions
         Object.assign(scope.specRoot.securityDefinitions, spec.securityDefinitions);
-    }
-    if (spec['x-default-params']) {
-        Object.assign(scope.specRoot['x-default-params'], spec['x-default-params']);
     }
     var self = this;
 

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -1,7 +1,6 @@
 swagger: '2.0'
 paths:
   /{api:v1}: &default_project_paths_v1
-    swagger: '2.0'
     # swagger options, overriding the shared ones from the merged specs (?)
     info:
       version: 1.0.0-beta
@@ -26,7 +25,6 @@ paths:
       license:
         name: Apache2
         url: http://www.apache.org/licenses/LICENSE-2.0
-      x-is-api-root: true
 
     securityDefinitions: &wp/content-security/1.0.0
       mediawiki_auth:
@@ -68,9 +66,6 @@ paths:
           options: '{{options.mathoid}}'
 
   /{api:sys}: &default_project_paths_sys
-    swagger: 2.0
-    info:
-      x-is-api-root: true
     x-modules: &default_project_paths_sys_modules
       /table: &sys_table
         - type: npm

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -1,0 +1,101 @@
+swagger: '2.0'
+paths:
+  /{api:v1}: &default_project_paths_v1
+    swagger: '2.0'
+    # swagger options, overriding the shared ones from the merged specs (?)
+    info:
+      version: 1.0.0-beta
+      title: Wikimedia REST API
+      description: >
+          This API aims to provide coherent and low-latency access to
+          Wikimedia content and services. It is currently in beta testing, so
+          things aren't completely locked down yet. Each entry point has
+          explicit stability markers to inform you about development status
+          and change policy, according to [our API version
+          policy](https://www.mediawiki.org/wiki/API_versioning).
+
+          ### High-volume access
+            - Don't perform more than 200 requests/s to this API.
+            - Set a unique `User-Agent` header that allows us to contact you
+              quickly. Email addresses or URLs of contact pages work well.
+
+      termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+      contact:
+        name: the Wikimedia Services team
+        url: http://mediawiki.org/wiki/RESTBase
+      license:
+        name: Apache2
+        url: http://www.apache.org/licenses/LICENSE-2.0
+      x-is-api-root: true
+
+    securityDefinitions: &wp/content-security/1.0.0
+      mediawiki_auth:
+        description: Checks permissions using MW api
+        type: apiKey
+        in: header
+        name: cookie
+        x-internal-request-whitelist:
+          - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
+          - http://parsoid-lb.eqiad.wikimedia.org
+          - http://parsoid-beta.wmflabs.org
+      header_match:
+        description: Checks client ip against one of the predefined whitelists
+        x-error-message: This client is not allowed to use the endpoint
+        x-whitelists:
+          internal:
+            - /^(?:::ffff:)?(?:10|127)\./
+        x-is-api: true
+    # Override the base path for host-based (proxied) requests. In our case,
+    # we proxy https://{domain}/api/rest_v1/ to the API.
+    x-host-basePath: /api/rest_v1
+
+    x-modules: &default_project_paths_v1_modules
+      /:
+        # The main content module, defining page/* and transform entry
+        # points.
+        - path: v1/content.yaml
+      /page:
+        - path: v1/mobileapps.yaml
+          options: '{{options.mobileapps}}'
+        - path: v1/graphoid.yaml
+          options: '{{options.graphoid}}'
+        - path: v1/definition.yaml
+          options:
+            response_cache-control: 'max-age: 3600, s-maxage: 3600'
+            host: '{{options.mobileapps.host}}'
+      /media:
+        - path: v1/mathoid.yaml
+          options: '{{options.mathoid}}'
+
+  /{api:sys}: &default_project_paths_sys
+    swagger: 2.0
+    info:
+      x-is-api-root: true
+    x-modules: &default_project_paths_sys_modules
+      /table: &sys_table
+        - type: npm
+          name: restbase-mod-table-cassandra
+          # See:
+          # https://github.com/wikimedia/restbase-mod-table-cassandra/blob/master/Readme.md#configuration
+          options:
+            conf: '{{options.table}}'
+      /key_value: &sys_key_value
+        - path: sys/key_value.js
+      /key_rev_value:
+        - path: sys/key_rev_value.js
+      /page_revisions:
+        - path: sys/page_revisions.js
+      /post_data: &sys_post_data
+        - path: sys/post_data.js
+      /action:
+        - path: sys/action.js
+          options: "{{options.action}}"
+      /page_save:
+        - path: sys/page_save.js
+      /parsoid:
+        - path: sys/parsoid.js
+          options:
+            parsoidHost: '{{options.parsoid.host}}'
+      /mobileapps:
+        - path: sys/mobileapps.yaml
+          options: '{{options.mobileapps}}'

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -346,7 +346,9 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
                 // In future this should be controlled by dependency tracking system.
                 // return is missed on purpose - we don't want to wait for the result
                 restbase.get({
-                    uri: new URI([rp.domain, 'v1', 'page', 'summary', rp.title]),
+                    uri: new URI([rp.domain, 'v1', 'page',
+                        rp.domain.indexOf('wiktionary') < 0 ? 'summary' : 'definition',
+                        rp.title]),
                     headers: {
                         'cache-control': 'no-cache'
                     }

--- a/test/features/specification/monitoring.js
+++ b/test/features/specification/monitoring.js
@@ -50,14 +50,6 @@ function constructTests(spec, options) {
                     return;
                 }
 
-                // This is a hack. We're running tests again parsoid instance in labs
-                // which doesn't have access to en.wikipedia.org, but all of our x-amples
-                // point to en.wiki. So for tests which involve parsoid we have to manually
-                // rewrite the domain.
-                if (ex.tags && ex.tags.indexOf('parsoid') >= 0) {
-                    ex.request.params.domain = 'en.wikipedia.beta.wmflabs.org';
-                }
-
                 ret.push(constructTestCase(
                     ex.title,
                     uri.toString({params: ex.request.params}),

--- a/test/features/specification/monitoring.js
+++ b/test/features/specification/monitoring.js
@@ -25,15 +25,8 @@ function constructTestCase(title, path, method, request, response) {
     };
 }
 
-function constructTests(spec, defParams) {
+function constructTests(spec, options) {
     var paths = spec.paths;
-    if (spec['x-default-params']) {
-        Object.keys(spec['x-default-params']).forEach(function(paramName) {
-           if (!defParams[paramName]) {
-               defParams[paramName] = spec['x-default-params'][paramName];
-           }
-        });
-    }
     var ret = [];
     Object.keys(paths).forEach(function(pathStr) {
         if (!pathStr) return;
@@ -53,9 +46,21 @@ function constructTests(spec, defParams) {
             }
             p['x-amples'].forEach(function(ex) {
                 ex.request = ex.request || {};
+                if (ex.request.params && ex.request.params.domain !== options.domain) {
+                    return;
+                }
+
+                // This is a hack. We're running tests again parsoid instance in labs
+                // which doesn't have access to en.wikipedia.org, but all of our x-amples
+                // point to en.wiki. So for tests which involve parsoid we have to manually
+                // rewrite the domain.
+                if (ex.tags && ex.tags.indexOf('parsoid') >= 0) {
+                    ex.request.params.domain = 'en.wikipedia.beta.wmflabs.org';
+                }
+
                 ret.push(constructTestCase(
                     ex.title,
-                    uri.toString({params: Object.assign({}, defParams, ex.request.params || {})}),
+                    uri.toString({params: ex.request.params}),
                     method,
                     ex.request,
                     ex.response || {}
@@ -145,6 +150,10 @@ describe('Monitoring tests', function() {
             {
                 domain: 'wikimedia.org',
                 specURI: server.config.globalURL + '/?spec'
+            },
+            {
+                domain: 'en.wiktionary.org',
+                specURI: server.config.hostPort + '/en.wiktionary.org/v1/?spec'
             }],
         function(options) {
             return preq.get(options.specURI)
@@ -156,13 +165,7 @@ describe('Monitoring tests', function() {
             })
             .then(function(spec) {
                 describe('Monitoring routes, ' + options.domain + ' domain', function() {
-                    var defaults = spec['x-default-params'] || {};
-                    if (options.domain === 'en.wikipedia.org') {
-                        defaults.domain = 'en.wikipedia.beta.wmflabs.org';
-                    } else {
-                        defaults.domain = options.domain;
-                    }
-                    constructTests(spec, defaults).forEach(function(testCase) {
+                    constructTests(spec, options).forEach(function(testCase) {
                         it(testCase.title, function() {
                             return preq(testCase.request)
                             .then(function(res) {

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -11,8 +11,6 @@ info:
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0
-x-default-params:
-  domain: en.wikipedia.org
 paths:
   /{module:page}/:
     get:
@@ -127,6 +125,7 @@ paths:
         - title: Get rev by title from storage
           request:
             params:
+              domain: en.wikipedia.org
               title: Foobar
           response:
             status: 200
@@ -292,8 +291,10 @@ paths:
         #      content-type: /^text\/html.+/
         #    body: /^<!DOCTYPE html>.*/
         - title: Get html by title from storage
+          tags: [ 'content', 'parsoid' ]
           request:
             params:
+              domain: en.wikipedia.org
               title: Foobar
           response:
             status: 200
@@ -582,8 +583,10 @@ paths:
       x-monitor: true
       x-amples:
         - title: Get data-parsoid by title
+          tags: [ 'content', 'parsoid' ]
           request:
             params:
+              domain: en.wikipedia.org
               title: Foobar
           response:
             status: 200
@@ -1033,8 +1036,10 @@ paths:
       x-monitor: true
       x-amples:
         - title: Transform wikitext to html
+          tags: [ 'content', 'parsoid' ]
           request:
             params:
+              domain: en.wikipedia.org
               title: Foobar
             body:
               wikitext: == Heading ==

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -291,7 +291,6 @@ paths:
         #      content-type: /^text\/html.+/
         #    body: /^<!DOCTYPE html>.*/
         - title: Get html by title from storage
-          tags: [ 'content', 'parsoid' ]
           request:
             params:
               domain: en.wikipedia.org
@@ -583,7 +582,6 @@ paths:
       x-monitor: true
       x-amples:
         - title: Get data-parsoid by title
-          tags: [ 'content', 'parsoid' ]
           request:
             params:
               domain: en.wikipedia.org
@@ -1036,7 +1034,6 @@ paths:
       x-monitor: true
       x-amples:
         - title: Transform wikitext to html
-          tags: [ 'content', 'parsoid' ]
           request:
             params:
               domain: en.wikipedia.org

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -37,7 +37,11 @@ paths:
           schema:
             $ref: '#/definitions/definitionsResponse'
         '404':
-          description: Unknown term or definitions not supported for this language
+          description: Unknown term
+          schema:
+            $ref: '#/definitions/problem'
+        '501':
+          description: Term definitions not supported for this language
           schema:
             $ref: '#/definitions/problem'
         default:
@@ -49,7 +53,7 @@ paths:
         # Set up a simple key-value bucket.
         - init:
             method: 'put'
-            uri: /{domain}/sys/key_value/definition
+            uri: /{domain}/sys/key_value/term.definition
             body:
               valueType: 'json'
 
@@ -69,7 +73,7 @@ paths:
               method: get
               headers:
                 cache-control: '{{cache-control}}'
-              uri: /{domain}/sys/key_value/definition/{request.params.term}
+              uri: /{domain}/sys/key_value/term.definition/{request.params.term}
             catch:
               status: 404
             return_if:
@@ -97,7 +101,7 @@ paths:
         - store_and_return:
             request:
               method: put
-              uri: /{domain}/sys/key_value/definition/{request.params.term}
+              uri: /{domain}/sys/key_value/term.definition/{request.params.term}
               headers: '{{extract.headers}}'
               body: '{{extract.body}}'
             return:

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -1,8 +1,8 @@
 swagger: '2.0'
 info:
   version: '1.0.0-beta'
-  title: MediaWiki Summary API
-  description: Page content summary API
+  title: MediaWiki Definition API
+  description: Wikitionary word definition API
   termsofservice: https://github.com/wikimedia/restbase#restbase
   contact:
     name: Services
@@ -12,14 +12,13 @@ info:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
-  /summary/{title}:
+  /definition/{term}:
     get:
       tags:
         - Page content
       description: >
-        Returns the summary of the latest page content available in storage.
-        Currently the summary includes the text for the first several sentences and
-        the thumbnail URL.
+        Returns the definition of the term based on the latest wikitionary page content
+        available in storage.
 
         Provide a `Cache-Control: no-cache` header to request the latest data.
 
@@ -27,18 +26,18 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: title
+        - name: term
           in: path
-          description: The page title.
+          description: The term to define
           type: string
           required: true
       responses:
         '200':
-          description: The summary for the given page
+          description: The definition for the given term
           schema:
-            $ref: '#/definitions/summary'
+            $ref: '#/definitions/definitionsResponse'
         '404':
-          description: Unknown page title
+          description: Unknown term or definitions not supported for this language
           schema:
             $ref: '#/definitions/problem'
         default:
@@ -50,19 +49,18 @@ paths:
         # Set up a simple key-value bucket.
         - init:
             method: 'put'
-            uri: /{domain}/sys/key_value/summary
+            uri: /{domain}/sys/key_value/definition
             body:
               valueType: 'json'
 
       x-request-handler:
-
         # Get the revision metadata for access control (will return an error
         # if there's no access), and so that we can use the normalized title &
         # other info in case we have a storage miss.
         - rev_info:
             request:
               method: get
-              uri: /{domain}/sys/page_revisions/page/{title}
+              uri: /{domain}/sys/page_revisions/page/{term}
             response:
               body: '{{rev_info.body.items[0]}}'
 
@@ -71,7 +69,7 @@ paths:
               method: get
               headers:
                 cache-control: '{{cache-control}}'
-              uri: /{domain}/sys/key_value/summary/{request.params.title}
+              uri: /{domain}/sys/key_value/definition/{request.params.term}
             catch:
               status: 404
             return_if:
@@ -85,39 +83,23 @@ paths:
                 cache-control: '{{options.response_cache-control}}'
               body: '{{storage.body}}'
 
-        # Storage miss. Call the Action API to get the textextract.
+        # Storage miss. Call mobile content service to get the definition.
         - extract:
             request:
-              method: post
-              uri: /{domain}/sys/action/query
-              body:
-                prop: 'extracts|pageimages'
-                redirects: true
-                exsentences: 5
-                explaintext: true
-                piprop: 'thumbnail'
-                pithumbsize: 320
-                titles: '{{rev_info.body.title}}'
+              method: get
+              uri: '{{$$.options.host}}/{domain}/v1/page/definition/{term}'
             response:
               # Define the response to save & return.
               headers:
                 content-type: application/json
                 etag: '"{{rev_info.body.rev}}/{{rev_info.body.tid}}"'
-              body:
-                title: '{{extract.body.items[0].title}}'
-                extract: '{{extract.body.items[0].extract}}'
-                thumbnail: '{{httpsSource(extract.body.items[0].thumbnail)}}'
-                # Need to figure out the format of this before we can add it.
-                # See https://phabricator.wikimedia.org/T117082#1787617.
-                #timestamp: '{{request.params.timestamp}}'
-
+              body: '{{extract.body}}'
         - store_and_return:
             request:
               method: put
-              uri: /{domain}/sys/key_value/summary/{request.params.title}
+              uri: /{domain}/sys/key_value/definition/{request.params.term}
               headers: '{{extract.headers}}'
               body: '{{extract.body}}'
-
             return:
               status: 200
               headers:
@@ -128,20 +110,16 @@ paths:
 
       x-monitor: true
       x-amples:
-        - title: Get summary from storage
+        - title: Get definition from storage
           request:
             params:
-              domain: en.wikipedia.org
-              title: Barack_Obama
+              domain: en.wiktionary.org
+              term: cat
           response:
             status: 200
             headers:
               etag: /.+/
               content-type: /^application\/json$/
-            body:
-              extract: /.+/
-              thumbnail:
-                source: /^https:/
 
 definitions:
   # A https://tools.ietf.org/html/draft-nottingham-http-problem
@@ -158,30 +136,37 @@ definitions:
       instance:
         type: string
 
-  summary:
+  definition:
+    type: object
+    description: Describes a single definition of a term
+    properties:
+      definition:
+        type: string
+        description: A term definition
+      examples:
+        type: array
+        items:
+          type: string
+          description: An example of word usage
+    required: [ 'definition' ]
+
+  usageDescription:
     type: object
     properties:
-      title:
+      partOfSpeech:
         type: string
-        description: The page title
-      #timestamp:
-      #  type: string
-      #  format: date-time
-      #  description: The ISO timestamp of a page revision
-      extract:
-        type: string
-        description: First several sentences of an article in plain text
-      thumbnail:
-        type: object
-        properties:
-          source:
-            type: string
-            description: Thumbnail image URI
-          width:
-            type: integer
-            description: Thumbnail width
-          height:
-            type: integer
-            description: Thumnail height
-        required: ['source', 'width', 'height']
-    required: ['title', 'extract']
+        description: Part of speech (e.g. 'Noun' or 'Verb')
+      definitions:
+        type: array
+        items:
+          $ref: definition
+    required: [ 'partOfSpeech', 'definitions' ]
+
+  definitionsResponse:
+    type: object
+    properties:
+      usages:
+        type: array
+        items:
+          $ref: usageDescription
+    required: [ 'usages' ]

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -53,6 +53,7 @@ paths:
         - title: Mathoid - check test formula
           request:
             params:
+              domain: wikimedia.org
               type: tex
             body:
               q: E=mc^{2}

--- a/v1/pageviews.yaml
+++ b/v1/pageviews.yaml
@@ -157,6 +157,7 @@ paths:
         - title: Get aggregate page views
           request:
             params:
+              domain: wikimedia.org
               project: en.wikipedia
               access: all-access
               agent: all-agents


### PR DESCRIPTION
This PR adds a `definition` endpoint for `wiktionary` domains instead of a summary endpoint. For details see https://phabricator.wikimedia.org/T123142

I created the definition response schema based on sale responses from the service, so I'm not completely sure it's 100% correct and covers all the optionals.

Another thing happening here is some refactoring of the x-amples tests:
1. I've removed the `x-default-params` stanza, because it doesn't make sense - default params should be domain-specific, but there's no way to achieve that. Also, there's very little use of that, it's easier to set the domain for each test.
2. To verify all the `x-amples` we need to run tests with different domains. If the domain of the `x-ample` doesn't match currently tested domain, we need to skip that test, bc the test data is domain-dependent.
3. This adds a very tacky thing, but it's the only possible solution I could come up with. We're running tests against the labs parsoid, so the domain of all tests, requiring parsoid, should be changed to labs, while x-amples should still point to en.wiki, as they're used in production. So, to solve this I've added `tags` to x-amples, that kinda define what's being involved in the test, so that we could rewrite the domain of every test that involve parsoid, but not other tests. If there're any other ideas how to achieve the same behaviour, please tell me. 

cc @wikimedia/services 