### PR TITLE
Switch to Node 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-    # Production runs 0.10.29
-    - "0.10.29"
     - "0.10"
     - "0.12"
     - "4.2"

--- a/package.json
+++ b/package.json
@@ -61,5 +61,12 @@
     "swagger-test": "0.2.0",
     "url-template": "^2.0.6",
     "temp": "^0.8.3"
+  },
+  "deploy": {
+    "node": "4.2",
+    "target": "debian",
+    "dependencies": {
+      "_all": []
+    }
   }
 }


### PR DESCRIPTION
We have switched our production hosts to use Node 4.2 LTS. Indicate that
in package.json so that the docker build script builds the node module
dependencies against the correct Node version.

Bug: [T107762](https://phabricator.wikimedia.org/T107762)