### PR TITLE
Definitions invalidation: Narrow down logging

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -354,7 +354,7 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
                     }
                 })
                 .catch(function(e) {
-                    if (e.status !== 501) {
+                    if (e.status !== 501 && e.status !== 404) {
                         self.log('error/' + rp.domain.indexOf('wiktionary') < 0 ?
                             'summary' : 'definition', e);
                     }

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -354,7 +354,10 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
                     }
                 })
                 .catch(function(e) {
-                    self.log('error/summary', e);
+                    if (e.status !== 501) {
+                        self.log('error/' + rp.domain.indexOf('wiktionary') < 0 ?
+                            'summary' : 'definition', e);
+                    }
                 }),
                 // End of temp code block
 


### PR DESCRIPTION
After we've enabled the definitions endpoint, we're receiving lots of error logs for unsupported languages. 
Ignore those errors as it's ok that an underlying service doesn't implement this functionality.

cc @wikimedia/services 