### PR TITLE
Set up prefixed metric trees

### DIFF
--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -33,12 +33,13 @@ function cloneRequest(req) {
     };
 }
 
-function RESTBase(options, req) {
+function RESTBase(options, req, parOptions) {
     if (options && options.constructor === RESTBase) {
         // Child instance
         var par = options;
-        this.log = par.log;
-        this.metrics = par.metrics;
+        parOptions = parOptions || {};
+        this.log = parOptions.log || par.log;
+        this.metrics = parOptions.metrics || par.metrics;
         this.reqId = par.reqId ||
             req && req.headers && req.headers['x-request-id'] ||
             utils.generateRequestId();
@@ -98,8 +99,8 @@ RESTBase.prototype.setRequestId = function(req) {
 };
 
 // Make a child instance
-RESTBase.prototype.makeChild = function(req) {
-    return new RESTBase(this, req);
+RESTBase.prototype.makeChild = function(req, options) {
+    return new RESTBase(this, req, options);
 };
 
 // A default listing handler for URIs that end in / and don't have any
@@ -247,11 +248,11 @@ RESTBase.prototype._checkInternalApiRequest = function(req) {
     }
 };
 
-RESTBase.prototype.request = function(req) {
+RESTBase.prototype.request = function(req, options) {
     if (req.method) {
         req.method = req.method.toLowerCase();
     }
-    return this._request(req);
+    return this._request(req, options);
 };
 
 RESTBase.prototype._wrapInMetrics = function(handlerPromise, match, req) {
@@ -317,7 +318,7 @@ RESTBase.prototype._wrapInAccessCheck = function(handlerPromise, match, childReq
 };
 
 // Process one request
-RESTBase.prototype._request = function(req) {
+RESTBase.prototype._request = function(req, options) {
     var self = this;
 
     // Special handling for https? requests
@@ -362,7 +363,7 @@ RESTBase.prototype._request = function(req) {
 
     if (handler) {
         // Prepare to call the handler with a child restbase instance
-        var childRESTBase = this.makeChild(childReq);
+        var childRESTBase = this.makeChild(childReq, options);
 
         // Call the handler with P.try to catch synchronous exceptions.
         var reqHandlerPromise;

--- a/lib/restbase.js
+++ b/lib/restbase.js
@@ -267,7 +267,11 @@ RESTBase.prototype._wrapInMetrics = function(handlerPromise, match, req) {
     return handlerPromise.then(function(res) {
         // Record request metrics & log
         var statusClass = Math.floor(res.status / 100) + 'xx';
-        self.metrics.endTiming([statName + statusClass, statName + 'ALL'], startTime);
+        self.metrics.endTiming([
+                statName + res.status,
+                statName + statusClass,
+                statName + 'ALL',
+        ], startTime);
         return res;
     },
     function(err) {
@@ -275,7 +279,11 @@ RESTBase.prototype._wrapInMetrics = function(handlerPromise, match, req) {
         if (err && err.status) {
             statusClass = Math.floor(err.status / 100) + 'xx';
         }
-        self.metrics.endTiming([statName + statusClass, statName + 'ALL'], startTime);
+        self.metrics.endTiming([
+                statName + err.status,
+                statName + statusClass,
+                statName + 'ALL',
+        ], startTime);
         throw err;
     });
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -350,7 +350,7 @@ function handleRequest(opts, req, resp) {
                 status: 200
             });
         } else {
-            return opts.restbase.request(newReq);
+            return opts.restbase.request(newReq, reqOpts);
         }
     })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -187,6 +187,11 @@ function handleResponse(opts, req, resp, response) {
             delete response.body;
         }
 
+        opts.metrics.endTiming([
+                'ALL.ALL',
+                req.method.toUpperCase() + '.' + response.status.toString()
+        ], opts.startTime);
+
         if (response.body) {
             body = response.body;
             var bodyIsStream = body instanceof stream.Readable;
@@ -286,15 +291,25 @@ function handleRequest(opts, req, resp) {
         }),
         log: null,
         reqId: req.headers['x-request-id'],
-        metrics: opts.metrics
+        metrics: opts.metrics,
+        startTime: Date.now()
     };
     reqOpts.log = reqOpts.logger.log.bind(reqOpts.logger);
 
-    // Simplistic count of requests from public & private networks
+    /**
+     * We use separate metric trees for requests from private networks, so
+     * that we can separately study performance for those different use cases.
+     * We implement this by passing a specialized prefixed metric producer to
+     * the handler. All derived metrics associated with a private / update
+     * request are thus recorded in .internal or .internal_update prefixed
+     * metric trees.
+     */
     if (/^(?:::ffff:)?(?:10|127)\./.test(remoteAddr)) {
-        reqOpts.metrics.increment('requests.private');
-    } else {
-        reqOpts.metrics.increment('requests.public');
+        if (req.headers['cache-control'] && /no-cache/i.test(req.headers['cache-control'])) {
+            reqOpts.metrics = opts.child_metrics.internal_update;
+        } else {
+            reqOpts.metrics = opts.child_metrics.internal;
+        }
     }
 
     // Create a new, clean request object
@@ -383,7 +398,11 @@ function main(options) {
         conf: conf,
         logger: options.logger,
         log: options.logger.log.bind(options.logger),
-        metrics: options.metrics
+        metrics: options.metrics,
+        child_metrics: {
+            internal: options.metrics.makeChild('private'),
+            internal_update: options.metrics.makeChild('internal_update'),
+        }
     };
 
     opts.router = new Router(opts);

--- a/lib/server.js
+++ b/lib/server.js
@@ -137,7 +137,7 @@ function handleResponse(opts, req, resp, response) {
         }
         opts.log(logLevel, {
             message: response.message,
-            req: req,
+            root_req: req,
             res: response,
             stack: response.stack
         });
@@ -232,7 +232,7 @@ function handleResponse(opts, req, resp, response) {
         } else {
             if (response.headers['content-length']) {
                 opts.log('warn/response/content-length', {
-                    req: req,
+                    root_req: req,
                     res: response,
                     reason: new Error('Invalid content-length')
                 });
@@ -243,7 +243,7 @@ function handleResponse(opts, req, resp, response) {
         }
     } else {
         opts.log('error/request', {
-            req: req,
+            root_req: req,
             msg: "No content returned"
         });
 
@@ -274,7 +274,7 @@ function handleRequest(opts, req, resp) {
     var reqOpts = {
         conf: opts.conf,
         logger: opts.logger.child({
-            req: {
+            root_req: {
                 method: req.method.toLowerCase(),
                 uri: req.url,
                 headers: {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cassandra-uuid": "^0.0.2",
     "preq": "^0.4.8",
     "restbase-mod-table-cassandra": "^0.8.15",
-    "service-runner": "^0.3.8",
+    "service-runner": "^1.0.0",
     "swagger-router": "^0.3.4",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",


### PR DESCRIPTION
We currently mix metrics for internal and external requests with update
requests. As the performance characteristics of especially update requests
differ significantly, this makes it hard to establish actual performance for
the most important use cases.

This patch uses new child metric producer support in service-runner 1.0 to
separate metrics of primary and derived requests into three trees:

1) external requests,
2) internal update requests, and finally
3) internal service requests.

This is done by setting up two prefixed child metric producers, and passing
those to the handler to use for all metrics reporting when internal / update
requests are identified.