### PR TITLE
Support streaming responses

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -16,6 +16,7 @@ var fs = require('fs');
 var Router = require('./router');
 var URI = require('swagger-router').URI;
 var zlib = require('zlib');
+var stream = require('stream');
 
 function handleResponse(opts, req, resp, response) {
     if (response && response.status) {
@@ -106,8 +107,9 @@ function handleResponse(opts, req, resp, response) {
 
         if (response.body) {
             body = response.body;
-            // Convert to a buffer
-            if (!Buffer.isBuffer(body)) {
+            var bodyIsStream = body instanceof stream.Readable;
+            if (!Buffer.isBuffer(body) && !bodyIsStream) {
+                // Convert to a buffer
                 if (typeof body === 'object') {
                     if (!response.headers['content-type']) {
                         response.headers['content-type'] = 'application/json';
@@ -127,7 +129,14 @@ function handleResponse(opts, req, resp, response) {
                 resp.writeHead(response.status, '', response.headers);
                 var zStream = zlib.createGzip({ level: 3 });
                 zStream.pipe(resp);
-                zStream.end(body);
+                if (bodyIsStream) {
+                    body.pipe(zStream);
+                } else {
+                    zStream.end(body);
+                }
+            } else if (bodyIsStream) {
+                resp.writeHead(response.status, '', response.headers);
+                body.pipe(resp);
             } else {
                 response.headers['content-length'] = body.length;
                 resp.writeHead(response.status, '', response.headers);

--- a/test/framework/streaming/general.js
+++ b/test/framework/streaming/general.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var assert = require('../utils/assert.js');
+var Server = require('../utils/server.js');
+var preq = require('preq');
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+describe('Handler Template', function() {
+    var server = new Server('test/framework/streaming/test_config.yaml');
+    before(function() { return server.start(); });
+
+    it('Basic streaming', function () {
+        return preq.get({ uri: server.hostPort + '/test/hello' })
+        .then(function (res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-type'], 'text/html');
+            assert.deepEqual(res.body, 'hello');
+        });
+    });
+
+    it('Buffer streaming', function () {
+        return preq.get({ uri: server.hostPort + '/test/buffer' })
+        .then(function (res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-type'], 'text/html');
+            assert.deepEqual(res.body, 'hello');
+        });
+    });
+
+    it('Multi-chunk streaming', function () {
+        return preq.get({ uri: server.hostPort + '/test/chunks' })
+        .then(function (res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-type'], 'text/html');
+            if (!/^0123456.*99$/.test(res.body)) {
+                throw new Error('Expected the body to match /^0123456.*99$/');
+            }
+        });
+    });
+
+    after(function() { return server.stop(); });
+});

--- a/test/framework/streaming/general.js
+++ b/test/framework/streaming/general.js
@@ -29,6 +29,18 @@ describe('Handler Template', function() {
         });
     });
 
+    it('Buffer streaming, no compression', function () {
+        return preq.get({
+            uri: server.hostPort + '/test/buffer',
+            gzip: false
+        })
+        .then(function (res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-type'], 'text/html');
+            assert.deepEqual(res.body, 'hello');
+        });
+    });
+
     it('Multi-chunk streaming', function () {
         return preq.get({ uri: server.hostPort + '/test/chunks' })
         .then(function (res) {

--- a/test/framework/streaming/stream_module.js
+++ b/test/framework/streaming/stream_module.js
@@ -1,0 +1,71 @@
+'use strict';
+
+var stream = require('stream');
+
+function hello(restbase, req) {
+    var body = new stream.PassThrough();
+    body.end('hello');
+    return {
+        status: 200,
+        headers: {
+            'content-type': 'text/html',
+        },
+        body: body
+    };
+}
+
+function buffer(restbase, req) {
+    var body = new stream.PassThrough();
+    body.end(new Buffer('hello'));
+    return {
+        status: 200,
+        headers: {
+            'content-type': 'text/html',
+        },
+        body: body
+    };
+}
+
+function chunks(restbase, req) {
+    var body = new stream.PassThrough();
+    for (var i = 0; i < 100; i++) {
+        body.write(i.toString());
+    }
+    body.end();
+    return {
+        status: 200,
+        headers: {
+            'content-type': 'text/html',
+        },
+        body: body
+    };
+}
+
+module.exports = function(options) {
+    return {
+        spec: {
+            paths: {
+                '/hello': {
+                    get: {
+                        operationId: 'hello'
+                    }
+                },
+                '/buffer': {
+                    get: {
+                        operationId: 'buffer'
+                    }
+                },
+                '/chunks': {
+                    get: {
+                        operationId: 'chunks'
+                    }
+                }
+            }
+        },
+        operations: {
+            hello: hello,
+            buffer: buffer,
+            chunks: chunks,
+        }
+    };
+};

--- a/test/framework/streaming/stream_module.js
+++ b/test/framework/streaming/stream_module.js
@@ -16,7 +16,12 @@ function hello(restbase, req) {
 
 function buffer(restbase, req) {
     var body = new stream.PassThrough();
-    body.end(new Buffer('hello'));
+    body.write(new Buffer('hel'));
+    // Delay the final write to test async production.
+    setTimeout(function() {
+        body.end(new Buffer('lo'));
+    }, 500);
+
     return {
         status: 200,
         headers: {

--- a/test/framework/streaming/test_config.yaml
+++ b/test/framework/streaming/test_config.yaml
@@ -1,0 +1,21 @@
+spec_root: &spec_root
+  paths:
+    /test:
+      x-modules:
+        /:
+          - path: test/framework/streaming/stream_module.js
+
+# Finally, a standard service-runner config.
+info:
+  name: restbase
+
+services:
+  - name: test_service
+    module: ./lib/server
+    conf:
+      port: 12345
+      spec: *spec_root
+      salt: secret
+      default_page_size: 1
+      user_agent: RESTBase-testsuite
+


### PR DESCRIPTION
Use cases like chunked storage and proxied requests can be sped up by
streaming the response as it comes in.

This patch adds support for returning a `Readable` stream from handlers, and
is targeted at chunked storage buckets. In the longer term, we probably want
to switch to the richer
[ReadableStream](https://streams.spec.whatwg.org/#rs-model) abstraction, but
node implementations for that are still lacking, and this gets us started with
Node's native streams.

Task: https://phabricator.wikimedia.org/T124696