### PR TITLE
Disabled test

### DIFF
--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -345,7 +345,9 @@ describe('page content access', function() {
             assert.deepEqual(res.status, 403);
         });
     });
-    it('should correctly store updated restrictions', function() {
+
+    // FIXME: Test disabled until cached responses are once again used (see: T120212).
+    it.skip('should correctly store updated restrictions', function() {
         var pageTitle = 'User:Pchelolo%2frestriction_testing_mock';
         var pageRev = 301375;
         var normalRev = {


### PR DESCRIPTION
Since we are not caching revision metadata (a temporary work-around), it does
not make sense to test the caching of revision metadata.

Bug: https://phabricator.wikimedia.org/T120212