### PR TITLE
Graphoid: re-enable the Graphoid spec test

### DIFF
--- a/v1/graphoid.yaml
+++ b/v1/graphoid.yaml
@@ -49,7 +49,7 @@ paths:
             request:
               uri: '{+ $$.options.host }/{domain}/v1/png/{title}/{revision}/{graph_id}'
 
-      x-monitor: false
+      x-monitor: true
       x-amples:
         - title: Get a graph from Graphoid
           request:


### PR DESCRIPTION
`graphoid-beta.wmflabs.org` is now back and operational, so re-enable the x-ample from the Grapohid spec.