### PR TITLE
Load modules relative to the app base path

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -52,24 +52,6 @@ function Router(options) {
     this.router = new SwaggerRouter();
 }
 
-// Load & parse a yaml spec from disk
-Router.prototype._readSpec = function(path) {
-    var fsPath = __dirname + '/../';
-    if (/^\//.test(path)) {
-        // absolute path
-        fsPath = path;
-    } else if (/\.yaml$/.test(path)) {
-        fsPath += path;
-    } else {
-        fsPath += 'specs/' + path + '.yaml';
-    }
-    // Let errors bubble up for now. Fail loud & early.
-    return fs.readFileAsync(fsPath)
-    .then(function(yamlString) {
-        return yaml.safeLoad(yamlString);
-    });
-};
-
 // Extend an existing route tree with a new path by walking the existing tree
 // and inserting new subtrees at the desired location.
 Router.prototype._buildPath = function route(node, path, value) {
@@ -126,17 +108,11 @@ Router.prototype._loadModule = function(modDef, globals) {
             if (modDef.path && /^\//.test(modDef.path)) {
                 // Absolute path
                 loadPath = modDef.path;
-            } else {
+            } else if (modDef.path) {
                 // Relative path or missing
-                loadPath = __dirname + '/../';
-                if (modDef.path) {
-                    // The path has been provided, use it
-                    loadPath += modDef.path;
-                } else {
-                    // No path given, so assume the file name matches the
-                    // module name & the default 'mods' dir is used.
-                    loadPath += 'mods/' + modDef.name;
-                }
+                loadPath = this._options.appBasePath + '/' + modDef.path;
+            } else {
+                throw new Error('Unknown module path');
             }
             break;
         case 'npm':
@@ -562,21 +538,12 @@ Router.prototype.handleResources = function(hyper) {
 Router.prototype.loadSpec = function(spec, hyper) {
     var self = this;
     var rootNode = new Node();
-    var specPromise;
-    if (spec && spec.constructor === String) {
-        specPromise = this._readSpec(spec);
-    } else {
-        specPromise = P.resolve(spec);
-    }
-    return specPromise
-    .then(function(spec) {
-        var scope = new ApiScope({
-            globals: {
-                options: hyper.config,
-            }
-        });
-        return self._handleSwaggerSpec(rootNode, spec, scope);
-    })
+    var scope = new ApiScope({
+        globals: {
+            options: hyper.config
+        }
+    });
+    return self._handleSwaggerSpec(rootNode, spec, scope)
     .then(function() {
         // Only set the tree after loading everything
         // console.log(JSON.stringify(rootNode, null, 2));

--- a/lib/server.js
+++ b/lib/server.js
@@ -393,6 +393,7 @@ function main(options) {
     var conf = setupConfigDefaults(options.config);
     // Set up the global options object with a logger
     var opts = {
+        appBasePath: options.appBasePath,
         conf: conf,
         logger: options.logger,
         log: options.logger.log.bind(options.logger),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cassandra-uuid": "^0.0.2",
     "preq": "^0.4.8",
     "restbase-mod-table-cassandra": "^0.8.15",
-    "service-runner": "^1.0.0",
+    "service-runner": "^1.1.0",
     "swagger-router": "^0.3.4",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -20,61 +20,6 @@ var rootSpec = {
     }
 };
 
-// x-subspec and x-subspecs is no longer supported.
-var faultySpec = {
-    paths: {
-        '/{domain:en.wikipedia.org}': {
-            'x-subspecs': [],
-            'x-subspec': {}
-        }
-    }
-};
-
-var additionalMethodSpec = {
-    paths: {
-        '/{domain:en.wikipedia.org}/v1': {
-            'x-modules': {
-                '/': [{
-                    path: 'test/features/router/subspec1.yaml',
-                },
-                {
-                    path: 'test/features/router/subspec2.yaml',
-                }],
-            }
-        }
-    }
-};
-
-var overlappingMethodSpec = {
-    paths: {
-        '/{domain:en.wikipedia.org}/v1': {
-            'x-modules': {
-                '/': [{
-                    path: 'test/features/router/subspec1.yaml',
-                },
-                {
-                    path: 'test/features/router/subspec1.yaml',
-                }]
-            }
-        }
-    }
-};
-
-
-var nestedSecuritySpec = {
-    paths: {
-        '/{domain:en.wikipedia.org}/v1': {
-            'x-modules': {
-                '/': [{
-                    path: 'test/features/router/secure_subspec.yaml'
-                }],
-            },
-            security: ['first'],
-        }
-    }
-};
-
-
 var fullSpec = server.loadConfig('config.example.wikimedia.yaml');
 
 var fakeHyperSwitch = { config: {} };
@@ -84,7 +29,9 @@ describe('tree building', function() {
     before(function() { server.start(); });
 
     it('should build a simple spec tree', function() {
-        var router = new Router();
+        var router = new Router({
+            appBasePath: __dirname + '/../../..'
+        });
         return router.loadSpec(rootSpec, fakeHyperSwitch)
         .then(function() {
             //console.log(JSON.stringify(router.tree, null, 2));
@@ -97,7 +44,9 @@ describe('tree building', function() {
     });
 
     it('should build the example config spec tree', function() {
-        var router = new Router();
+        var router = new Router({
+            appBasePath: __dirname + '/../../..'
+        });
         var resourceRequests = [];
         return router.loadSpec(fullSpec.spec_root, {
             request: function(req) {

--- a/test/framework/router/buildTree.js
+++ b/test/framework/router/buildTree.js
@@ -77,7 +77,9 @@ var nestedSecuritySpec = {
 describe('Router', function() {
 
     it('should fail loading a faulty spec', function() {
-        var router = new Router();
+        var router = new Router({
+            appBasePath: __dirname + '/../../..'
+        });
         return router.loadSpec(faultySpec, fakeHyperSwitch)
         .then(function() {
             throw new Error("Should throw an exception!");
@@ -89,7 +91,9 @@ describe('Router', function() {
     });
 
     it('should allow adding methods to existing paths', function() {
-        var router = new Router();
+        var router = new Router({
+            appBasePath: __dirname + '/../../..'
+        });
         return router.loadSpec(additionalMethodSpec, fakeHyperSwitch)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/Foo/html');
@@ -99,7 +103,9 @@ describe('Router', function() {
     });
 
     it('should error on overlapping methods on the same path', function() {
-        var router = new Router();
+        var router = new Router({
+            appBasePath: __dirname + '/../../..'
+        });
         return router.loadSpec(overlappingMethodSpec, fakeHyperSwitch)
         .then(function() {
             throw new Error("Should throw an exception!");
@@ -110,7 +116,9 @@ describe('Router', function() {
     });
 
     it('should pass permission along the path to endpoint', function() {
-        var router = new Router();
+        var router = new Router({
+            appBasePath: __dirname + '/../../..'
+        });
         return router.loadSpec(nestedSecuritySpec, fakeHyperSwitch)
         .then(function() {
             var handler = router.route('/en.wikipedia.org/v1/page/secure');
@@ -123,7 +131,9 @@ describe('Router', function() {
         });
     });
     it('should fail when no handler found for method', function() {
-        var router = new Router();
+        var router = new Router({
+            appBasePath: __dirname + '/../../..'
+        });
         return router.loadSpec(noHandlerSpec, fakeHyperSwitch)
         .then(function() {
             throw new Error("Should throw an exception!");
@@ -136,7 +146,9 @@ describe('Router', function() {
 
     it('should not modify top-level spec-root', function() {
         var spec = yaml.safeLoad(fs.readFileSync(__dirname + '/multi_domain_spec.yaml'));
-        var router = new Router();
+        var router = new Router({
+            appBasePath: __dirname + '/../../..'
+        });
         return router.loadSpec(spec, fakeHyperSwitch)
         .then(function() {
             var node = router.route('/test2');


### PR DESCRIPTION
Currently in module/spec loading we rely on the fact that `router` is located in `/lib/router.js`. However, when we move lib directory to the framework, that will not be the case any more. To solve the problem we will get an appBasePath from service-runner and resolve everything from it.

Tests will not pass until https://github.com/wikimedia/service-runner/pull/80 is merged and published.