### PR TITLE
Renamed RESTBase to HyperSwitch everywhere

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -23,11 +23,11 @@ function constructInternalRequestRegex(reqWhiteList) {
 }
 
 /**
- * Copies forwarded headers from Hyperswitch to request.
+ * Copies forwarded headers from HyperSwitch to request.
  * If the same header was already set it takes precedence over
  * the forwarded header.
  *
- * @param hyper a Hyperswitch instance to take the forwarded headers from
+ * @param hyper a HyperSwitch instance to take the forwarded headers from
  * @param req a request where to copy the headers
  * @param headers array of header names to copy
  */
@@ -135,7 +135,7 @@ var securityDefinitionCreators = {
             },
             checkPermissions: function(hyper, req, permissions) {
                 if (hyper._rootReq.uri === '#internal-startup') {
-                    // Skip a check on requests made by Hyperswitch during startup
+                    // Skip a check on requests made by HyperSwitch during startup
                     return;
                 }
 
@@ -241,7 +241,7 @@ AuthService.prototype.addRequirements = function(requirements) {
  * In case some of the permissions are absent - throws 401 Unauthorized.
  * In case failed to get permisisons for MW API throws 400 Bad Request.
  *
- * @param hyper Hyperswitch instance to use
+ * @param hyper HyperSwitch instance to use
  * @param req original request
  */
 AuthService.prototype.checkPermissions = function(hyper, req) {
@@ -260,7 +260,7 @@ AuthService.prototype.checkPermissions = function(hyper, req) {
  * For example, for mediawiki_auth type is forwards cookies to internal
  * services.
  *
- * @param hyper current Hyperswitch instance
+ * @param hyper current HyperSwitch instance
  * @param req request that would be modified
  */
 AuthService.prototype.prepareRequest = function(hyper, req) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -27,16 +27,16 @@ function constructInternalRequestRegex(reqWhiteList) {
  * If the same header was already set it takes precedence over
  * the forwarded header.
  *
- * @param hs a Hyperswitch instance to take the forwarded headers from
+ * @param hyper a Hyperswitch instance to take the forwarded headers from
  * @param req a request where to copy the headers
  * @param headers array of header names to copy
  */
-function copyForwardedHeaders(hs, req, headers) {
-    if (hs._rootReq && hs._forwardedHeaders) {
+function copyForwardedHeaders(hyper, req, headers) {
+    if (hyper._rootReq && hyper._forwardedHeaders) {
         req.headers = req.headers || {};
         headers.forEach(function(header) {
-            if (!req.headers[header] && hs._forwardedHeaders[header]) {
-                req.headers[header] = hs._forwardedHeaders[header];
+            if (!req.headers[header] && hyper._forwardedHeaders[header]) {
+                req.headers[header] = hyper._forwardedHeaders[header];
             }
         });
     }
@@ -47,9 +47,9 @@ function copyForwardedHeaders(hs, req, headers) {
  * A collection of known security requirement object checker factories.
  * Returns a checker object, identified by the security requirement name,
  * and containing 2 functions: prepareRequest and checkPermissions
- * - prepareRequest(hs, req) - preforms modifications on the request,
+ * - prepareRequest(hyper, req) - preforms modifications on the request,
  *                                   needed by the security scheme
- * - checkPermissions(hs, req, permissions) - checks that all permissions are present.
+ * - checkPermissions(hyper, req, permissions) - checks that all permissions are present.
  */
 var securityDefinitionCreators = {
     mediawiki_auth: function(definition) {
@@ -64,13 +64,13 @@ var securityDefinitionCreators = {
         }
 
         return {
-            prepareRequest: function(hs, req) {
+            prepareRequest: function(hyper, req) {
                 if (isInternalRequest(req)) {
-                    copyForwardedHeaders(hs, req,
+                    copyForwardedHeaders(hyper, req,
                         ['cookie', 'x-forwarded-for', 'x-client-ip']);
                 }
             },
-            checkPermissions: function(hs, req, permDefinitions) {
+            checkPermissions: function(hyper, req, permDefinitions) {
                 // First filter permissions applicable to the current method
                 var permissions = [];
                 permDefinitions.forEach(function(perm) {
@@ -92,7 +92,7 @@ var securityDefinitionCreators = {
                         uiprop: 'rights'
                     }
                 };
-                return hs.post(checkReq)
+                return hyper.post(checkReq)
                 .then(function(userInfo) {
                     userInfo = userInfo.body;
                     if (userInfo && userInfo.rights && Array.isArray(userInfo.rights)) {
@@ -133,8 +133,8 @@ var securityDefinitionCreators = {
         return {
             prepareRequest: function() {
             },
-            checkPermissions: function(hs, req, permissions) {
-                if (hs._rootReq.uri === '#internal-startup') {
+            checkPermissions: function(hyper, req, permissions) {
+                if (hyper._rootReq.uri === '#internal-startup') {
                     // Skip a check on requests made by Hyperswitch during startup
                     return;
                 }
@@ -149,7 +149,7 @@ var securityDefinitionCreators = {
                     var headerMatchRequirement = requirementDefinition.value;
                     var headerName = headerMatchRequirement.header;
                     var headerValue = req.headers && req.headers[headerName]
-                            || hs._rootReq.headers && hs._rootReq.headers[headerName];
+                            || hyper._rootReq.headers && hyper._rootReq.headers[headerName];
 
                     headerMatchRequirement.patterns.forEach(function(patternName) {
                         if (!whitelistMap[patternName]) {
@@ -241,17 +241,17 @@ AuthService.prototype.addRequirements = function(requirements) {
  * In case some of the permissions are absent - throws 401 Unauthorized.
  * In case failed to get permisisons for MW API throws 400 Bad Request.
  *
- * @param hs Hyperswitch instance to use
+ * @param hyper Hyperswitch instance to use
  * @param req original request
  */
-AuthService.prototype.checkPermissions = function(hs, req) {
+AuthService.prototype.checkPermissions = function(hyper, req) {
     var self = this;
     return P.all(Object.keys(self.securityRequirements).map(function(requirementName) {
         var checker = self.securityDefinitions[requirementName];
         if (!checker) {
             throw new Error('Unknown security requirement name: ' + requirementName);
         }
-        return checker.checkPermissions(hs, req, self.securityRequirements[requirementName]);
+        return checker.checkPermissions(hyper, req, self.securityRequirements[requirementName]);
     }));
 };
 
@@ -260,17 +260,17 @@ AuthService.prototype.checkPermissions = function(hs, req) {
  * For example, for mediawiki_auth type is forwards cookies to internal
  * services.
  *
- * @param hs current Hyperswitch instance
+ * @param hyper current Hyperswitch instance
  * @param req request that would be modified
  */
-AuthService.prototype.prepareRequest = function(hs, req) {
+AuthService.prototype.prepareRequest = function(hyper, req) {
     var self = this;
     Object.keys(self.securityRequirements).map(function(requirementName) {
         var checker = self.securityDefinitions[requirementName];
         if (!checker) {
             throw new Error('Unknown security requirement name: ' + requirementName);
         }
-        checker.prepareRequest(hs, req);
+        checker.prepareRequest(hyper, req);
     });
 };
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -23,20 +23,20 @@ function constructInternalRequestRegex(reqWhiteList) {
 }
 
 /**
- * Copies forwarded headers from restbase to request.
+ * Copies forwarded headers from Hyperswitch to request.
  * If the same header was already set it takes precedence over
  * the forwarded header.
  *
- * @param restbase a restbase instance to take the forwarded headers from
+ * @param hs a Hyperswitch instance to take the forwarded headers from
  * @param req a request where to copy the headers
  * @param headers array of header names to copy
  */
-function copyForwardedHeaders(restbase, req, headers) {
-    if (restbase._rootReq && restbase._forwardedHeaders) {
+function copyForwardedHeaders(hs, req, headers) {
+    if (hs._rootReq && hs._forwardedHeaders) {
         req.headers = req.headers || {};
         headers.forEach(function(header) {
-            if (!req.headers[header] && restbase._forwardedHeaders[header]) {
-                req.headers[header] = restbase._forwardedHeaders[header];
+            if (!req.headers[header] && hs._forwardedHeaders[header]) {
+                req.headers[header] = hs._forwardedHeaders[header];
             }
         });
     }
@@ -47,9 +47,9 @@ function copyForwardedHeaders(restbase, req, headers) {
  * A collection of known security requirement object checker factories.
  * Returns a checker object, identified by the security requirement name,
  * and containing 2 functions: prepareRequest and checkPermissions
- * - prepareRequest(restbase, req) - preforms modifications on the request,
+ * - prepareRequest(hs, req) - preforms modifications on the request,
  *                                   needed by the security scheme
- * - checkPermissions(restbase, req, permissions) - checks that all permissions are present.
+ * - checkPermissions(hs, req, permissions) - checks that all permissions are present.
  */
 var securityDefinitionCreators = {
     mediawiki_auth: function(definition) {
@@ -64,13 +64,13 @@ var securityDefinitionCreators = {
         }
 
         return {
-            prepareRequest: function(restbase, req) {
+            prepareRequest: function(hs, req) {
                 if (isInternalRequest(req)) {
-                    copyForwardedHeaders(restbase, req,
+                    copyForwardedHeaders(hs, req,
                         ['cookie', 'x-forwarded-for', 'x-client-ip']);
                 }
             },
-            checkPermissions: function(restbase, req, permDefinitions) {
+            checkPermissions: function(hs, req, permDefinitions) {
                 // First filter permissions applicable to the current method
                 var permissions = [];
                 permDefinitions.forEach(function(perm) {
@@ -92,7 +92,7 @@ var securityDefinitionCreators = {
                         uiprop: 'rights'
                     }
                 };
-                return restbase.post(checkReq)
+                return hs.post(checkReq)
                 .then(function(userInfo) {
                     userInfo = userInfo.body;
                     if (userInfo && userInfo.rights && Array.isArray(userInfo.rights)) {
@@ -133,9 +133,9 @@ var securityDefinitionCreators = {
         return {
             prepareRequest: function() {
             },
-            checkPermissions: function(restbase, req, permissions) {
-                if (restbase._rootReq.uri === '#internal-startup') {
-                    // Skip a check on requests made by RESTBase during startup
+            checkPermissions: function(hs, req, permissions) {
+                if (hs._rootReq.uri === '#internal-startup') {
+                    // Skip a check on requests made by Hyperswitch during startup
                     return;
                 }
 
@@ -149,7 +149,7 @@ var securityDefinitionCreators = {
                     var headerMatchRequirement = requirementDefinition.value;
                     var headerName = headerMatchRequirement.header;
                     var headerValue = req.headers && req.headers[headerName]
-                            || restbase._rootReq.headers && restbase._rootReq.headers[headerName];
+                            || hs._rootReq.headers && hs._rootReq.headers[headerName];
 
                     headerMatchRequirement.patterns.forEach(function(patternName) {
                         if (!whitelistMap[patternName]) {
@@ -241,17 +241,17 @@ AuthService.prototype.addRequirements = function(requirements) {
  * In case some of the permissions are absent - throws 401 Unauthorized.
  * In case failed to get permisisons for MW API throws 400 Bad Request.
  *
- * @param restbase restbase instance to use
+ * @param hs Hyperswitch instance to use
  * @param req original request
  */
-AuthService.prototype.checkPermissions = function(restbase, req) {
+AuthService.prototype.checkPermissions = function(hs, req) {
     var self = this;
     return P.all(Object.keys(self.securityRequirements).map(function(requirementName) {
         var checker = self.securityDefinitions[requirementName];
         if (!checker) {
             throw new Error('Unknown security requirement name: ' + requirementName);
         }
-        return checker.checkPermissions(restbase, req, self.securityRequirements[requirementName]);
+        return checker.checkPermissions(hs, req, self.securityRequirements[requirementName]);
     }));
 };
 
@@ -260,17 +260,17 @@ AuthService.prototype.checkPermissions = function(restbase, req) {
  * For example, for mediawiki_auth type is forwards cookies to internal
  * services.
  *
- * @param restbase current restbase instance
+ * @param hs current Hyperswitch instance
  * @param req request that would be modified
  */
-AuthService.prototype.prepareRequest = function(restbase, req) {
+AuthService.prototype.prepareRequest = function(hs, req) {
     var self = this;
     Object.keys(self.securityRequirements).map(function(requirementName) {
         var checker = self.securityDefinitions[requirementName];
         if (!checker) {
             throw new Error('Unknown security requirement name: ' + requirementName);
         }
-        checker.prepareRequest(restbase, req);
+        checker.prepareRequest(hs, req);
     });
 };
 

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -196,7 +196,7 @@ function makeRequestHandler(info, options) {
                     req.method = ctx.model.request.method
                         || options.defaultMethod || 'get';
                 }
-                return ctx.hs.request(req)
+                return ctx.hyper.request(req)
                 .then(function(res) {
                     ctx.model[info.name] = res;
                     ctx._doReturn = ctx._doReturn || shouldReturn(res);
@@ -220,7 +220,7 @@ function makeRequestHandler(info, options) {
                 }
                 // Set up the return no matter what.
                 ctx._doReturn = info.name;
-                return ctx.hs.request(req)
+                return ctx.hyper.request(req)
                 .then(function(res) {
                     ctx.model[info.name] = res;
                     ctx._doReturn = info.name;
@@ -234,7 +234,7 @@ function makeRequestHandler(info, options) {
                     req.method = ctx.model.request.method
                         || options.defaultMethod || 'get';
                 }
-                return ctx.hs.request(req)
+                return ctx.hyper.request(req)
                 .then(function(res) {
                     ctx.model[info.name] = res;
                     ctx._doReturn = ctx._doReturn || shouldReturn(res);
@@ -438,9 +438,9 @@ function createHandler(spec, options) {
         return makeStep(stepSpec, options);
     });
 
-    return function(hs, req) {
+    return function(hyper, req) {
         var ctx = {
-            hs: hs,
+            hyper: hyper,
             // The root model exposed to templates.
             model: {
                 request: req,

--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -196,7 +196,7 @@ function makeRequestHandler(info, options) {
                     req.method = ctx.model.request.method
                         || options.defaultMethod || 'get';
                 }
-                return ctx.restbase.request(req)
+                return ctx.hs.request(req)
                 .then(function(res) {
                     ctx.model[info.name] = res;
                     ctx._doReturn = ctx._doReturn || shouldReturn(res);
@@ -220,7 +220,7 @@ function makeRequestHandler(info, options) {
                 }
                 // Set up the return no matter what.
                 ctx._doReturn = info.name;
-                return ctx.restbase.request(req)
+                return ctx.hs.request(req)
                 .then(function(res) {
                     ctx.model[info.name] = res;
                     ctx._doReturn = info.name;
@@ -234,7 +234,7 @@ function makeRequestHandler(info, options) {
                     req.method = ctx.model.request.method
                         || options.defaultMethod || 'get';
                 }
-                return ctx.restbase.request(req)
+                return ctx.hs.request(req)
                 .then(function(res) {
                     ctx.model[info.name] = res;
                     ctx._doReturn = ctx._doReturn || shouldReturn(res);
@@ -438,9 +438,9 @@ function createHandler(spec, options) {
         return makeStep(stepSpec, options);
     });
 
-    return function(restbase, req) {
+    return function(hs, req) {
         var ctx = {
-            restbase: restbase,
+            hs: hs,
             // The root model exposed to templates.
             model: {
                 request: req,

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * RESTBase request dispatcher and general shared per-request state namespace
+ * HyperSwitch request dispatcher and general shared per-request state namespace
  */
 
 var jwt = require('jsonwebtoken');
@@ -33,8 +33,8 @@ function cloneRequest(req) {
     };
 }
 
-function RESTBase(options, req, parOptions) {
-    if (options && options.constructor === RESTBase) {
+function HyperSwitch(options, req, parOptions) {
+    if (options && options.constructor === HyperSwitch) {
         // Child instance
         var par = options;
         parOptions = parOptions || {};
@@ -50,7 +50,7 @@ function RESTBase(options, req, parOptions) {
         this._req = req;
         this._recursionDepth = par._recursionDepth + 1;
         this._priv = par._priv;
-        this.rb_config = this._priv.options.conf;
+        this.config = this._priv.options.conf;
         this._rootReq = par._rootReq || req;
         this._forwardedHeaders = par._forwardedHeaders || this._rootReq.headers;
         this._authService = par._authService ? new AuthService(par._authService) : null;
@@ -68,7 +68,7 @@ function RESTBase(options, req, parOptions) {
         options.maxDepth = options.maxDepth || 10;
 
         if (!options.conf.salt || typeof options.conf.salt !== 'string') {
-            throw new Error("Missing or invalid `salt` option in RESTBase config. "
+            throw new Error("Missing or invalid `salt` option in HyperSwitch config. "
                     + "Expected a string.");
         }
 
@@ -78,8 +78,8 @@ function RESTBase(options, req, parOptions) {
             router: options.router
         };
 
-        this.rb_config = options.conf;
-        this.rb_config.user_agent = this.rb_config.user_agent || 'RESTBase';
+        this.config = options.conf;
+        this.config.user_agent = this.config.user_agent || 'HyperSwitch';
         this._rootReq = null;
         this._forwardedHeaders = null;
         this._authService = null;
@@ -88,7 +88,7 @@ function RESTBase(options, req, parOptions) {
 
 // Sets the request id for this instance and adds it to
 // the request header, if defined
-RESTBase.prototype.setRequestId = function(req) {
+HyperSwitch.prototype.setRequestId = function(req) {
 
     req.headers = req.headers || {};
     if (req.headers['x-request-id']) {
@@ -99,13 +99,13 @@ RESTBase.prototype.setRequestId = function(req) {
 };
 
 // Make a child instance
-RESTBase.prototype.makeChild = function(req, options) {
-    return new RESTBase(this, req, options);
+HyperSwitch.prototype.makeChild = function(req, options) {
+    return new HyperSwitch(this, req, options);
 };
 
 // A default listing handler for URIs that end in / and don't have any
 // handlers associated with it otherwise.
-RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
+HyperSwitch.prototype.defaultListingHandler = function(value, hs, req) {
     var rq = req.query;
     if (rq.spec !== undefined && value.specRoot) {
         var spec = Object.assign({}, value.specRoot, {
@@ -127,7 +127,7 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
         if (!req.query.path) {
             req.query.path = '/index.html';
         }
-        return swaggerUI(restbase, req);
+        return swaggerUI(hs, req);
     } else if (/\btext\/html\b/.test(req.headers.accept)
             && req.uri.path.length <= 2) {
         // Browser request and above api level
@@ -158,7 +158,7 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
             + "omit the <code>Accept</code> header, or send one that does not contain "
             + "<code>text/html</code>.</p></div>";
 
-        return swaggerUI(restbase, req)
+        return swaggerUI(hs, req)
         .then(function(res) {
             res.body = res.body
                 .replace(/window\.swaggerUi\.load/, '')
@@ -177,10 +177,10 @@ RESTBase.prototype.defaultListingHandler = function(value, restbase, req) {
 };
 
 // Special handling for external web requests
-RESTBase.prototype.defaultWebRequestHandler = function(req) {
+HyperSwitch.prototype.defaultWebRequestHandler = function(req) {
     // Enforce the usage of UA
     req.headers = req.headers || {};
-    req.headers['user-agent'] = req.headers['user-agent'] || this.rb_config.user_agent;
+    req.headers['user-agent'] = req.headers['user-agent'] || this.config.user_agent;
     if (this._authService) {
         this._authService.prepareRequest(this, req);
     }
@@ -195,7 +195,7 @@ RESTBase.prototype.defaultWebRequestHandler = function(req) {
     return P.resolve(preq(req));
 };
 
-RESTBase.prototype._isSysRequest = function(req) {
+HyperSwitch.prototype._isSysRequest = function(req) {
     return ((req.uri.params && req.uri.params.api === 'sys')
         // TODO: Remove once params.api is reliable
             || (req.uri.path && req.uri.path.length > 1 && req.uri.path[1] === 'sys'));
@@ -208,7 +208,7 @@ RESTBase.prototype._isSysRequest = function(req) {
  * @param {Object} req - a current request object
  * @private
  */
-RESTBase.prototype._checkMaxRecursionDepth = function(req) {
+HyperSwitch.prototype._checkMaxRecursionDepth = function(req) {
     if (this._recursionDepth > this._priv.options.maxDepth) {
         var parents = [];
         var rb = this._parent;
@@ -220,7 +220,7 @@ RESTBase.prototype._checkMaxRecursionDepth = function(req) {
             status: 500,
             body: {
                 type: 'request_recursion_depth_exceeded',
-                title: 'RESTBase request recursion depth exceeded.',
+                title: 'HyperSwitch request recursion depth exceeded.',
                 uri: req.uri,
                 method: req.method,
                 parents: parents,
@@ -236,7 +236,7 @@ RESTBase.prototype._checkMaxRecursionDepth = function(req) {
  * @param {Object} req - an original request
  * @private
  */
-RESTBase.prototype._checkInternalApiRequest = function(req) {
+HyperSwitch.prototype._checkInternalApiRequest = function(req) {
     if (this._recursionDepth === 0 && this._isSysRequest(req)) {
         throw new HTTPError({
             status: 403,
@@ -248,14 +248,14 @@ RESTBase.prototype._checkInternalApiRequest = function(req) {
     }
 };
 
-RESTBase.prototype.request = function(req, options) {
+HyperSwitch.prototype.request = function(req, options) {
     if (req.method) {
         req.method = req.method.toLowerCase();
     }
     return this._request(req, options);
 };
 
-RESTBase.prototype._wrapInMetrics = function(handlerPromise, match, req) {
+HyperSwitch.prototype._wrapInMetrics = function(handlerPromise, match, req) {
     var self = this;
     // Remove the /{domain}/ prefix, as it's not very useful in stats
     var statName = match.value.path.replace(/\/[^\/]+\//, '')
@@ -289,11 +289,11 @@ RESTBase.prototype._wrapInMetrics = function(handlerPromise, match, req) {
     });
 };
 
-RESTBase.prototype._wrapInAccessCheck = function(handlerPromise, match, childReq) {
+HyperSwitch.prototype._wrapInAccessCheck = function(handlerPromise, match, childReq) {
     var self = this;
     // Don't need to check access restrictions on /sys requests,
     // as these endpoints are internal, so can be accessed only
-    // within RESTBase. (See RESTBase.prototype.request) All required
+    // within HyperSwitch. (See HyperSwitch.prototype.request) All required
     // checks should be added and made at the root of the request chain,
     // at /v1 level
     if (!this._isSysRequest(childReq)
@@ -318,7 +318,7 @@ RESTBase.prototype._wrapInAccessCheck = function(handlerPromise, match, childReq
 };
 
 // Process one request
-RESTBase.prototype._request = function(req, options) {
+HyperSwitch.prototype._request = function(req, options) {
     var self = this;
 
     // Special handling for https? requests
@@ -351,8 +351,8 @@ RESTBase.prototype._request = function(req, options) {
         // A GET for an URL that ends with /: return a default listing
         if (!match.value) { match.value = {}; }
         if (!match.value.path) { match.value.path = '_defaultListingHandler'; }
-        handler = function(restbase, req) {
-            return self.defaultListingHandler(match.value, restbase, req);
+        handler = function(hs, req) {
+            return self.defaultListingHandler(match.value, hs, req);
         };
     }
 
@@ -362,8 +362,8 @@ RESTBase.prototype._request = function(req, options) {
     }
 
     if (handler) {
-        // Prepare to call the handler with a child restbase instance
-        var childRESTBase = this.makeChild(childReq, options);
+        // Prepare to call the handler with a child hyperswitch instance
+        var childHS = this.makeChild(childReq, options);
 
         // Call the handler with P.try to catch synchronous exceptions.
         var reqHandlerPromise;
@@ -372,10 +372,10 @@ RESTBase.prototype._request = function(req, options) {
                 return handler.validator.validate(childReq);
             })
             .then(function() {
-                return handler(childRESTBase, childReq);
+                return handler(childHS, childReq);
             });
         } else {
-            reqHandlerPromise = P.try(handler, [childRESTBase, childReq]);
+            reqHandlerPromise = P.try(handler, [childHS, childReq]);
         }
 
         reqHandlerPromise = self._wrapInMetrics(reqHandlerPromise, match, req)
@@ -383,7 +383,7 @@ RESTBase.prototype._request = function(req, options) {
             self.log('trace', {
                 req: req,
                 res: res,
-                request_id: childRESTBase.reqId
+                request_id: childHS.reqId
             });
 
             if (!res) {
@@ -406,7 +406,7 @@ RESTBase.prototype._request = function(req, options) {
             }
         });
 
-        return childRESTBase._wrapInAccessCheck(reqHandlerPromise, match, childReq);
+        return childHS._wrapInAccessCheck(reqHandlerPromise, match, childReq);
     } else {
         // No handler found.
         throw new HTTPError({
@@ -452,25 +452,25 @@ function makeRequest(uri, reqOrBody, method) {
 var methods = ['get', 'post', 'put', 'delete', 'head', 'options',
     'trace', 'connect', 'copy', 'move', 'purge', 'search'];
 methods.forEach(function(method) {
-    RESTBase.prototype[method] = function(uri, req) {
+    HyperSwitch.prototype[method] = function(uri, req) {
         return this._request(makeRequest(uri, req, method));
     };
 });
 
 
-// Utility methods that need access to restbase state.
+// Utility methods that need access to hyperswitch state.
 
 // Create a json web token
 // @param {string} token
 // @return {string} JWT signed token
-RESTBase.prototype.encodeToken = function(token) {
+HyperSwitch.prototype.encodeToken = function(token) {
     return jwt.sign({ next: token }, this._priv.options.conf.salt);
 };
 
 // Decode signed token and decode the orignal token
 // @param {string} JWT token
 // @return {string} original token
-RESTBase.prototype.decodeToken = function(token) {
+HyperSwitch.prototype.decodeToken = function(token) {
     try {
         var next = jwt.verify(token, this._priv.options.conf.salt);
         return next.next;
@@ -485,4 +485,4 @@ RESTBase.prototype.decodeToken = function(token) {
     }
 };
 
-module.exports = RESTBase;
+module.exports = HyperSwitch;

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -363,7 +363,7 @@ HyperSwitch.prototype._request = function(req, options) {
 
     if (handler) {
         // Prepare to call the handler with a child HyperSwitch instance
-        var childHyper = this.makeChild(childReq, options);
+        var childHyperSwitch = this.makeChild(childReq, options);
 
         // Call the handler with P.try to catch synchronous exceptions.
         var reqHandlerPromise;
@@ -372,10 +372,10 @@ HyperSwitch.prototype._request = function(req, options) {
                 return handler.validator.validate(childReq);
             })
             .then(function() {
-                return handler(childHyper, childReq);
+                return handler(childHyperSwitch, childReq);
             });
         } else {
-            reqHandlerPromise = P.try(handler, [childHyper, childReq]);
+            reqHandlerPromise = P.try(handler, [childHyperSwitch, childReq]);
         }
 
         reqHandlerPromise = self._wrapInMetrics(reqHandlerPromise, match, req)
@@ -383,7 +383,7 @@ HyperSwitch.prototype._request = function(req, options) {
             self.log('trace', {
                 req: req,
                 res: res,
-                request_id: childHyper.reqId
+                request_id: childHyperSwitch.reqId
             });
 
             if (!res) {
@@ -406,7 +406,7 @@ HyperSwitch.prototype._request = function(req, options) {
             }
         });
 
-        return childHyper._wrapInAccessCheck(reqHandlerPromise, match, childReq);
+        return childHyperSwitch._wrapInAccessCheck(reqHandlerPromise, match, childReq);
     } else {
         // No handler found.
         throw new HTTPError({

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -362,7 +362,7 @@ HyperSwitch.prototype._request = function(req, options) {
     }
 
     if (handler) {
-        // Prepare to call the handler with a child hyperswitch instance
+        // Prepare to call the handler with a child HyperSwitch instance
         var childHyper = this.makeChild(childReq, options);
 
         // Call the handler with P.try to catch synchronous exceptions.
@@ -458,7 +458,7 @@ methods.forEach(function(method) {
 });
 
 
-// Utility methods that need access to hyperswitch state.
+// Utility methods that need access to HyperSwitch state.
 
 // Create a json web token
 // @param {string} token

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -105,7 +105,7 @@ HyperSwitch.prototype.makeChild = function(req, options) {
 
 // A default listing handler for URIs that end in / and don't have any
 // handlers associated with it otherwise.
-HyperSwitch.prototype.defaultListingHandler = function(value, hs, req) {
+HyperSwitch.prototype.defaultListingHandler = function(value, hyper, req) {
     var rq = req.query;
     if (rq.spec !== undefined && value.specRoot) {
         var spec = Object.assign({}, value.specRoot, {
@@ -127,7 +127,7 @@ HyperSwitch.prototype.defaultListingHandler = function(value, hs, req) {
         if (!req.query.path) {
             req.query.path = '/index.html';
         }
-        return swaggerUI(hs, req);
+        return swaggerUI(hyper, req);
     } else if (/\btext\/html\b/.test(req.headers.accept)
             && req.uri.path.length <= 2) {
         // Browser request and above api level
@@ -158,7 +158,7 @@ HyperSwitch.prototype.defaultListingHandler = function(value, hs, req) {
             + "omit the <code>Accept</code> header, or send one that does not contain "
             + "<code>text/html</code>.</p></div>";
 
-        return swaggerUI(hs, req)
+        return swaggerUI(hyper, req)
         .then(function(res) {
             res.body = res.body
                 .replace(/window\.swaggerUi\.load/, '')
@@ -351,8 +351,8 @@ HyperSwitch.prototype._request = function(req, options) {
         // A GET for an URL that ends with /: return a default listing
         if (!match.value) { match.value = {}; }
         if (!match.value.path) { match.value.path = '_defaultListingHandler'; }
-        handler = function(hs, req) {
-            return self.defaultListingHandler(match.value, hs, req);
+        handler = function(hyper, req) {
+            return self.defaultListingHandler(match.value, hyper, req);
         };
     }
 
@@ -363,7 +363,7 @@ HyperSwitch.prototype._request = function(req, options) {
 
     if (handler) {
         // Prepare to call the handler with a child hyperswitch instance
-        var childHS = this.makeChild(childReq, options);
+        var childHyper = this.makeChild(childReq, options);
 
         // Call the handler with P.try to catch synchronous exceptions.
         var reqHandlerPromise;
@@ -372,10 +372,10 @@ HyperSwitch.prototype._request = function(req, options) {
                 return handler.validator.validate(childReq);
             })
             .then(function() {
-                return handler(childHS, childReq);
+                return handler(childHyper, childReq);
             });
         } else {
-            reqHandlerPromise = P.try(handler, [childHS, childReq]);
+            reqHandlerPromise = P.try(handler, [childHyper, childReq]);
         }
 
         reqHandlerPromise = self._wrapInMetrics(reqHandlerPromise, match, req)
@@ -383,7 +383,7 @@ HyperSwitch.prototype._request = function(req, options) {
             self.log('trace', {
                 req: req,
                 res: res,
-                request_id: childHS.reqId
+                request_id: childHyper.reqId
             });
 
             if (!res) {
@@ -406,7 +406,7 @@ HyperSwitch.prototype._request = function(req, options) {
             }
         });
 
-        return childHS._wrapInAccessCheck(reqHandlerPromise, match, childReq);
+        return childHyper._wrapInAccessCheck(reqHandlerPromise, match, childReq);
     } else {
         // No handler found.
         throw new HTTPError({

--- a/lib/router.js
+++ b/lib/router.js
@@ -527,7 +527,7 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, scope, optionalPa
  * Any error during resource creation (status code >= 400) will abort startup
  * after logging the error as a fatal.
  */
-Router.prototype.handleResources = function(hs) {
+Router.prototype.handleResources = function(hyper) {
     var self = this;
     return this.tree.visitAsync(function(value, path) {
         if (value && Array.isArray(value.resources) && value.resources.length > 0) {
@@ -545,7 +545,7 @@ Router.prototype.handleResources = function(hs) {
                         + JSON.stringify(path));
                 }
                 req.method = req.method || 'put';
-                return hs.request(req);
+                return hyper.request(req);
             });
         } else {
             return P.resolve();
@@ -559,7 +559,7 @@ Router.prototype.handleResources = function(hs) {
  * This involves building a tree, initializing modules, merging specs &
  * initializing resources: Basically the entire app startup.
  */
-Router.prototype.loadSpec = function(spec, hs) {
+Router.prototype.loadSpec = function(spec, hyper) {
     var self = this;
     var rootNode = new Node();
     var specPromise;
@@ -572,7 +572,7 @@ Router.prototype.loadSpec = function(spec, hs) {
     .then(function(spec) {
         var scope = new ApiScope({
             globals: {
-                options: hs.config,
+                options: hyper.config,
             }
         });
         return self._handleSwaggerSpec(rootNode, spec, scope);
@@ -582,7 +582,7 @@ Router.prototype.loadSpec = function(spec, hs) {
         // console.log(JSON.stringify(rootNode, null, 2));
         self.tree = rootNode;
         self.router.setTree(rootNode);
-        return self.handleResources(hs);
+        return self.handleResources(hyper);
     })
     .then(function() {
         return self;

--- a/lib/router.js
+++ b/lib/router.js
@@ -207,18 +207,18 @@ Router.prototype._loadModule = function(modDef, globals) {
     }
 };
 
-Router.prototype._loadModules = function(node, hsModules, scope) {
+Router.prototype._loadModules = function(node, hyperModules, scope) {
     var self = this;
-    if (Array.isArray(hsModules)) {
+    if (Array.isArray(hyperModules)) {
         throw new Error('Old style module config detected! '
                 + 'New format expects an object, not an array. '
                 + 'Please update your config.');
-    } else if (typeof hsModules !== 'object') {
+    } else if (typeof hyperModules !== 'object') {
         return P.resolve();
     }
 
-    return P.each(Object.keys(hsModules), function(modulePath) {
-        var pathMods = hsModules[modulePath];
+    return P.each(Object.keys(hyperModules), function(modulePath) {
+        var pathMods = hyperModules[modulePath];
         if (!Array.isArray(pathMods)) {
             throw new Error('Error in module definition for ' + modulePath + '!\n'
                     + 'Expected an array, got ' + pathMods);

--- a/lib/router.js
+++ b/lib/router.js
@@ -207,18 +207,18 @@ Router.prototype._loadModule = function(modDef, globals) {
     }
 };
 
-Router.prototype._loadModules = function(node, restBaseModules, scope) {
+Router.prototype._loadModules = function(node, hsModules, scope) {
     var self = this;
-    if (Array.isArray(restBaseModules)) {
+    if (Array.isArray(hsModules)) {
         throw new Error('Old style module config detected! '
                 + 'New format expects an object, not an array. '
                 + 'Please update your config.');
-    } else if (typeof restBaseModules !== 'object') {
+    } else if (typeof hsModules !== 'object') {
         return P.resolve();
     }
 
-    return P.each(Object.keys(restBaseModules), function(modulePath) {
-        var pathMods = restBaseModules[modulePath];
+    return P.each(Object.keys(hsModules), function(modulePath) {
+        var pathMods = hsModules[modulePath];
         if (!Array.isArray(pathMods)) {
             throw new Error('Error in module definition for ' + modulePath + '!\n'
                     + 'Expected an array, got ' + pathMods);
@@ -374,10 +374,10 @@ Router.prototype._handleSwaggerPathSpec = function(node, pathspec, scope, parent
     }
 
     // Load modules
-    var restBaseModules = pathspec['x-modules'];
-    if (restBaseModules) {
+    var hsModules = pathspec['x-modules'];
+    if (hsModules) {
         loaderPromise = loaderPromise.then(function() {
-            return self._loadModules(node, restBaseModules, scope);
+            return self._loadModules(node, hsModules, scope);
         });
     }
 
@@ -527,7 +527,7 @@ Router.prototype._handleSwaggerSpec = function(rootNode, spec, scope, optionalPa
  * Any error during resource creation (status code >= 400) will abort startup
  * after logging the error as a fatal.
  */
-Router.prototype.handleResources = function(restbase) {
+Router.prototype.handleResources = function(hs) {
     var self = this;
     return this.tree.visitAsync(function(value, path) {
         if (value && Array.isArray(value.resources) && value.resources.length > 0) {
@@ -545,7 +545,7 @@ Router.prototype.handleResources = function(restbase) {
                         + JSON.stringify(path));
                 }
                 req.method = req.method || 'put';
-                return restbase.request(req);
+                return hs.request(req);
             });
         } else {
             return P.resolve();
@@ -559,7 +559,7 @@ Router.prototype.handleResources = function(restbase) {
  * This involves building a tree, initializing modules, merging specs &
  * initializing resources: Basically the entire app startup.
  */
-Router.prototype.loadSpec = function(spec, restbase) {
+Router.prototype.loadSpec = function(spec, hs) {
     var self = this;
     var rootNode = new Node();
     var specPromise;
@@ -572,7 +572,7 @@ Router.prototype.loadSpec = function(spec, restbase) {
     .then(function(spec) {
         var scope = new ApiScope({
             globals: {
-                options: restbase.rb_config,
+                options: hs.config,
             }
         });
         return self._handleSwaggerSpec(rootNode, spec, scope);
@@ -582,7 +582,7 @@ Router.prototype.loadSpec = function(spec, restbase) {
         // console.log(JSON.stringify(rootNode, null, 2));
         self.tree = rootNode;
         self.router.setTree(rootNode);
-        return self.handleResources(restbase);
+        return self.handleResources(hs);
     })
     .then(function() {
         return self;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,9 +1,9 @@
 "use strict";
 
 /*
- * Hyperswitch web service entry point
+ * HyperSwitch web service entry point
  *
- * Sets up a hyperswitch instance by loading and setting up handlers and the
+ * Sets up a HyperSwitch instance by loading and setting up handlers and the
  * storage layer, and then dispatches requests to it.
  */
 
@@ -18,7 +18,7 @@ var stream = require('stream');
 var URI = require('swagger-router').URI;
 
 var exports = require('./exports');
-var Hyperswitch = require('./hyperswitch');
+var HyperSwitch = require('./hyperswitch');
 var Router = require('./router');
 var utils = require('./utils');
 
@@ -254,7 +254,7 @@ function handleResponse(opts, req, resp, response) {
         resp.writeHead(response.status || 500, '', response.headers);
         resp.end(req.method === 'head' ? undefined : JSON.stringify({
             type: 'https://restbase.org/errors/no_content',
-            title: 'Hyperswitch error: No content returned by backend.',
+            title: 'HyperSwitch error: No content returned by backend.',
             uri: req.url,
             method: req.method
         }));
@@ -406,8 +406,8 @@ function main(options) {
     };
 
     opts.router = new Router(opts);
-    opts.hyper = new Hyperswitch(opts);
-    // Use a child hyperswitch instance to sidestep the security protection for
+    opts.hyper = new HyperSwitch(opts);
+    // Use a child HyperSwitch instance to sidestep the security protection for
     // direct requests to /sys
     var childHyper = opts.hyper.makeChild({ uri: '#internal-startup' });
     // Main app startup happens during async spec loading:

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,9 +1,9 @@
 "use strict";
 
 /*
- * RESTBase web service entry point
+ * Hyperswitch web service entry point
  *
- * Sets up a restbase instance by loading and setting up handlers and the
+ * Sets up a hyperswitch instance by loading and setting up handlers and the
  * storage layer, and then dispatches requests to it.
  */
 
@@ -18,7 +18,7 @@ var stream = require('stream');
 var URI = require('swagger-router').URI;
 
 var exports = require('./exports');
-var Restbase = require('./restbase');
+var Hyperswitch = require('./hyperswitch');
 var Router = require('./router');
 var utils = require('./utils');
 
@@ -177,7 +177,7 @@ function handleResponse(opts, req, resp, response) {
             }
 
             // Prefix error base URL
-            // XXX: make the prefix configurable
+            // TODO: make the prefix configurable
             body.type = 'https://restbase.org/errors/' + body.type;
             response.body = body;
         }
@@ -254,7 +254,7 @@ function handleResponse(opts, req, resp, response) {
         resp.writeHead(response.status || 500, '', response.headers);
         resp.end(req.method === 'head' ? undefined : JSON.stringify({
             type: 'https://restbase.org/errors/no_content',
-            title: 'RESTBase error: No content returned by backend.',
+            title: 'Hyperswitch error: No content returned by backend.',
             uri: req.url,
             method: req.method
         }));
@@ -350,7 +350,7 @@ function handleRequest(opts, req, resp) {
                 status: 200
             });
         } else {
-            return opts.restbase.request(newReq, reqOpts);
+            return opts.hs.request(newReq, reqOpts);
         }
     })
 
@@ -385,7 +385,7 @@ function handleRequest(opts, req, resp) {
 function setupConfigDefaults(conf) {
     if (!conf) { conf = {}; }
     if (!conf.logging) { conf.logging = {}; }
-    if (!conf.logging.name) { conf.logging.name = 'restbase'; }
+    if (!conf.logging.name) { conf.logging.name = 'hyperswitch'; }
     if (!conf.logging.level) { conf.logging.level = 'warn'; }
     return conf;
 }
@@ -406,12 +406,12 @@ function main(options) {
     };
 
     opts.router = new Router(opts);
-    opts.restbase = new Restbase(opts);
-    // Use a child restbase instance to sidestep the security protection for
+    opts.hs = new Hyperswitch(opts);
+    // Use a child hyperswitch instance to sidestep the security protection for
     // direct requests to /sys
-    var childRestBase = opts.restbase.makeChild({ uri: '#internal-startup' });
+    var childHS = opts.hs.makeChild({ uri: '#internal-startup' });
     // Main app startup happens during async spec loading:
-    return opts.router.loadSpec(conf.spec, childRestBase)
+    return opts.router.loadSpec(conf.spec, childHS)
     .then(function(router) {
         var server = http.createServer(handleRequest.bind(null, opts));
         // Use a large listen queue

--- a/lib/server.js
+++ b/lib/server.js
@@ -409,9 +409,9 @@ function main(options) {
     opts.hyper = new HyperSwitch(opts);
     // Use a child HyperSwitch instance to sidestep the security protection for
     // direct requests to /sys
-    var childHyper = opts.hyper.makeChild({ uri: '#internal-startup' });
+    var childHyperSwitch = opts.hyper.makeChild({ uri: '#internal-startup' });
     // Main app startup happens during async spec loading:
-    return opts.router.loadSpec(conf.spec, childHyper)
+    return opts.router.loadSpec(conf.spec, childHyperSwitch)
     .then(function(router) {
         var server = http.createServer(handleRequest.bind(null, opts));
         // Use a large listen queue

--- a/lib/server.js
+++ b/lib/server.js
@@ -350,7 +350,7 @@ function handleRequest(opts, req, resp) {
                 status: 200
             });
         } else {
-            return opts.hs.request(newReq, reqOpts);
+            return opts.hyper.request(newReq, reqOpts);
         }
     })
 
@@ -406,12 +406,12 @@ function main(options) {
     };
 
     opts.router = new Router(opts);
-    opts.hs = new Hyperswitch(opts);
+    opts.hyper = new Hyperswitch(opts);
     // Use a child hyperswitch instance to sidestep the security protection for
     // direct requests to /sys
-    var childHS = opts.hs.makeChild({ uri: '#internal-startup' });
+    var childHyper = opts.hyper.makeChild({ uri: '#internal-startup' });
     // Main app startup happens during async spec loading:
-    return opts.router.loadSpec(conf.spec, childHS)
+    return opts.router.loadSpec(conf.spec, childHyper)
     .then(function(router) {
         var server = http.createServer(handleRequest.bind(null, opts));
         // Use a large listen queue

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -7,7 +7,7 @@ var path = require('path');
 var docRoot = require('swagger-ui').dist + '/';
 var HTTPError = require('./exports').HTTPError;
 
-function staticServe(restbase, req) {
+function staticServe(hs, req) {
     var reqPath = req.query.path;
 
     var filePath = path.join(docRoot, reqPath);
@@ -27,7 +27,7 @@ function staticServe(restbase, req) {
                 .replace(/<a id="logo".*?<\/a>/,
                         '<a id="logo" href="https://www.mediawiki.org/wiki/RESTBase">RESTBase</a>')
                 .replace(/<title>[^<]*<\/title>/,
-                        '<title>RESTBase docs</title>')
+                        '<title>RESTBase docs</title>') // TODO: Make this configurable
                 // Replace the default url with ours, switch off validation &
                 // limit the size of documents to apply syntax highlighting to
                 .replace(/Sorter: "alpha"/, 'Sorter: "alpha", ' + 'validatorUrl: null, ' +

--- a/lib/swaggerUI.js
+++ b/lib/swaggerUI.js
@@ -7,7 +7,7 @@ var path = require('path');
 var docRoot = require('swagger-ui').dist + '/';
 var HTTPError = require('./exports').HTTPError;
 
-function staticServe(hs, req) {
+function staticServe(hyper, req) {
     var reqPath = req.query.path;
 
     var filePath = path.join(docRoot, reqPath);

--- a/sys/action.js
+++ b/sys/action.js
@@ -175,7 +175,7 @@ function buildEditResponse(res) {
     return res;
 }
 
-ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
+ActionService.prototype._doRequest = function(hs, req, defBody, cont) {
     var apiRequest = this.apiRequestTemplate({
         request: req
     });
@@ -185,18 +185,18 @@ ActionService.prototype._doRequest = function(restbase, req, defBody, cont) {
     if (!apiRequest.body.hasOwnProperty('continue') && apiRequest.action === 'query') {
         apiRequest.body.continue = '';
     }
-    return restbase.request(apiRequest).then(cont);
+    return hs.request(apiRequest).then(cont);
 };
 
-ActionService.prototype.query = function(restbase, req) {
-    return this._doRequest(restbase, req, {
+ActionService.prototype.query = function(hs, req) {
+    return this._doRequest(hs, req, {
         action: 'query',
         format: 'json'
     }, buildQueryResponse);
 };
 
-ActionService.prototype.edit = function(restbase, req) {
-    return this._doRequest(restbase, req, {
+ActionService.prototype.edit = function(hs, req) {
+    return this._doRequest(hs, req, {
         action: 'edit',
         format: 'json',
         formatversion: 2

--- a/sys/action.js
+++ b/sys/action.js
@@ -175,7 +175,7 @@ function buildEditResponse(res) {
     return res;
 }
 
-ActionService.prototype._doRequest = function(hs, req, defBody, cont) {
+ActionService.prototype._doRequest = function(hyper, req, defBody, cont) {
     var apiRequest = this.apiRequestTemplate({
         request: req
     });
@@ -185,18 +185,18 @@ ActionService.prototype._doRequest = function(hs, req, defBody, cont) {
     if (!apiRequest.body.hasOwnProperty('continue') && apiRequest.action === 'query') {
         apiRequest.body.continue = '';
     }
-    return hs.request(apiRequest).then(cont);
+    return hyper.request(apiRequest).then(cont);
 };
 
-ActionService.prototype.query = function(hs, req) {
-    return this._doRequest(hs, req, {
+ActionService.prototype.query = function(hyper, req) {
+    return this._doRequest(hyper, req, {
         action: 'query',
         format: 'json'
     }, buildQueryResponse);
 };
 
-ActionService.prototype.edit = function(hs, req) {
-    return this._doRequest(hs, req, {
+ActionService.prototype.edit = function(hyper, req) {
+    return this._doRequest(hyper, req, {
         action: 'edit',
         format: 'json',
         formatversion: 2

--- a/sys/key_value.js
+++ b/sys/key_value.js
@@ -19,7 +19,7 @@ function KVBucket(options) {
     this.log = options.log || function() {};
 }
 
-KVBucket.prototype.getBucketInfo = function(restbase, req, options) {
+KVBucket.prototype.getBucketInfo = function(hs, req, options) {
     var self = this;
     return P.resolve({
         status: 200,
@@ -70,7 +70,7 @@ KVBucket.prototype.makeSchema = function(opts) {
     };
 };
 
-KVBucket.prototype.createBucket = function(restbase, req) {
+KVBucket.prototype.createBucket = function(hs, req) {
     var schema = this.makeSchema(req.body || {});
     schema.table = req.params.bucket;
     var rp = req.params;
@@ -78,7 +78,7 @@ KVBucket.prototype.createBucket = function(restbase, req) {
         uri: new URI([rp.domain, 'sys', 'table', rp.bucket]),
         body: schema
     };
-    return restbase.put(storeRequest);
+    return hs.put(storeRequest);
 };
 
 
@@ -93,13 +93,13 @@ KVBucket.prototype.getListQuery = function(options, bucket) {
 
 
 
-KVBucket.prototype.listBucket = function(restbase, req, options) {
+KVBucket.prototype.listBucket = function(hs, req, options) {
     var self = this;
     // XXX: check params!
     var rp = req.params;
 
     var listQuery = this.getListQuery(options, rp.bucket);
-    return restbase.get({
+    return hs.get({
         uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '']),
         body: listQuery
     })
@@ -177,7 +177,7 @@ function coerceTid(tidString) {
     });
 }
 
-KVBucket.prototype.getRevision = function(restbase, req) {
+KVBucket.prototype.getRevision = function(hs, req) {
     if (req.headers && /no-cache/i.test(req.headers['cache-control'])) {
         throw new HTTPError({
             status: 404
@@ -198,11 +198,11 @@ KVBucket.prototype.getRevision = function(restbase, req) {
     if (rp.tid) {
         storeReq.body.attributes.tid = coerceTid(rp.tid);
     }
-    return restbase.get(storeReq).then(returnRevision(req));
+    return hs.get(storeReq).then(returnRevision(req));
 };
 
 
-KVBucket.prototype.listRevisions = function(restbase, req) {
+KVBucket.prototype.listRevisions = function(hs, req) {
     var rp = req.params;
     var storeRequest = {
         uri: new URI([rp.domain, 'sys', 'table', rp.bucket, '']),
@@ -215,7 +215,7 @@ KVBucket.prototype.listRevisions = function(restbase, req) {
             limit: 1000
         }
     };
-    return restbase.get(storeRequest)
+    return hs.get(storeRequest)
     .then(function(res) {
         return {
             status: 200,
@@ -232,7 +232,7 @@ KVBucket.prototype.listRevisions = function(restbase, req) {
 };
 
 
-KVBucket.prototype.putRevision = function(restbase, req) {
+KVBucket.prototype.putRevision = function(hs, req) {
     // TODO: support other formats! See cassandra backend getRevision impl.
     var rp = req.params;
     var tid = rp.tid && coerceTid(rp.tid);
@@ -256,7 +256,7 @@ KVBucket.prototype.putRevision = function(restbase, req) {
             }
         }
     };
-    return restbase.put(storeReq)
+    return hs.put(storeReq)
     .then(function(res) {
         if (res.status === 201) {
             return {
@@ -274,7 +274,7 @@ KVBucket.prototype.putRevision = function(restbase, req) {
         }
     })
     .catch(function(error) {
-        restbase.log('error/kv/putRevision', error);
+        hs.log('error/kv/putRevision', error);
         return { status: 400 };
     });
 };

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -134,24 +134,24 @@ PRS.prototype._checkRevReturn = function(item) {
 };
 
 // /page/
-PRS.prototype.listTitles = function(restbase, req, options) {
+PRS.prototype.listTitles = function(hs, req, options) {
     var rp = req.params;
     var listReq = {
         uri: new URI([rp.domain, 'sys', 'action', 'query']),
         method: 'post',
         body: {
             generator: 'allpages',
-            gaplimit: restbase.rb_config.default_page_size,
+            gaplimit: hs.config.default_page_size,
             prop: 'revisions',
             format: 'json'
         }
     };
 
     if (req.query.page) {
-        Object.assign(listReq.body, restbase.decodeToken(req.query.page));
+        Object.assign(listReq.body, hs.decodeToken(req.query.page));
     }
 
-    return restbase.get(listReq)
+    return hs.get(listReq)
     .then(function(res) {
         var pages = res.body.items;
         var items = [];
@@ -165,7 +165,7 @@ PRS.prototype.listTitles = function(restbase, req, options) {
         if (res.body.next) {
             next = {
                 next: {
-                    href: "?page=" + restbase.encodeToken(res.body.next)
+                    href: "?page=" + hs.encodeToken(res.body.next)
                 }
             };
         }
@@ -209,7 +209,7 @@ PRS.prototype._checkSameRev = function(firstRev, secondRev) {
     return stringify(normalizeRev(firstRev)) === stringify(normalizeRev(secondRev));
 };
 
-PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
+PRS.prototype.fetchAndStoreMWRevision = function(hs, req) {
     var self = this;
     var rp = req.params;
     // Try to resolve MW oldids to tids
@@ -228,7 +228,7 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
     } else {
         apiReq.body.titles = rp.title;
     }
-    return restbase.post(apiReq)
+    return hs.post(apiReq)
     .then(function(apiRes) {
         var items = apiRes.body.items;
         if (!items.length || !items[0].revisions) {
@@ -273,7 +273,7 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
         };
 
         // Check if the same revision is already in storage
-        return restbase.get({
+        return hs.get({
             uri: self.tableURI(rp.domain),
             body: {
                 table: self.tableName,
@@ -292,7 +292,7 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
             }
         })
         .catch({ status: 404 }, function() {
-            return restbase.put({ // Save / update the revision entry
+            return hs.put({ // Save / update the revision entry
                 uri: self.tableURI(rp.domain),
                 body: {
                     table: self.tableName,
@@ -305,7 +305,7 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
             // No restrictions, continue
             rp.revision = apiRev.revid + '';
             rp.title = dataResp.title;
-            return self.getTitleRevision(restbase, req);
+            return self.getTitleRevision(hs, req);
         });
     }).catch(function(e) {
         // If a bad revision is supplied, the action module
@@ -326,12 +326,12 @@ PRS.prototype.fetchAndStoreMWRevision = function(restbase, req) {
 };
 
 
-PRS.prototype.getTitleRevision = function(restbase, req) {
+PRS.prototype.getTitleRevision = function(hs, req) {
     var self = this;
     var rp = req.params;
     var revisionRequest;
     function getLatestTitleRevision() {
-        return restbase.get({
+        return hs.get({
             uri: self.tableURI(rp.domain),
             body: {
                 table: self.tableName,
@@ -345,7 +345,7 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
 
     if (/^[0-9]+$/.test(rp.revision)) {
         // Check the local db
-        revisionRequest = restbase.get({
+        revisionRequest = hs.get({
             uri: this.tableURI(rp.domain),
             body: {
                 table: this.tableName,
@@ -357,11 +357,11 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
             }
         })
         .catch({ status: 404 }, function() {
-            return self.fetchAndStoreMWRevision(restbase, req);
+            return self.fetchAndStoreMWRevision(hs, req);
         });
     } else if (!rp.revision) {
         if (req.headers && /no-cache/.test(req.headers['cache-control'])) {
-            revisionRequest = self.fetchAndStoreMWRevision(restbase, req)
+            revisionRequest = self.fetchAndStoreMWRevision(hs, req)
             .catch({ status: 404 }, function(e) {
                 return getLatestTitleRevision()
                 // In case 404 is returned by MW api, the page is deleted
@@ -370,7 +370,7 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
                     result.tid = uuid.now().toString();
                     result.restrictions = result.restrictions || [];
                     result.restrictions.push('page_deleted');
-                    return restbase.put({
+                    return hs.put({
                         uri: self.tableURI(rp.domain),
                         body: {
                             table: self.tableName,
@@ -382,7 +382,7 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
         } else {
             revisionRequest = getLatestTitleRevision()
             .catch({ status: 404 }, function() {
-                return self.fetchAndStoreMWRevision(restbase, req);
+                return self.fetchAndStoreMWRevision(hs, req);
             });
         }
     } else {
@@ -406,7 +406,7 @@ PRS.prototype.getTitleRevision = function(restbase, req) {
     // TODO: handle other revision formats (tid)
 };
 
-PRS.prototype.listTitleRevisions = function(restbase, req) {
+PRS.prototype.listTitleRevisions = function(hs, req) {
     var rp = req.params;
     var revisionRequest = {
         table: this.tableName,
@@ -414,12 +414,12 @@ PRS.prototype.listTitleRevisions = function(restbase, req) {
             title: mwUtil.normalizeTitle(rp.title)
         },
         proj: ['rev'],
-        limit: restbase.rb_config.default_page_size
+        limit: hs.config.default_page_size
     };
     if (req.query.page) {
-        revisionRequest.next = restbase.decodeToken(req.query.page);
+        revisionRequest.next = hs.decodeToken(req.query.page);
     }
-    return restbase.get({
+    return hs.get({
         uri: this.tableURI(rp.domain),
         body: revisionRequest
     })
@@ -437,7 +437,7 @@ PRS.prototype.listTitleRevisions = function(restbase, req) {
         if (res.body.next) {
             res.body._links = {
                 next: {
-                    href: "?page=" + restbase.encodeToken(res.body.next)
+                    href: "?page=" + hs.encodeToken(res.body.next)
                 }
             };
         }
@@ -447,7 +447,7 @@ PRS.prototype.listTitleRevisions = function(restbase, req) {
 };
 
 // /rev/
-PRS.prototype.listRevisions = function(restbase, req) {
+PRS.prototype.listRevisions = function(hs, req) {
     var rp = req.params;
 
     var listReq = {
@@ -455,15 +455,15 @@ PRS.prototype.listRevisions = function(restbase, req) {
         method: 'post',
         body: {
             generator: 'allpages',
-            gaplimit: restbase.rb_config.default_page_size,
+            gaplimit: hs.config.default_page_size,
             prop: 'revisions',
             format: 'json'
         }
     };
     if (req.query.page) {
-        Object.assign(listReq.body, restbase.decodeToken(req.query.page));
+        Object.assign(listReq.body, hs.decodeToken(req.query.page));
     }
-    return restbase.get(listReq)
+    return hs.get(listReq)
     .then(function(res) {
         var pages = res.body.items;
         var items = [];
@@ -475,7 +475,7 @@ PRS.prototype.listRevisions = function(restbase, req) {
         if (res.body.next) {
             next = {
                 next: {
-                    href: "?page=" + restbase.encodeToken(res.body.next)
+                    href: "?page=" + hs.encodeToken(res.body.next)
                 }
             };
         }
@@ -490,7 +490,7 @@ PRS.prototype.listRevisions = function(restbase, req) {
     });
 };
 
-PRS.prototype.getRevision = function(restbase, req) {
+PRS.prototype.getRevision = function(hs, req) {
     var rp = req.params;
     var self = this;
     // Sanity check
@@ -506,11 +506,11 @@ PRS.prototype.getRevision = function(restbase, req) {
     if (req.headers && /no-cache/.test(req.headers['cache-control'])) {
         // Ask the MW API directly and
         // store and return its result
-        return this.fetchAndStoreMWRevision(restbase, req);
+        return this.fetchAndStoreMWRevision(hs, req);
     }
     // Check the storage, and, if no match is found
     // ask the MW API about the revision
-    return restbase.get({
+    return hs.get({
         uri: this.tableURI(rp.domain),
         body: {
             table: this.tableName,
@@ -531,10 +531,10 @@ PRS.prototype.getRevision = function(restbase, req) {
         // And get the revision info for the
         // page now that we have the title
         rp.title = res.body.items[0].title;
-        return self.getTitleRevision(restbase, req);
+        return self.getTitleRevision(hs, req);
     })
     .catch({ status: 404 }, function() {
-        return self.fetchAndStoreMWRevision(restbase, req);
+        return self.fetchAndStoreMWRevision(hs, req);
     });
 };
 

--- a/sys/page_save.js
+++ b/sys/page_save.js
@@ -75,7 +75,7 @@ PageSave.prototype._getBaseRevision = function(req) {
     return undefined;
 };
 
-PageSave.prototype._getRevInfo = function(restbase, req, revision) {
+PageSave.prototype._getRevInfo = function(hs, req, revision) {
     var rp = req.params;
     var path = [rp.domain, 'sys', 'page_revisions', 'page',
                     mwUtil.normalizeTitle(rp.title)];
@@ -90,7 +90,7 @@ PageSave.prototype._getRevInfo = function(restbase, req, revision) {
         });
     }
     path.push(revision);
-    return restbase.get({
+    return hs.get({
         uri: new URI(path)
     })
     .then(function(res) {
@@ -118,7 +118,7 @@ PageSave.prototype._checkParams = function(params) {
     }
 };
 
-PageSave.prototype.saveWikitext = function(restbase, req) {
+PageSave.prototype.saveWikitext = function(hs, req) {
     var self = this;
     var rp = req.params;
     var title = mwUtil.normalizeTitle(rp.title);
@@ -126,7 +126,7 @@ PageSave.prototype.saveWikitext = function(restbase, req) {
     this._checkParams(req.body);
     var baseRevision = this._getBaseRevision(req);
     if (baseRevision) {
-        promise = this._getRevInfo(restbase, req, baseRevision);
+        promise = this._getRevInfo(hs, req, baseRevision);
     }
     return promise.then(function(revInfo) {
         var body = {
@@ -149,7 +149,7 @@ PageSave.prototype.saveWikitext = function(restbase, req) {
             body.basetimestamp = revInfo.timestamp;
         }
         body.starttimestamp = self._getStartTimestamp(req);
-        return restbase.post({
+        return hs.post({
             uri: new URI([rp.domain, 'sys', 'action', 'edit']),
             headers: {
                 cookie: req.headers.cookie
@@ -159,7 +159,7 @@ PageSave.prototype.saveWikitext = function(restbase, req) {
     });
 };
 
-PageSave.prototype.saveHtml = function(restbase, req) {
+PageSave.prototype.saveHtml = function(hs, req) {
     var self = this;
     var rp = req.params;
     var title = mwUtil.normalizeTitle(rp.title);
@@ -170,7 +170,7 @@ PageSave.prototype.saveHtml = function(restbase, req) {
     if (baseRevision) {
         path.push(baseRevision);
     }
-    return restbase.post({
+    return hs.post({
         uri: new URI(path),
         body: {
             html: req.body.html
@@ -183,7 +183,7 @@ PageSave.prototype.saveHtml = function(restbase, req) {
         // Then send it to the MW API
         req.body.wikitext = res.body;
         delete req.body.html;
-        return self.saveWikitext(restbase, req);
+        return self.saveWikitext(hs, req);
     });
 };
 

--- a/sys/page_save.js
+++ b/sys/page_save.js
@@ -75,7 +75,7 @@ PageSave.prototype._getBaseRevision = function(req) {
     return undefined;
 };
 
-PageSave.prototype._getRevInfo = function(hs, req, revision) {
+PageSave.prototype._getRevInfo = function(hyper, req, revision) {
     var rp = req.params;
     var path = [rp.domain, 'sys', 'page_revisions', 'page',
                     mwUtil.normalizeTitle(rp.title)];
@@ -90,7 +90,7 @@ PageSave.prototype._getRevInfo = function(hs, req, revision) {
         });
     }
     path.push(revision);
-    return hs.get({
+    return hyper.get({
         uri: new URI(path)
     })
     .then(function(res) {
@@ -118,7 +118,7 @@ PageSave.prototype._checkParams = function(params) {
     }
 };
 
-PageSave.prototype.saveWikitext = function(hs, req) {
+PageSave.prototype.saveWikitext = function(hyper, req) {
     var self = this;
     var rp = req.params;
     var title = mwUtil.normalizeTitle(rp.title);
@@ -126,7 +126,7 @@ PageSave.prototype.saveWikitext = function(hs, req) {
     this._checkParams(req.body);
     var baseRevision = this._getBaseRevision(req);
     if (baseRevision) {
-        promise = this._getRevInfo(hs, req, baseRevision);
+        promise = this._getRevInfo(hyper, req, baseRevision);
     }
     return promise.then(function(revInfo) {
         var body = {
@@ -149,7 +149,7 @@ PageSave.prototype.saveWikitext = function(hs, req) {
             body.basetimestamp = revInfo.timestamp;
         }
         body.starttimestamp = self._getStartTimestamp(req);
-        return hs.post({
+        return hyper.post({
             uri: new URI([rp.domain, 'sys', 'action', 'edit']),
             headers: {
                 cookie: req.headers.cookie
@@ -159,7 +159,7 @@ PageSave.prototype.saveWikitext = function(hs, req) {
     });
 };
 
-PageSave.prototype.saveHtml = function(hs, req) {
+PageSave.prototype.saveHtml = function(hyper, req) {
     var self = this;
     var rp = req.params;
     var title = mwUtil.normalizeTitle(rp.title);
@@ -170,7 +170,7 @@ PageSave.prototype.saveHtml = function(hs, req) {
     if (baseRevision) {
         path.push(baseRevision);
     }
-    return hs.post({
+    return hyper.post({
         uri: new URI(path),
         body: {
             html: req.body.html
@@ -183,7 +183,7 @@ PageSave.prototype.saveHtml = function(hs, req) {
         // Then send it to the MW API
         req.body.wikitext = res.body;
         delete req.body.html;
-        return self.saveWikitext(hs, req);
+        return self.saveWikitext(hyper, req);
     });
 };
 

--- a/sys/pageviews.js
+++ b/sys/pageviews.js
@@ -264,14 +264,14 @@ var validateYearMonthDay = function(rp) {
     throwIfNeeded(errors);
 };
 
-PJVS.prototype.pageviewsForArticleFlat = function(hs, req) {
+PJVS.prototype.pageviewsForArticleFlat = function(hyper, req) {
     var rp = req.params;
 
     // dates are passed in as YYYYMMDD but we need the HH to match the loaded data
     // which was originally planned at hourly resolution, so we pass "fakeHour"
     validateStartAndEnd(rp, { fakeHour: true });
 
-    var dataRequest = hs.get({
+    var dataRequest = hyper.get({
         uri: tableURI(rp.domain, tables.articleFlat),
         body: {
             table: tables.articleFlat,
@@ -310,12 +310,12 @@ PJVS.prototype.pageviewsForArticleFlat = function(hs, req) {
     });
 };
 
-PJVS.prototype.pageviewsForProjects = function(hs, req) {
+PJVS.prototype.pageviewsForProjects = function(hyper, req) {
     var rp = req.params;
 
     validateStartAndEnd(rp);
 
-    var dataRequest = hs.get({
+    var dataRequest = hyper.get({
         uri: tableURI(rp.domain, tables.project),
         body: {
             table: tables.project,
@@ -349,12 +349,12 @@ PJVS.prototype.pageviewsForProjects = function(hs, req) {
     });
 };
 
-PJVS.prototype.pageviewsForTops = function(hs, req) {
+PJVS.prototype.pageviewsForTops = function(hyper, req) {
     var rp = req.params;
 
     validateYearMonthDay(rp);
 
-    var dataRequest = hs.get({
+    var dataRequest = hyper.get({
         uri: tableURI(rp.domain, tables.tops),
         body: {
             table: tables.tops,

--- a/sys/pageviews.js
+++ b/sys/pageviews.js
@@ -264,14 +264,14 @@ var validateYearMonthDay = function(rp) {
     throwIfNeeded(errors);
 };
 
-PJVS.prototype.pageviewsForArticleFlat = function(restbase, req) {
+PJVS.prototype.pageviewsForArticleFlat = function(hs, req) {
     var rp = req.params;
 
     // dates are passed in as YYYYMMDD but we need the HH to match the loaded data
     // which was originally planned at hourly resolution, so we pass "fakeHour"
     validateStartAndEnd(rp, { fakeHour: true });
 
-    var dataRequest = restbase.get({
+    var dataRequest = hs.get({
         uri: tableURI(rp.domain, tables.articleFlat),
         body: {
             table: tables.articleFlat,
@@ -310,12 +310,12 @@ PJVS.prototype.pageviewsForArticleFlat = function(restbase, req) {
     });
 };
 
-PJVS.prototype.pageviewsForProjects = function(restbase, req) {
+PJVS.prototype.pageviewsForProjects = function(hs, req) {
     var rp = req.params;
 
     validateStartAndEnd(rp);
 
-    var dataRequest = restbase.get({
+    var dataRequest = hs.get({
         uri: tableURI(rp.domain, tables.project),
         body: {
             table: tables.project,
@@ -349,12 +349,12 @@ PJVS.prototype.pageviewsForProjects = function(restbase, req) {
     });
 };
 
-PJVS.prototype.pageviewsForTops = function(restbase, req) {
+PJVS.prototype.pageviewsForTops = function(hs, req) {
     var rp = req.params;
 
     validateYearMonthDay(rp);
 
-    var dataRequest = restbase.get({
+    var dataRequest = hs.get({
         uri: tableURI(rp.domain, tables.tops),
         body: {
             table: tables.tops,

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -219,7 +219,7 @@ PSP._dependenciesUpdate = function(hyper, req) {
  * P.all() call, bundling it with a request for revision
  * info, so that a 403 error gets raised overall if access to
  * the revision should be denied
- * @param hyper the Hyperswitch router object
+ * @param {HyperSwitch} hyper the HyperSwitch router object
  * @param {Object} req the user request
  * @param {Object} promise the promise object to wrap
  * @private
@@ -236,7 +236,7 @@ PSP._wrapInAccessCheck = function(hyper, req, promise) {
  * Wrap content request with sections request if needed
  * and ensures charset in the response
  *
- * @param {Hyperswitch} hyper the Hyperswitch router object
+ * @param {HyperSwitch} hyper the HyperSwitch router object
  * @param {Object} req the user request
  * @param {Object} promise the promise object to wrap
  * @param {String} format the requested format

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -176,13 +176,13 @@ PSP.purgeCaches = function(domain, title) {
 
 // TEMP TEMP TEMP!!!
 // Wiktionary / summary invalidation and mobileapps pregeneration
-PSP._dependenciesUpdate = function(restbase, req) {
+PSP._dependenciesUpdate = function(hs, req) {
     var self = this;
     var rp = req.params;
     var summaryPromise = P.resolve();
     if (rp.domain.indexOf('wiktionary') === -1) {
         // non-wiktionary, update summary
-        summaryPromise = restbase.get({
+        summaryPromise = hs.get({
             uri: new URI([rp.domain, 'v1', 'page', 'summary', rp.title]),
             headers: {
                 'cache-control': 'no-cache'
@@ -190,7 +190,7 @@ PSP._dependenciesUpdate = function(restbase, req) {
         });
     } else if (/en.wiktionary/.test(rp.domain)) {
         // wiktionary update, we are interested only in en.wiktionary
-        summaryPromise = restbase.get({
+        summaryPromise = hs.get({
             uri: new URI([rp.domain, 'v1', 'page', 'definition', rp.title]),
             headers: {
                 'cache-control': 'no-cache'
@@ -205,7 +205,7 @@ PSP._dependenciesUpdate = function(restbase, req) {
     });
     return P.join(
         summaryPromise,
-        restbase.get({
+        hs.get({
             uri: new URI([rp.domain, 'sys', 'mobileapps', 'v1',
                 'handling', 'content', 'mobile-sections', 'no-cache', rp.title])
         }).catch(function(e) {
@@ -219,15 +219,15 @@ PSP._dependenciesUpdate = function(restbase, req) {
  * P.all() call, bundling it with a request for revision
  * info, so that a 403 error gets raised overall if access to
  * the revision should be denied
- * @param restbase RESTBase the Restbase router object
+ * @param hs the Hyperswitch router object
  * @param {Object} req the user request
  * @param {Object} promise the promise object to wrap
  * @private
  */
-PSP._wrapInAccessCheck = function(restbase, req, promise) {
+PSP._wrapInAccessCheck = function(hs, req, promise) {
     return P.props({
         content: promise,
-        revisionInfo: this.getRevisionInfo(restbase, req)
+        revisionInfo: this.getRevisionInfo(hs, req)
     })
     .then(function(responses) { return responses.content; });
 };
@@ -236,20 +236,20 @@ PSP._wrapInAccessCheck = function(restbase, req, promise) {
  * Wrap content request with sections request if needed
  * and ensures charset in the response
  *
- * @param restbase RESTBase the Restbase router object
+ * @param {Hyperswitch} hs the Hyperswitch router object
  * @param {Object} req the user request
  * @param {Object} promise the promise object to wrap
  * @param {String} format the requested format
  * @param {String} tid time ID of the requested render
  */
-PSP.wrapContentReq = function(restbase, req, promise, format, tid) {
+PSP.wrapContentReq = function(hs, req, promise, format, tid) {
     var rp = req.params;
     var reqs = { content: promise };
 
     // If the format is HTML and sections were requested, also request section
     // offsets
     if (format === 'html' && req.query.sections) {
-        reqs.sectionOffsets = restbase.get({
+        reqs.sectionOffsets = hs.get({
             uri: this.getBucketURI(rp, 'section.offsets', tid)
         });
     }
@@ -306,7 +306,7 @@ PSP.getBucketURI = function(rp, format, tid) {
     return new URI(path);
 };
 
-PSP.pagebundle = function(restbase, req) {
+PSP.pagebundle = function(hs, req) {
     var rp = req.params;
     var domain = rp.domain;
     var newReq = Object.assign({}, req);
@@ -314,19 +314,19 @@ PSP.pagebundle = function(restbase, req) {
     var path = (newReq.method === 'get') ? 'page' : 'transform/wikitext/to';
     newReq.uri = this.parsoidHost + '/' + domain + '/v3/' + path + '/pagebundle/'
         + encodeURIComponent(mwUtil.normalizeTitle(rp.title)) + '/' + rp.revision;
-    return restbase.request(newReq);
+    return hs.request(newReq);
 };
 
-PSP.saveParsoidResult = function(restbase, req, format, tid, parsoidResp) {
+PSP.saveParsoidResult = function(hs, req, format, tid, parsoidResp) {
     var self = this;
     var rp = req.params;
     return P.join(
-        restbase.put({
+        hs.put({
             uri: self.getBucketURI(rp, 'data-parsoid', tid),
             headers: parsoidResp.body['data-parsoid'].headers,
             body: parsoidResp.body['data-parsoid'].body
         }),
-        restbase.put({
+        hs.put({
             uri: self.getBucketURI(rp, 'section.offsets', tid),
             headers: { 'content-type': 'application/json' },
             body: parsoidResp.body['data-parsoid'].body.sectionOffsets
@@ -334,7 +334,7 @@ PSP.saveParsoidResult = function(restbase, req, format, tid, parsoidResp) {
     )
     // Save HTML last, so that any error in metadata storage suppresses HTML.
     .then(function() {
-        return restbase.put({
+        return hs.put({
             uri: self.getBucketURI(rp, 'html', tid),
             headers: parsoidResp.body.html.headers,
             body: parsoidResp.body.html.body
@@ -342,7 +342,7 @@ PSP.saveParsoidResult = function(restbase, req, format, tid, parsoidResp) {
     });
 };
 
-PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
+PSP.generateAndSave = function(hs, req, format, currentContentRes) {
     var self = this;
     // Try to generate HTML on the fly by calling Parsoid
     var rp = req.params;
@@ -353,13 +353,13 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
     // Helper for retrieving original content from storage & posting it to
     // the Parsoid pagebundle end point
     function getOrigAndPostToParsoid(revision, contentName, updateMode) {
-        return self._getOriginalContent(restbase, req, revision)
+        return self._getOriginalContent(hs, req, revision)
         .then(function(res) {
             var body = {
                 update: updateMode
             };
             body[contentName] = res;
-            return restbase.post({
+            return hs.post({
                 uri: pageBundleUri,
                 headers: {
                     'content-type': 'application/json',
@@ -369,7 +369,7 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
             });
         }, function(e) {
             // Fall back to plain GET
-            return restbase.get({ uri: pageBundleUri });
+            return hs.get({ uri: pageBundleUri });
         });
     }
 
@@ -386,7 +386,7 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
         parsoidReq = getOrigAndPostToParsoid(rp.revision, 'original', updateMode);
     } else {
         // Plain render
-        parsoidReq = restbase.get({ uri: pageBundleUri });
+        parsoidReq = hs.get({ uri: pageBundleUri });
     }
 
     return parsoidReq
@@ -397,15 +397,15 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
         if (format === 'html' && currentContentRes
                 && sameHtml(res.body.html.body, currentContentRes.body)) {
             // New render is the same as the previous one, no need to store it.
-            restbase.metrics.increment('sys_parsoid_generateAndSave.unchanged_rev_render');
+            hs.metrics.increment('sys_parsoid_generateAndSave.unchanged_rev_render');
 
             // No need to check access again here, as we rely on the pagebundle request
             // being wrapped & throwing an error if access is denied
-            return self.wrapContentReq(restbase, req, P.resolve(currentContentRes), format, rp.tid);
+            return self.wrapContentReq(hs, req, P.resolve(currentContentRes), format, rp.tid);
         } else if (res.status === 200) {
-            return self.saveParsoidResult(restbase, req, format, tid, res)
+            return self.saveParsoidResult(hs, req, format, tid, res)
             .then(function() {
-                return self._dependenciesUpdate(restbase, req); })
+                return self._dependenciesUpdate(hs, req); })
             .then(function() {
                 var resp = {
                     status: res.status,
@@ -413,7 +413,7 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
                     body: res.body[format].body
                 };
                 resp.headers.etag = mwUtil.makeETag(rp.revision, tid);
-                return self.wrapContentReq(restbase, req, P.resolve(resp), format, tid);
+                return self.wrapContentReq(hs, req, P.resolve(resp), format, tid);
             });
         } else {
             return res;
@@ -422,7 +422,7 @@ PSP.generateAndSave = function(restbase, req, format, currentContentRes) {
 };
 
 // Get / check the revision metadata for a request
-PSP.getRevisionInfo = function(restbase, req) {
+PSP.getRevisionInfo = function(hs, req) {
     var rp = req.params;
     var path = [rp.domain, 'sys', 'page_revisions', 'page',
                     mwUtil.normalizeTitle(rp.title)];
@@ -432,7 +432,7 @@ PSP.getRevisionInfo = function(restbase, req) {
         throw new Error("Invalid revision: " + rp.revision);
     }
 
-    return restbase.get({
+    return hs.get({
         uri: new URI(path),
         headers: {
             'cache-control': req.headers && req.headers['cache-control']
@@ -466,23 +466,23 @@ PSP._okayToRerender = function(req) {
     return true;
 };
 
-PSP.getFormat = function(format, restbase, req) {
+PSP.getFormat = function(format, hs, req) {
     var self = this;
     var rp = req.params;
     rp.title = mwUtil.normalizeTitle(rp.title);
 
     function generateContent(storageRes) {
         if (storageRes.status === 404 || storageRes.status === 200) {
-            var revInfoPromise = self.getRevisionInfo(restbase, req)
+            var revInfoPromise = self.getRevisionInfo(hs, req)
             .then(function(revInfo) {
                 rp.revision = revInfo.rev + '';
                 if (revInfo.title !== rp.title) {
                     // Re-try to retrieve from storage with the
                     // normalized title & revision
                     rp.title = revInfo.title;
-                    return self.getFormat(format, restbase, req);
+                    return self.getFormat(format, hs, req);
                 } else {
-                    return self.generateAndSave(restbase, req, format, storageRes);
+                    return self.generateAndSave(hs, req, format, storageRes);
                 }
             });
             if (self.purgeOnUpdate) {
@@ -500,7 +500,7 @@ PSP.getFormat = function(format, restbase, req) {
 
     if (!self._okayToRerender(req)) {
         // Still update the revision metadata.
-        return self.getRevisionInfo(restbase, req)
+        return self.getRevisionInfo(hs, req)
         .then(function() {
             throw new HTTPError({
                 status: 403,
@@ -512,7 +512,7 @@ PSP.getFormat = function(format, restbase, req) {
         });
     }
 
-    var contentReq = restbase.get({
+    var contentReq = hs.get({
         uri: self.getBucketURI(rp, format, rp.tid)
     });
 
@@ -534,10 +534,10 @@ PSP.getFormat = function(format, restbase, req) {
             generateContent);
     } else {
         // Only (possibly) generate content if there was an error
-        contentReq = self.wrapContentReq(restbase, req, contentReq, format)
+        contentReq = self.wrapContentReq(hs, req, contentReq, format)
         .catch(generateContent)
         .then(function(res) {
-            return self._wrapInAccessCheck(restbase, req, P.resolve(res));
+            return self._wrapInAccessCheck(hs, req, P.resolve(res));
         });
     }
     return contentReq
@@ -551,27 +551,27 @@ PSP.getFormat = function(format, restbase, req) {
     });
 };
 
-PSP.listRevisions = function(format, restbase, req) {
+PSP.listRevisions = function(format, hs, req) {
     var self = this;
     var rp = req.params;
     var revReq = {
         uri: new URI([rp.domain, 'sys', 'key_rev_value', 'parsoid.' + format,
                         mwUtil.normalizeTitle(rp.title), '']),
         body: {
-            limit: restbase.rb_config.default_page_size
+            limit: hs.config.default_page_size
         }
     };
 
     if (req.query.page) {
-        revReq.body.next = restbase.decodeToken(req.query.page);
+        revReq.body.next = hs.decodeToken(req.query.page);
     }
 
-    return restbase.get(revReq)
+    return hs.get(revReq)
     .then(function(res) {
         if (res.body.next) {
             res.body._links = {
                 next: {
-                    href: "?page=" + restbase.encodeToken(res.body.next)
+                    href: "?page=" + hs.encodeToken(res.body.next)
                 }
             };
         }
@@ -579,7 +579,7 @@ PSP.listRevisions = function(format, restbase, req) {
     });
 };
 
-PSP._getOriginalContent = function(restbase, req, revision, tid) {
+PSP._getOriginalContent = function(hs, req, revision, tid) {
     var rp = req.params;
 
     function get(format) {
@@ -589,7 +589,7 @@ PSP._getOriginalContent = function(restbase, req, revision, tid) {
             path.push(tid);
         }
 
-        return restbase.get({
+        return hs.get({
             uri: new URI(path)
         })
         .then(function(res) {
@@ -616,13 +616,13 @@ PSP._getOriginalContent = function(restbase, req, revision, tid) {
 
 };
 
-PSP._getStashedContent = function(restbase, req, etag) {
+PSP._getStashedContent = function(hs, req, etag) {
     var self = this;
     var rp = req.params;
 
     rp.title = mwUtil.normalizeTitle(rp.title);
     function getStash(format) {
-        return restbase.get({
+        return hs.get({
             uri: self.getBucketURI(rp, 'stash.' + format, etag.tid)
         }).then(function(fRes) {
             if (fRes.body && Buffer.isBuffer(fRes.body)) {
@@ -695,7 +695,7 @@ function parseSections(req) {
 }
 
 
-PSP.transformRevision = function(restbase, req, from, to) {
+PSP.transformRevision = function(hs, req, from, to) {
     var self = this;
     var rp = req.params;
 
@@ -723,9 +723,9 @@ PSP.transformRevision = function(restbase, req, from, to) {
 
     var contentPromise;
     if (etag && etag.suffix === 'stash' && from === 'html' && to === 'wikitext') {
-        contentPromise = this._getStashedContent(restbase, req, etag);
+        contentPromise = this._getStashedContent(hs, req, etag);
     } else {
-        contentPromise = this._getOriginalContent(restbase, req, rp.revision, tid);
+        contentPromise = this._getOriginalContent(hs, req, rp.revision, tid);
     }
     return contentPromise.then(function(original) {
         // Check if parsoid metadata is present as it's required by parsoid.
@@ -782,12 +782,12 @@ PSP.transformRevision = function(restbase, req, from, to) {
             },
             body: body2
         };
-        return self.callParsoidTransform(restbase, newReq, from, to);
+        return self.callParsoidTransform(hs, newReq, from, to);
     });
 
 };
 
-PSP.stashTransform = function(restbase, req, transformPromise) {
+PSP.stashTransform = function(hs, req, transformPromise) {
     // A stash has been requested. We need to store the wikitext sent by
     // the client together with the page bundle returned by Parsoid, so it
     // can be later reused when transforming back from HTML to wikitext
@@ -800,12 +800,12 @@ PSP.stashTransform = function(restbase, req, transformPromise) {
         // Save the returned data-parsoid for the transform and
         // the wikitext sent by the client
         return P.all([
-            restbase.put({
+            hs.put({
                 uri: self.getBucketURI(rp, 'stash.data-parsoid', tid),
                 headers: original.body['data-parsoid'].headers,
                 body: original.body['data-parsoid'].body
             }),
-            restbase.put({
+            hs.put({
                 uri: self.getBucketURI(rp, 'stash.wikitext', tid),
                 headers: { 'content-type': wtType },
                 body: req.body.wikitext
@@ -814,7 +814,7 @@ PSP.stashTransform = function(restbase, req, transformPromise) {
         // Save HTML last, so that any error in metadata storage suppresses
         // HTML.
         .then(function() {
-            return restbase.put({
+            return hs.put({
                 uri: self.getBucketURI(rp, 'stash.html', tid),
                 headers: original.body.html.headers,
                 body: original.body.html.body
@@ -828,7 +828,7 @@ PSP.stashTransform = function(restbase, req, transformPromise) {
     });
 };
 
-PSP.callParsoidTransform = function callParsoidTransform(restbase, req, from, to) {
+PSP.callParsoidTransform = function callParsoidTransform(hs, req, from, to) {
     var rp = req.params;
     var parsoidTo = to;
     if (to === 'html') {
@@ -865,9 +865,9 @@ PSP.callParsoidTransform = function callParsoidTransform(restbase, req, from, to
         body: req.body
     };
 
-    var transformPromise = restbase.post(parsoidReq);
+    var transformPromise = hs.post(parsoidReq);
     if (req.body.stash && from === 'wikitext' && to === 'html') {
-        return this.stashTransform(restbase, req, transformPromise);
+        return this.stashTransform(hs, req, transformPromise);
     }
     return transformPromise;
 
@@ -891,7 +891,7 @@ function cheapBodyInnerHTML(html) {
 PSP.makeTransform = function(from, to) {
     var self = this;
 
-    return function(restbase, req) {
+    return function(hs, req) {
         var rp = req.params;
         if ((!req.body && req.body !== '')
                 || (!req.body[from] && req.body[from] !== '')) {
@@ -923,9 +923,9 @@ PSP.makeTransform = function(from, to) {
         var originalScrubWikitext = req.body.scrubWikitext;
         var transform;
         if (rp.revision && rp.revision !== '0') {
-            transform = self.transformRevision(restbase, req, from, to);
+            transform = self.transformRevision(hs, req, from, to);
         } else {
-            transform = self.callParsoidTransform(restbase, req, from, to);
+            transform = self.callParsoidTransform(hs, req, from, to);
         }
         return transform
         .catch(function(e) {
@@ -962,7 +962,7 @@ PSP.makeTransform = function(from, to) {
             if (originalScrubWikitext) {
                 self.log('warn/parsoid/scrubWikitext', {
                     msg: 'Client-supplied scrubWikitext flag encountered',
-                    req_headers: restbase._rootReq && restbase._rootReq.headers
+                    req_headers: hs._rootReq && hs._rootReq.headers
                 });
             }
             return res;

--- a/sys/post_data.js
+++ b/sys/post_data.js
@@ -16,9 +16,9 @@ function PostDataBucket(options) {
     this.log = options.log || function() {};
 }
 
-PostDataBucket.prototype.createBucket = function(hs, req) {
+PostDataBucket.prototype.createBucket = function(hyper, req) {
     var rp = req.params;
-    return hs.put({
+    return hyper.put({
         uri: new URI([rp.domain, 'sys', 'key_value', rp.bucket]),
         body: {
             keyType: 'string',
@@ -27,13 +27,13 @@ PostDataBucket.prototype.createBucket = function(hs, req) {
     });
 };
 
-PostDataBucket.prototype.getRevision = function(hs, req) {
+PostDataBucket.prototype.getRevision = function(hyper, req) {
     var rp = req.params;
     var path = [rp.domain, 'sys', 'key_value', rp.bucket, rp.key];
     if (rp.tid) {
         path.push(rp.tid);
     }
-    return hs.get({
+    return hyper.get({
         uri: new URI(path),
         headers: {
             'cache-control': req.headers && req.headers['cache-control']
@@ -47,12 +47,12 @@ function calculateHash(storedData) {
                  .digest('hex');
 }
 
-PostDataBucket.prototype.putRevision = function(hs, req) {
+PostDataBucket.prototype.putRevision = function(hyper, req) {
     var rp = req.params;
     var storedData = req.body || {};
     var key = calculateHash(storedData);
     req.params.key = key;
-    return this.getRevision(hs, req)
+    return this.getRevision(hyper, req)
     .then(function() {
         return {
             status: 200,
@@ -63,7 +63,7 @@ PostDataBucket.prototype.putRevision = function(hs, req) {
         };
     })
     .catch({ status: 404 }, function() {
-        return hs.put({
+        return hyper.put({
             uri: new URI([rp.domain, 'sys', 'key_value', rp.bucket, key]),
             headers: {
                 'content-type': 'application/json',

--- a/sys/post_data.js
+++ b/sys/post_data.js
@@ -16,9 +16,9 @@ function PostDataBucket(options) {
     this.log = options.log || function() {};
 }
 
-PostDataBucket.prototype.createBucket = function(restbase, req) {
+PostDataBucket.prototype.createBucket = function(hs, req) {
     var rp = req.params;
-    return restbase.put({
+    return hs.put({
         uri: new URI([rp.domain, 'sys', 'key_value', rp.bucket]),
         body: {
             keyType: 'string',
@@ -27,13 +27,13 @@ PostDataBucket.prototype.createBucket = function(restbase, req) {
     });
 };
 
-PostDataBucket.prototype.getRevision = function(restbase, req) {
+PostDataBucket.prototype.getRevision = function(hs, req) {
     var rp = req.params;
     var path = [rp.domain, 'sys', 'key_value', rp.bucket, rp.key];
     if (rp.tid) {
         path.push(rp.tid);
     }
-    return restbase.get({
+    return hs.get({
         uri: new URI(path),
         headers: {
             'cache-control': req.headers && req.headers['cache-control']
@@ -47,12 +47,12 @@ function calculateHash(storedData) {
                  .digest('hex');
 }
 
-PostDataBucket.prototype.putRevision = function(restbase, req) {
+PostDataBucket.prototype.putRevision = function(hs, req) {
     var rp = req.params;
     var storedData = req.body || {};
     var key = calculateHash(storedData);
     req.params.key = key;
-    return this.getRevision(restbase, req)
+    return this.getRevision(hs, req)
     .then(function() {
         return {
             status: 200,
@@ -63,7 +63,7 @@ PostDataBucket.prototype.putRevision = function(restbase, req) {
         };
     })
     .catch({ status: 404 }, function() {
-        return restbase.put({
+        return hs.put({
             uri: new URI([rp.domain, 'sys', 'key_value', rp.bucket, key]),
             headers: {
                 'content-type': 'application/json',

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -77,7 +77,7 @@ var nestedSecuritySpec = {
 
 var fullSpec = server.loadConfig('config.example.wikimedia.yaml');
 
-var fakeRestBase = { rb_config: {} };
+var fakeHyperswitch = { config: {} };
 
 describe('tree building', function() {
 
@@ -85,7 +85,7 @@ describe('tree building', function() {
 
     it('should build a simple spec tree', function() {
         var router = new Router();
-        return router.loadSpec(rootSpec, fakeRestBase)
+        return router.loadSpec(rootSpec, fakeHyperswitch)
         .then(function() {
             //console.log(JSON.stringify(router.tree, null, 2));
             var handler = router.route('/en.wikipedia.org/v1/page/html/Foo');
@@ -103,7 +103,7 @@ describe('tree building', function() {
             request: function(req) {
                 resourceRequests.push(req);
             },
-            rb_config: {},
+            config: {},
         })
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/html/Foo');

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -77,7 +77,7 @@ var nestedSecuritySpec = {
 
 var fullSpec = server.loadConfig('config.example.wikimedia.yaml');
 
-var fakeHyperswitch = { config: {} };
+var fakeHyperSwitch = { config: {} };
 
 describe('tree building', function() {
 
@@ -85,7 +85,7 @@ describe('tree building', function() {
 
     it('should build a simple spec tree', function() {
         var router = new Router();
-        return router.loadSpec(rootSpec, fakeHyperswitch)
+        return router.loadSpec(rootSpec, fakeHyperSwitch)
         .then(function() {
             //console.log(JSON.stringify(router.tree, null, 2));
             var handler = router.route('/en.wikipedia.org/v1/page/html/Foo');

--- a/test/framework/handlerTemplate/test_config.yaml
+++ b/test/framework/handlerTemplate/test_config.yaml
@@ -82,7 +82,7 @@ spec_root: &spec_root
 
 # Finally, a standard service-runner config.
 info:
-  name: restbase
+  name: hyperswitch
 
 services:
   - name: test_service
@@ -92,5 +92,5 @@ services:
       spec: *spec_root
       salt: secret
       default_page_size: 1
-      user_agent: RESTBase-testsuite
+      user_agent: HyperSwitch-testsuite
 

--- a/test/framework/router/buildTree.js
+++ b/test/framework/router/buildTree.js
@@ -8,7 +8,7 @@ var assert = require('../utils/assert');
 var fs     = require('fs');
 var yaml   = require('js-yaml');
 
-var fakeRestBase = { rb_config: {} };
+var fakeHyperswitch = { config: {} };
 
 // x-subspec and x-subspecs is no longer supported.
 var faultySpec = {
@@ -78,7 +78,7 @@ describe('Router', function() {
 
     it('should fail loading a faulty spec', function() {
         var router = new Router();
-        return router.loadSpec(faultySpec, fakeRestBase)
+        return router.loadSpec(faultySpec, fakeHyperswitch)
         .then(function() {
             throw new Error("Should throw an exception!");
         },
@@ -90,7 +90,7 @@ describe('Router', function() {
 
     it('should allow adding methods to existing paths', function() {
         var router = new Router();
-        return router.loadSpec(additionalMethodSpec, fakeRestBase)
+        return router.loadSpec(additionalMethodSpec, fakeHyperswitch)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/Foo/html');
             assert.deepEqual(!!handler.value.methods.get, true);
@@ -100,7 +100,7 @@ describe('Router', function() {
 
     it('should error on overlapping methods on the same path', function() {
         var router = new Router();
-        return router.loadSpec(overlappingMethodSpec, fakeRestBase)
+        return router.loadSpec(overlappingMethodSpec, fakeHyperswitch)
         .then(function() {
             throw new Error("Should throw an exception!");
         },
@@ -111,7 +111,7 @@ describe('Router', function() {
 
     it('should pass permission along the path to endpoint', function() {
         var router = new Router();
-        return router.loadSpec(nestedSecuritySpec, fakeRestBase)
+        return router.loadSpec(nestedSecuritySpec, fakeHyperswitch)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/secure');
             assert.deepEqual(handler.permissions, [
@@ -124,7 +124,7 @@ describe('Router', function() {
     });
     it('should fail when no handler found for method', function() {
         var router = new Router();
-        return router.loadSpec(noHandlerSpec, fakeRestBase)
+        return router.loadSpec(noHandlerSpec, fakeHyperswitch)
         .then(function() {
             throw new Error("Should throw an exception!");
         },
@@ -137,7 +137,7 @@ describe('Router', function() {
     it('should not modify top-level spec-root', function() {
         var spec = yaml.safeLoad(fs.readFileSync(__dirname + '/multi_domain_spec.yaml'));
         var router = new Router();
-        return router.loadSpec(spec, fakeRestBase)
+        return router.loadSpec(spec, fakeHyperswitch)
         .then(function() {
             var node = router.route('/test2');
             assert.deepEqual(node.value.path, '/test2');

--- a/test/framework/router/buildTree.js
+++ b/test/framework/router/buildTree.js
@@ -8,7 +8,7 @@ var assert = require('../utils/assert');
 var fs     = require('fs');
 var yaml   = require('js-yaml');
 
-var fakeHyperswitch = { config: {} };
+var fakeHyperSwitch = { config: {} };
 
 // x-subspec and x-subspecs is no longer supported.
 var faultySpec = {
@@ -78,7 +78,7 @@ describe('Router', function() {
 
     it('should fail loading a faulty spec', function() {
         var router = new Router();
-        return router.loadSpec(faultySpec, fakeHyperswitch)
+        return router.loadSpec(faultySpec, fakeHyperSwitch)
         .then(function() {
             throw new Error("Should throw an exception!");
         },
@@ -90,7 +90,7 @@ describe('Router', function() {
 
     it('should allow adding methods to existing paths', function() {
         var router = new Router();
-        return router.loadSpec(additionalMethodSpec, fakeHyperswitch)
+        return router.loadSpec(additionalMethodSpec, fakeHyperSwitch)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/Foo/html');
             assert.deepEqual(!!handler.value.methods.get, true);
@@ -100,7 +100,7 @@ describe('Router', function() {
 
     it('should error on overlapping methods on the same path', function() {
         var router = new Router();
-        return router.loadSpec(overlappingMethodSpec, fakeHyperswitch)
+        return router.loadSpec(overlappingMethodSpec, fakeHyperSwitch)
         .then(function() {
             throw new Error("Should throw an exception!");
         },
@@ -111,7 +111,7 @@ describe('Router', function() {
 
     it('should pass permission along the path to endpoint', function() {
         var router = new Router();
-        return router.loadSpec(nestedSecuritySpec, fakeHyperswitch)
+        return router.loadSpec(nestedSecuritySpec, fakeHyperSwitch)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/secure');
             assert.deepEqual(handler.permissions, [
@@ -124,7 +124,7 @@ describe('Router', function() {
     });
     it('should fail when no handler found for method', function() {
         var router = new Router();
-        return router.loadSpec(noHandlerSpec, fakeHyperswitch)
+        return router.loadSpec(noHandlerSpec, fakeHyperSwitch)
         .then(function() {
             throw new Error("Should throw an exception!");
         },
@@ -137,7 +137,7 @@ describe('Router', function() {
     it('should not modify top-level spec-root', function() {
         var spec = yaml.safeLoad(fs.readFileSync(__dirname + '/multi_domain_spec.yaml'));
         var router = new Router();
-        return router.loadSpec(spec, fakeHyperswitch)
+        return router.loadSpec(spec, fakeHyperSwitch)
         .then(function() {
             var node = router.route('/test2');
             assert.deepEqual(node.value.path, '/test2');

--- a/test/framework/streaming/stream_module.js
+++ b/test/framework/streaming/stream_module.js
@@ -2,7 +2,7 @@
 
 var stream = require('stream');
 
-function hello(restbase, req) {
+function hello(hs, req) {
     var body = new stream.PassThrough();
     body.end('hello');
     return {
@@ -14,7 +14,7 @@ function hello(restbase, req) {
     };
 }
 
-function buffer(restbase, req) {
+function buffer(hs, req) {
     var body = new stream.PassThrough();
     body.write(new Buffer('hel'));
     // Delay the final write to test async production.
@@ -31,7 +31,7 @@ function buffer(restbase, req) {
     };
 }
 
-function chunks(restbase, req) {
+function chunks(hs, req) {
     var body = new stream.PassThrough();
     for (var i = 0; i < 100; i++) {
         body.write(i.toString());

--- a/test/framework/streaming/stream_module.js
+++ b/test/framework/streaming/stream_module.js
@@ -2,7 +2,7 @@
 
 var stream = require('stream');
 
-function hello(hs, req) {
+function hello(hyper, req) {
     var body = new stream.PassThrough();
     body.end('hello');
     return {
@@ -14,7 +14,7 @@ function hello(hs, req) {
     };
 }
 
-function buffer(hs, req) {
+function buffer(hyper, req) {
     var body = new stream.PassThrough();
     body.write(new Buffer('hel'));
     // Delay the final write to test async production.
@@ -31,7 +31,7 @@ function buffer(hs, req) {
     };
 }
 
-function chunks(hs, req) {
+function chunks(hyper, req) {
     var body = new stream.PassThrough();
     for (var i = 0; i < 100; i++) {
         body.write(i.toString());

--- a/test/framework/streaming/test_config.yaml
+++ b/test/framework/streaming/test_config.yaml
@@ -7,7 +7,7 @@ spec_root: &spec_root
 
 # Finally, a standard service-runner config.
 info:
-  name: restbase
+  name: hyperswitch
 
 services:
   - name: test_service
@@ -17,5 +17,5 @@ services:
       spec: *spec_root
       salt: secret
       default_page_size: 1
-      user_agent: RESTBase-testsuite
+      user_agent: Hyperswitch-testsuite
 

--- a/test/framework/streaming/test_config.yaml
+++ b/test/framework/streaming/test_config.yaml
@@ -17,5 +17,5 @@ services:
       spec: *spec_root
       salt: secret
       default_page_size: 1
-      user_agent: Hyperswitch-testsuite
+      user_agent: HyperSwitch-testsuite
 

--- a/test/framework/utils/server.js
+++ b/test/framework/utils/server.js
@@ -10,7 +10,7 @@ var Server = function(configPath) {
     this._config = this._loadConfig();
     this._config.num_workers = 0;
     this._config.logging = {
-        name: 'restbase-tests',
+        name: 'hyperswitch-tests',
         level: 'fatal',
         streams: [{ type: 'stdout'}]
     };


### PR DESCRIPTION
Just renaming `RESTBase` to `HyperSwitch` everywhere it's needed. 