### PR TITLE
force MediaWiki reads of revision metadata

### DIFF
--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -101,7 +101,8 @@ paths:
             request:
               uri: /{domain}/sys/page_revisions/page/{title}
               headers:
-                cache-control: '{cache-control}'
+                # FIXME: Temporary work-around (see T120212).
+                cache-control: 'no-cache'
                 if-unmodified-since: '{if-unmodified-since}'
       x-monitor: true
       x-amples:
@@ -777,7 +778,8 @@ paths:
             request:
               uri: /{domain}/sys/page_revisions/rev/{revision}
               headers:
-                cache-control: '{cache-control}'
+                # FIXME: Temporary work-around (see T120212).
+                cache-control: 'no-cache'
       x-monitor: true
       x-amples:
         - title: Get rev by ID


### PR DESCRIPTION
There is currently no way for RESTBase to know when a user has been deleted /
suppressed on a site-wide basis.  Since the `/page/revision/{revision}` endpoint
seems to be the only place that suppressable user information is returned, and
since this endpoint is low volume, this changeset proposes to (temporarily)
address this by explicitly setting the `Cache-Control: no-cache` header, (i.e.
always read revision metadata from MediaWiki).

Bug: https://phabricator.wikimedia.org/T120212