### PR TITLE
Mobileapps: Enable pre-generation

### DIFF
--- a/sys/mobileapps.yaml
+++ b/sys/mobileapps.yaml
@@ -8,13 +8,12 @@ paths:
             request:
               method: get
               uri: /{domain}/sys/page_revisions/page/{title}
-              headers:
-                cache-control: '{cache-control}'
         - cache_branch:
             request:
               method: post
               uri: /{domain}/sys/mobileapps/v1/handling/content/{route}/{$$.default($.request.headers.cache-control, 'none-given')}/{title}
               headers:
+                cache-control: '{cache-control}'
                 content-type: application/json
               body: '{$.get_rev.body}'
 
@@ -25,18 +24,16 @@ paths:
             request:
               method: get
               uri: '{+$$.options.host}/{domain}/v1/page/mobile-sections/{title}'
-              headers:
-                x-restbase-etag: '{$.request.body.items[0].rev}/{$.request.body.items[0].tid}'
         - store_lead:
             request:
               method: put
-              uri: /{domain}/sys/key_value/mobileapps.lead/{title}/{$.request.body.items[0].tid}
+              uri: /{domain}/sys/key_value/mobileapps.lead/{title}
               headers: '{$.get_mobileapps.headers}'
               body: '{$.get_mobileapps.body.lead}'
-        - store_remaining:
+          store_remaining:
             request:
               method: put
-              uri: /{domain}/sys/key_value/mobileapps.remaining/{title}/{$.request.body.items[0].tid}
+              uri: /{domain}/sys/key_value/mobileapps.remaining/{title}
               headers: '{$.get_mobileapps.headers}'
               body: '{$.get_mobileapps.body.remaining}'
         - return:
@@ -74,13 +71,17 @@ paths:
         - check_storage_lead:
             request:
               method: get
-              uri: /{domain}/sys/key_value/mobileapps.lead/{title}/{$.request.body.items[0].tid}
+              uri: /{domain}/sys/key_value/mobileapps.lead/{title}
+              headers:
+                cache-control: '{cache-control}'
             catch:
               status: 404
         - check_storage_remaining:
             request:
               method: get
-              uri: /{domain}/sys/key_value/mobileapps.remaining/{title}/{$.request.body.items[0].tid}
+              uri: /{domain}/sys/key_value/mobileapps.remaining/{title}
+              headers:
+                cache-control: '{cache-control}'
             catch:
               status: 404
             return_if:
@@ -103,7 +104,7 @@ paths:
         - check_storage:
             request:
               method: get
-              uri: /{domain}/sys/key_value/mobileapps.lead/{title}/{$.request.body.items[0].tid}
+              uri: /{domain}/sys/key_value/mobileapps.lead/{title}
             return_if:
               status: '2xx'
             catch:
@@ -124,7 +125,7 @@ paths:
         - check_storage:
             request:
               method: get
-              uri: /{domain}/sys/key_value/mobileapps.remaining/{title}/{$.request.body.items[0].tid}
+              uri: /{domain}/sys/key_value/mobileapps.remaining/{title}
             return_if:
               status: '2xx'
             catch:

--- a/sys/mobileapps.yaml
+++ b/sys/mobileapps.yaml
@@ -8,17 +8,16 @@ paths:
             request:
               method: get
               uri: /{domain}/sys/page_revisions/page/{title}
-        - cache_branch:
+          cache_branch:
             request:
-              method: post
+              method: get
               uri: /{domain}/sys/mobileapps/v1/handling/content/{route}/{$$.default($.request.headers.cache-control, 'none-given')}/{title}
               headers:
                 cache-control: '{cache-control}'
-                content-type: application/json
-              body: '{$.get_rev.body}'
+            return: '{$.cache_branch}'
 
   /v1/handling/content/mobile-sections/no-cache/{title}:
-    post:
+    get:
       x-request-handler:
         - get_mobileapps:
             request:
@@ -43,7 +42,7 @@ paths:
               body: '{$.get_mobileapps.body}'
 
   /v1/handling/content/mobile-sections/{cache-default}/{title}:
-    post:
+    get:
       x-setup-handler:
         - init-lead:
             method: put
@@ -72,16 +71,12 @@ paths:
             request:
               method: get
               uri: /{domain}/sys/key_value/mobileapps.lead/{title}
-              headers:
-                cache-control: '{cache-control}'
             catch:
               status: 404
         - check_storage_remaining:
             request:
               method: get
               uri: /{domain}/sys/key_value/mobileapps.remaining/{title}
-              headers:
-                cache-control: '{cache-control}'
             catch:
               status: 404
             return_if:
@@ -94,12 +89,11 @@ paths:
                 remaining: '{$.check_storage_remaining.body}'
         - render:
             request:
-              method: post
+              method: get
               uri: /{domain}/sys/mobileapps/v1/handling/content/mobile-sections/no-cache/{title}
-              body: '{$.request.body}'
 
   /v1/handling/content/mobile-sections-lead/{cache-default}/{title}:
-    post:
+    get:
       x-request-handler:
         - check_storage:
             request:
@@ -111,16 +105,15 @@ paths:
               status: 404
         - get_sections:
             request:
-              method: post
+              method: get
               uri: /{domain}/sys/mobileapps/v1/handling/content/mobile-sections/no-cache/{title}
-              body: '{$.request.body}'
             return:
               status: 200
               headers: '{$.get_sections.headers}'
               body: '{$.get_sections.body.lead}'
 
   /v1/handling/content/mobile-sections-remaining/{cache-default}/{title}:
-    post:
+    get:
       x-request-handler:
         - check_storage:
             request:
@@ -132,9 +125,8 @@ paths:
               status: 404
         - get_sections:
             request:
-              method: post
+              method: get
               uri: /{domain}/sys/mobileapps/v1/handling/content/mobile-sections/no-cache/{title}
-              body: '{$.request.body}'
             return:
               status: 200
               headers: '{$.get_sections.headers}'

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -359,6 +359,15 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
                             'summary' : 'definition', e);
                     }
                 }),
+                // MobileApps pre-generation
+                restbase.get({
+                    uri: new URI([rp.domain, 'v1', 'page', 'mobile-sections', rp.title]),
+                    headers: {
+                        'cache-control': 'no-cache'
+                    }
+                }).catch(function(e) {
+                    self.log('warn/mobileapps', e);
+                }),
                 // End of temp code block
 
                 function(parsoidSaveResult, summaryUpdateResult) {

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -361,10 +361,8 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
                 }),
                 // MobileApps pre-generation
                 restbase.get({
-                    uri: new URI([rp.domain, 'v1', 'page', 'mobile-sections', rp.title]),
-                    headers: {
-                        'cache-control': 'no-cache'
-                    }
+                    uri: new URI([rp.domain, 'sys', 'mobileapps', 'v1',
+                        'handling', 'content', 'mobile-sections', 'no-cache', rp.title])
                 }).catch(function(e) {
                     self.log('warn/mobileapps', e);
                 }),


### PR DESCRIPTION
This PR enables pre-generation for MobileApps public endpoints. Every time RESTBase detects a page's HTML has been changed, it will send a request to Parsoid and once the result is in storage, a request is sent to the Mobile Content Service to regenerate the page's content so that it can be served directly from storage to clients.

Bug: [T102130](https://phabricator.wikimedia.org/T102130)
Bug: [T121293](https://phabricator.wikimedia.org/T121293)