### PR TITLE
Projects: Add SQLite variants

### DIFF
--- a/projects/wikimedia.org_sqlite.yaml
+++ b/projects/wikimedia.org_sqlite.yaml
@@ -1,0 +1,70 @@
+paths:
+  /{api:v1}: &default_project_paths_v1
+    # swagger options, overriding the shared ones from the merged specs (?)
+    info:
+      version: 1.0.0-beta
+      title: Wikimedia REST API
+      description: >
+          This API aims to provide coherent and low-latency access to
+          Wikimedia content and services. It is currently in beta testing, so
+          things aren't completely locked down yet. Each entry point has
+          explicit stability markers to inform you about development status
+          and change policy, according to [our API version
+          policy](https://www.mediawiki.org/wiki/API_versioning).
+
+          ### High-volume access
+            - Don't perform more than 500 requests/s to this API.
+            - Set a unique `User-Agent` header that allows us to contact you
+              quickly. Email addresses or URLs of contact pages work well.
+
+      termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+      contact:
+        name: the Wikimedia Services team
+        url: http://mediawiki.org/wiki/RESTBase
+      license:
+        name: Apache2
+        url: http://www.apache.org/licenses/LICENSE-2.0
+
+    securityDefinitions: &wp/content-security/1.0.0
+      mediawiki_auth:
+        description: Checks permissions using MW api
+        type: apiKey
+        in: header
+        name: cookie
+        x-internal-request-whitelist:
+          - /http:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
+          - http://parsoid-lb.eqiad.wikimedia.org
+      header_match:
+        description: Checks client ip against one of the predefined whitelists
+        x-error-message: This client is not allowed to use the endpoint
+        x-whitelists:
+          internal:
+            - /^(?:::ffff:)?(?:10|127)\./
+        x-is-api: true
+    # Override the base path for host-based (proxied) requests. In our case,
+    # we proxy https://{domain}/api/rest_v1/ to the API.
+    x-host-basePath: /api/rest_v1
+
+    x-modules:
+      /media:
+        - path: v1/mathoid.yaml
+          options: '{{options.mathoid}}'
+      /metrics:
+        - path: v1/pageviews.yaml
+
+  /{api:sys}:
+    x-modules:
+      /table:
+        - type: npm
+          name: restbase-mod-table-sqlite
+          options:
+            conf: '{{options.table}}'
+      /key_value:
+        - path: sys/key_value.js
+      /key_rev_value:
+        - path: sys/key_rev_value.js
+      /post_data: &sys_post_data
+        - path: sys/post_data.js
+      /pageviews:
+        - path: sys/pageviews_proxy.yaml
+          options: '{{options.pageviews}}'

--- a/projects/wmf_sqlite.yaml
+++ b/projects/wmf_sqlite.yaml
@@ -1,0 +1,128 @@
+paths:
+  /{api:v1}: &default_project_paths_v1
+    # swagger options, overriding the shared ones from the merged specs (?)
+    info:
+      version: 1.0.0-beta
+      title: Wikimedia REST API
+      description: >
+          This API aims to provide coherent and low-latency access to
+          Wikimedia content and services. It is currently in beta testing, so
+          things aren't completely locked down yet. Each entry point has
+          explicit stability markers to inform you about development status
+          and change policy, according to [our API version
+          policy](https://www.mediawiki.org/wiki/API_versioning).
+
+          ### High-volume access
+            - Don't perform more than 200 requests/s to this API.
+            - Set a unique `User-Agent` header that allows us to contact you
+              quickly. Email addresses or URLs of contact pages work well.
+
+      termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+      contact:
+        name: the Wikimedia Services team
+        url: http://mediawiki.org/wiki/RESTBase
+      license:
+        name: Apache2
+        url: http://www.apache.org/licenses/LICENSE-2.0
+
+    securityDefinitions: &wp/content-security/1.0.0
+      mediawiki_auth:
+        description: Checks permissions using MW api
+        type: apiKey
+        in: header
+        name: cookie
+        x-internal-request-whitelist:
+          - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
+          - http://parsoid-lb.eqiad.wikimedia.org
+          - http://parsoid-beta.wmflabs.org
+      header_match:
+        description: Checks client ip against one of the predefined whitelists
+        x-error-message: This client is not allowed to use the endpoint
+        x-whitelists:
+          internal:
+            - /^(?:::ffff:)?(?:10|127)\./
+        x-is-api: true
+    # Override the base path for host-based (proxied) requests. In our case,
+    # we proxy https://{domain}/api/rest_v1/ to the API.
+    x-host-basePath: /api/rest_v1
+
+    x-modules: &default_project_paths_v1_modules
+      /: 
+        # The main content module, defining page/* and transform entry
+        # points.
+        - path: v1/content.yaml
+      /page:
+        - path: v1/mobileapps.yaml
+          options: '{{options.mobileapps}}'
+        - path: v1/graphoid.yaml
+          options: '{{options.graphoid}}'
+        - path: v1/summary.js
+          options:
+            response_cache-control: 'max-age: 3600, s-maxage: 3600'
+      /media:
+        - path: v1/mathoid.yaml
+          options: '{{options.mathoid}}'
+
+  /{api:sys}: &default_project_paths_sys
+    x-modules: &default_project_paths_sys_modules
+      /table: &sys_table
+        - type: npm
+          name: restbase-mod-table-sqlite
+          options:
+            conf: '{{options.table}}'
+      /key_value: &sys_key_value
+        - path: sys/key_value.js
+      /key_rev_value:
+        - path: sys/key_rev_value.js
+      /page_revisions:
+        - path: sys/page_revisions.js
+      /post_data: &sys_post_data
+        - path: sys/post_data.js
+      /action:
+        - path: sys/action.js
+          options: "{{options.action}}"
+      /page_save:
+        - path: sys/page_save.js
+      /parsoid:
+        - path: sys/parsoid.js
+          options:
+            parsoidHost: '{{options.parsoid.host}}'
+            # To enable mobileApps purging - add these to the config.
+            # (TODO: remove after actual purging is implemented
+            #purge:
+            #  host: '239.128.0.112'
+            #  port: 4827
+
+            # A list of pages that we don't currently want to re-render on
+            # each edit. Most of these are huge bot-edited pages, which are
+            # rarely viewed in any case. 
+            rerenderBlacklist:
+              www.wikidata.org:
+                Q21558717: true
+                Q21505108: true
+                Q21481867: true
+                Q21521425: true
+              en.wikipedia.org:
+                Wikipedia:Administrators'_noticeboard/Incidents: true
+                User:JamesR/AdminStats: true
+                User:Kudpung/Dashboard: true
+                # Various dashboards
+                User:Breawycker/Wikipedia: true
+                User:Sonia/dashboard: true
+                User:Ocaasi/dashboard: true
+                User:Nolelover: true
+                User:Calmer_Waters: true
+                User:Technical_13/dashboard: true
+              ur.wikipedia.org:
+                نام_مقامات_ایل: true
+                نام_مقامات_ڈی: true
+                نام_مقامات_جے: true
+                نام_مقامات_جی: true
+                نام_مقامات_ایچ: true
+                نام_مقامات_ایم: true
+                نام_مقامات_ایس: true
+              commons.wikipedia.org:
+                Commons:Quality_images_candidates/candidate_list: true
+      /mobileapps:
+        - path: sys/mobileapps.yaml
+          options: '{{options.mobileapps}}'


### PR DESCRIPTION
There is currently no way to tell RB which table back-end to use via the config, so do an ugly copy of the project YAML files and make them use the restbase-mod-table-sqlite back-end.

Amongst other things, we need this in order to support MW-Vagrant installs.