### PR TITLE
Summary: Don't use revision etag to save the summary/definitions

### DIFF
--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -96,7 +96,6 @@ paths:
               # Define the response to save & return.
               headers:
                 content-type: application/json
-                etag: '"{{rev_info.body.rev}}/{{rev_info.body.tid}}"'
               body: '{{extract.body}}'
         - store_and_return:
             request:
@@ -108,7 +107,7 @@ paths:
               status: 200
               headers:
                 content-type: '{{extract.headers.content-type}}'
-                etag: '{{extract.headers.etag}}'
+                etag: '{{store_and_return.headers.etag}}'
                 cache-control: '{{options.response_cache-control}}'
               body: '{{extract.body}}'
 

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -102,7 +102,6 @@ paths:
               # Define the response to save & return.
               headers:
                 content-type: application/json
-                etag: '"{{rev_info.body.rev}}/{{rev_info.body.tid}}"'
               body:
                 title: '{{extract.body.items[0].title}}'
                 extract: '{{extract.body.items[0].extract}}'
@@ -124,7 +123,7 @@ paths:
               status: 200
               headers:
                 content-type: '{{extract.headers.content-type}}'
-                etag: '{{extract.headers.etag}}'
+                etag: '{{store_and_return.headers.etag}}'
                 cache-control: '{{options.response_cache-control}}'
               body: '{{extract.body}}'
 


### PR DESCRIPTION
Using the revision tag to store the summary/definition is wrong, because the content can't be updated as etags are actually the same for different renders.