### PR TITLE
Logging: Use child request-aware logger whenever possible

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -137,7 +137,6 @@ function handleResponse(opts, req, resp, response) {
         }
         opts.log(logLevel, {
             message: response.message,
-            root_req: req,
             res: response,
             stack: response.stack
         });
@@ -232,7 +231,6 @@ function handleResponse(opts, req, resp, response) {
         } else {
             if (response.headers['content-length']) {
                 opts.log('warn/response/content-length', {
-                    root_req: req,
                     res: response,
                     reason: new Error('Invalid content-length')
                 });

--- a/sys/key_rev_value.js
+++ b/sys/key_rev_value.js
@@ -19,7 +19,6 @@ var backend;
 var config;
 
 function KRVBucket(options) {
-    this.log = options.log || function() {};
 }
 
 KRVBucket.prototype.getBucketInfo = function(hyper, req, options) {
@@ -120,7 +119,7 @@ KRVBucket.prototype.listBucket = function(hyper, req, options) {
         };
     })
     .catch(function(error) {
-        self.log('error/kv/listBucket', error);
+        hyper.log('error/kv/listBucket', error);
         throw new HTTPError({ status: 404 });
     });
 };

--- a/sys/key_value.js
+++ b/sys/key_value.js
@@ -16,7 +16,6 @@ var fs = require('fs');
 var spec = yaml.safeLoad(fs.readFileSync(__dirname + '/key_value.yaml'));
 
 function KVBucket(options) {
-    this.log = options.log || function() {};
 }
 
 KVBucket.prototype.getBucketInfo = function(hyper, req, options) {
@@ -118,7 +117,7 @@ KVBucket.prototype.listBucket = function(hyper, req, options) {
         };
     })
     .catch(function(error) {
-        self.log('error/kv/listBucket', error);
+        hyper.log('error/kv/listBucket', error);
         throw new HTTPError({ status: 404 });
     });
 };

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -26,7 +26,6 @@ var spec = yaml.safeLoad(fs.readFileSync(__dirname + '/page_revisions.yaml'));
 // Title Revision Service
 function PRS(options) {
     this.options = options;
-    this.log = options.log || function() {};
 }
 
 

--- a/sys/page_save.js
+++ b/sys/page_save.js
@@ -16,7 +16,6 @@ var TimeUuid = require('cassandra-uuid').TimeUuid;
 
 function PageSave(options) {
     var self = this;
-    this.log = options.log || function() {};
     this.spec = {
         paths: {
             '/wikitext/{title}': {

--- a/sys/pageviews.js
+++ b/sys/pageviews.js
@@ -18,7 +18,6 @@ var HTTPError = require('../lib/exports').HTTPError;
 // Pageviews Service
 function PJVS(options) {
     this.options = options;
-    this.log = options.log || function() {};
 }
 
 

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -111,7 +111,6 @@ function ensureCharsetInContentType(res) {
 function ParsoidService(options) {
     var self = this;
     this.options = options = options || {};
-    this.log = options.log || function() {};
     this.parsoidHost = options.parsoidHost;
 
     // THIS IS EXPERIMENTAL AND ADDED FOR TESTING PURPOSE!
@@ -199,7 +198,7 @@ PSP._dependenciesUpdate = function(hyper, req) {
     }
     summaryPromise = summaryPromise.catch(function(e) {
         if (e.status !== 501 && e.status !== 404) {
-            self.log('error/' + rp.domain.indexOf('wiktionary') < 0 ?
+            hyper.log('error/' + rp.domain.indexOf('wiktionary') < 0 ?
             'summary' : 'definition', e);
         }
     });
@@ -209,7 +208,7 @@ PSP._dependenciesUpdate = function(hyper, req) {
             uri: new URI([rp.domain, 'sys', 'mobileapps', 'v1',
                 'handling', 'content', 'mobile-sections', 'no-cache', rp.title])
         }).catch(function(e) {
-            self.log('warn/mobileapps', e);
+            hyper.log('warn/mobileapps', e);
         })
     );
 };
@@ -960,9 +959,8 @@ PSP.makeTransform = function(from, to) {
             delete res.headers['content-length'];
             // Log remaining scrubWikitext flag uses / users before removing it from the API
             if (originalScrubWikitext) {
-                self.log('warn/parsoid/scrubWikitext', {
-                    msg: 'Client-supplied scrubWikitext flag encountered',
-                    req_headers: hyper._rootReq && hyper._rootReq.headers
+                hyper.log('warn/parsoid/scrubWikitext', {
+                    msg: 'Client-supplied scrubWikitext flag encountered'
                 });
             }
             return res;

--- a/sys/post_data.js
+++ b/sys/post_data.js
@@ -13,7 +13,6 @@ var stringify = require('json-stable-stringify');
 var URI = require('swagger-router').URI;
 
 function PostDataBucket(options) {
-    this.log = options.log || function() {};
 }
 
 PostDataBucket.prototype.createBucket = function(hyper, req) {


### PR DESCRIPTION
Right now we provide a logger to modules via constructor options. However, that's actually wrong: modules a singletons, so we're actually providing the root logger, that doesn't have all the useful data about the request we put to the child loggers. Instead, we need to use a logger exposed by a `hyper` instance, provided to the handler. This instance always uses a child, request-aware logger.

This is a WIP to discuss the approach actually. I think we need to stop providing modules the root logger in options completely, so that there's no ambiguity. But in order to achieve that, I need to update storage modules to use a logger from `hyper` object, not the one from options. 

@gwicke @d00rman @eevans What do you think? Should I proceed here?