### PR TITLE
Add x-textarea hints for wikitext / html transforms

### DIFF
--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -924,6 +924,7 @@ paths:
           description: The HTML to transform
           type: string
           required: true
+          x-textarea: true
         - name: scrub_wikitext
           in: formData
           description: Normalise the DOM to yield cleaner wikitext?
@@ -998,6 +999,7 @@ paths:
           description: The Wikitext to transform to HTML
           type: string
           required: true
+          x-textarea: true
         - name: body_only
           in: formData
           description: Return only `body.innerHTML`
@@ -1083,6 +1085,7 @@ paths:
           description: The HTML to transform
           type: string
           required: true
+          x-textarea: true
         - name: body_only
           in: formData
           description: Return only `body.innerHTML`


### PR DESCRIPTION
This patch sets the x-textarea flags introduced in
https://github.com/wikimedia/swagger-ui/pull/3 for wikitext / html
transform parameters in order to support multi-line input.

Task: https://phabricator.wikimedia.org/T110712