### PR TITLE
Mathoid: Open the POST end point to the public

### DIFF
--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -43,11 +43,6 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
-      security:
-        - header_match:
-            - header: 'x-client-ip'
-              patterns:
-                - internal
       x-monitor: true
       x-amples:
         - title: Mathoid - check test formula


### PR DESCRIPTION
We have changed the POST end point to execute only tex check and sanitisation, which addresses security concern about it. Consequently, open it up to the public.

Bug: [T116147](https://phabricator.wikimedia.org/T116147)