### PR TITLE
Post storage: removed dead code and unused methods

### DIFF
--- a/sys/post_data.js
+++ b/sys/post_data.js
@@ -16,13 +16,6 @@ function PostDataBucket(options) {
     this.log = options.log || function() {};
 }
 
-PostDataBucket.prototype.getBucketInfo = function(restbase, req) {
-    var rp = req.params;
-    return restbase.get({
-        uri: new URI([rp.domain, 'sys', 'key_value', rp.bucket]),
-    });
-};
-
 PostDataBucket.prototype.createBucket = function(restbase, req) {
     var rp = req.params;
     return restbase.put({
@@ -31,13 +24,6 @@ PostDataBucket.prototype.createBucket = function(restbase, req) {
             keyType: 'string',
             valueType: 'json'
         }
-    });
-};
-
-PostDataBucket.prototype.listBucket = function(restbase, req) {
-    var rp = req.params;
-    return restbase.get({
-        uri: new URI([rp.domain, 'sys', 'key_value', rp.bucket, ''])
     });
 };
 
@@ -103,9 +89,7 @@ module.exports = function(options) {
     return {
         spec: spec, // Re-export from spec module
         operations: {
-            getBucketInfo: postDataBucket.getBucketInfo.bind(postDataBucket),
             createBucket: postDataBucket.createBucket.bind(postDataBucket),
-            listBucket: postDataBucket.listBucket.bind(postDataBucket),
             getRevision: postDataBucket.getRevision.bind(postDataBucket),
             putRevision: postDataBucket.putRevision.bind(postDataBucket)
         }

--- a/sys/post_data.yaml
+++ b/sys/post_data.yaml
@@ -5,14 +5,10 @@ info:
   description: Revisioned post data storage with HTTP interface, backed by table storage
 paths:
   /{bucket}:
-    get:
-      operationId: getBucketInfo
     put:
       operationId: createBucket
 
   /{bucket}/:
-    get:
-      operationId: listBucket
     put:
       operationId: putRevision
 

--- a/test/features/post_data.js
+++ b/test/features/post_data.js
@@ -36,6 +36,15 @@ describe('post_data', function () {
         });
     });
 
+    it('should not explode on empty body', function() {
+        return preq.post({
+            uri: server.config.baseURL + '/post_data/'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 201);
+        });
+    });
+
     it('should not store identical request', function() {
         return preq.post({
             uri: server.config.baseURL + '/post_data/',


### PR DESCRIPTION
Trivial: removing dead code we don't use and which would not work anyway, because hash key listings are broken in cassandra storage, and we have no intention to fix it.