### PR TITLE
Graphoid: use graphoid-beta.wmflabs.org

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -23,7 +23,7 @@ default_project: &default_project
           action:
             apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
           graphoid:
-            host: http://graphoid.wikimedia.org
+            host: http://graphoid-beta.wmflabs.org
           mathoid:
             host: http://mathoid-tester.wmflabs.org
             # 10 days Varnish caching, one day client-side

--- a/v1/graphoid.yaml
+++ b/v1/graphoid.yaml
@@ -49,7 +49,7 @@ paths:
             request:
               uri: '{+ $$.options.host }/{domain}/v1/png/{title}/{revision}/{graph_id}'
 
-      x-monitor: true
+      x-monitor: false
       x-amples:
         - title: Get a graph from Graphoid
           request:


### PR DESCRIPTION
graphoid.wikimedia.org has been decommissioned, so switch to
graphoid-beta.wmflabs.org for testing.

Temporarily switch the monitoring point off, as the graphoid Labs
instance needs an update, which is blocked on havig Node 4.2 in Labs.