### PR TITLE
Summary: Added lang and direction to the summary endpoint

### DIFF
--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -93,7 +93,7 @@ paths:
               method: post
               uri: /{domain}/sys/action/query
               body:
-                prop: 'extracts|pageimages'
+                prop: 'info|extracts|pageimages'
                 redirects: true
                 exsentences: 5
                 explaintext: true
@@ -109,6 +109,8 @@ paths:
                 title: '{{extract.body.items[0].title}}'
                 extract: '{{extract.body.items[0].extract}}'
                 thumbnail: '{{httpsSource(extract.body.items[0].thumbnail)}}'
+                lang: '{{extract.body.items[0].pagelanguagehtmlcode}}'
+                dir: '{{extract.body.items[0].pagelanguagedir}}'
                 # Need to figure out the format of this before we can add it.
                 # See https://phabricator.wikimedia.org/T117082#1787617.
                 #timestamp: '{{request.params.timestamp}}'
@@ -185,4 +187,10 @@ definitions:
             type: integer
             description: Thumnail height
         required: ['source', 'width', 'height']
-    required: ['title', 'extract']
+      lang:
+        type: string
+        description: The page language
+      dir:
+        type: string
+        description: The page language direction (e.g. 'ltr' or 'rtl')
+    required: ['title', 'extract', 'lang', 'dir']

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -191,8 +191,10 @@ definitions:
         required: ['source', 'width', 'height']
       lang:
         type: string
-        description: The page language
+        description: The page language code
+        example: en
       dir:
         type: string
-        description: The page language direction (e.g. 'ltr' or 'rtl')
+        description: The page language direction code
+        example: ltr
     required: ['title', 'extract', 'lang', 'dir']

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -145,6 +145,8 @@ paths:
               extract: /.+/
               thumbnail:
                 source: /^https:/
+              lang: en
+              dir: ltr
 
 definitions:
   # A https://tools.ietf.org/html/draft-nottingham-http-problem


### PR DESCRIPTION
Added `lang` and `dir` properties to the summary endpoint response. The info is requested from the API.

We need to truncate the summary storage after deploying this to invalidate old content.

Bug: https://phabricator.wikimedia.org/T68114

cc @wikimedia/services 