### PR TITLE
Tests: Added more framework tests

### DIFF
--- a/lib/handlerTemplate.js
+++ b/lib/handlerTemplate.js
@@ -7,6 +7,7 @@
 
 var P = require('bluebird');
 var Template = require('swagger-router').Template;
+var stringify = require('json-stable-stringify');
 
 /**
  * Creates a JS function that verifies property equality
@@ -16,8 +17,8 @@ var Template = require('swagger-router').Template;
  */
 function compileCatchFunction(catchDefinition) {
     function createCondition(catchCond, option) {
-        var opt = option.toString();
         if (catchCond === 'status') {
+            var opt = option.toString();
             if (/^[0-9]+$/.test(opt)) {
                 return '(res["' + catchCond + '"] === ' + opt + ')';
             } else if (/^[0-9x]+$/.test(opt)) {
@@ -28,7 +29,8 @@ function compileCatchFunction(catchDefinition) {
                 throw new Error('Invalid catch condition ' + opt);
             }
         } else {
-            return '(res["' + catchCond + '"] === ' + opt + ')';
+            return '(stringify(res["' + catchCond + '"]) === \''
+                        + stringify(option) + '\')';
         }
     }
 
@@ -46,7 +48,7 @@ function compileCatchFunction(catchDefinition) {
     });
     code = 'return (' + condition.join(' && ') + ');';
     /* jslint evil: true */
-    return new Function('res', code);
+    return new Function('stringify', 'res', code).bind(null, stringify);
 }
 
 /**

--- a/test/framework/handlerTemplate/test_config.yaml
+++ b/test/framework/handlerTemplate/test_config.yaml
@@ -79,6 +79,36 @@ spec_root: &spec_root
                 body: '{$.repeat_request.body}'
         x-monitor: false
 
+    /service/non_status_catch/{title}:
+      get:
+        x-request-handler:
+          - get_from_api:
+              request:
+                uri: http://mocked_domain_for_tests.com/{title}
+              return_if:
+                body:
+                  test: 'test'
+              return:
+                status: '{$.get_from_api.status}'
+                headers:
+                  'content-type': '{$.get_from_api.headers.content-type}'
+                body: '{$.get_from_api.body}'
+        x-monitor: false
+
+    /service/setup_test:
+      get:
+        x-setup-handler:
+          - set_something:
+              method: 'get'
+              uri: http://mocked_domain_for_tests.com/test
+              headers:
+                test: 'test_value'
+        x-request-handler:
+          - get_from_api:
+              return:
+                status: 200
+                body: 'result'
+        x-monitor: false
 
 # Finally, a standard service-runner config.
 info:

--- a/test/framework/hyperswitch/hyperswitch.js
+++ b/test/framework/hyperswitch/hyperswitch.js
@@ -1,0 +1,107 @@
+'use strict';
+
+var assert = require('../utils/assert.js');
+var Server = require('../utils/server.js');
+var preq   = require('preq');
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+describe('HyperSwitch context', function() {
+    var server = new Server('test/framework/hyperswitch/test_config.yaml');
+
+    before(function() {
+        return server.start();
+    });
+
+    it('Does not allow infinite recursion', function () {
+        return preq.get({ uri: server.hostPort + '/service/recursive/TestTitle' })
+        .then(function () {
+            throw new Error('Must not allow infinite recursion')
+        }, function(e) {
+            assert.deepEqual(e.status, 500);
+            assert.deepEqual(e.body.title, 'HyperSwitch request recursion depth exceeded.');
+        });
+    });
+
+    it('Supports head request', function () {
+        return preq.head({ uri: server.hostPort + '/service/head/TestTitle' })
+        .then(function (res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers.test, 'test');
+            assert.deepEqual(res.body, new Buffer(''));
+        });
+    });
+
+    it('Automatically hooks validation', function () {
+        return preq.get({ uri: server.hostPort + '/service/validation/abcde' })
+        .then(function () {
+            throw new Error('Should throw a validation error');
+        }, function(e) {
+            assert.deepEqual(e.status, 400);
+            assert.deepEqual(e.body.title, 'Invalid parameters');
+        });
+    });
+
+
+    it('Works fine if validation is passed', function () {
+        return preq.get({ uri: server.hostPort + '/service/validation/1' })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers.test, 'test');
+        });
+    });
+
+    it('Provides API listings', function () {
+        return preq.get({ uri: server.hostPort + '/service/' })
+        .then(function (res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-type'], 'application/json');
+            assert.notDeepEqual(res.body.items.indexOf('head'), -1);
+            assert.notDeepEqual(res.body.items.indexOf('recursive'), -1);
+            assert.notDeepEqual(res.body.items.indexOf('validation'), -1);
+        });
+    });
+
+    it('Throws 404 when no handler is found', function () {
+        return preq.get({ uri: server.hostPort + '/this_path_does_not_exist/' })
+        .then(function () {
+            throw new Error('404 should be thrown');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+            assert.deepEqual(e.headers['content-type'], 'application/problem+json');
+            assert.deepEqual(e.body, {
+                type: 'https://restbase.org/errors/not_found#route',
+                title: 'Not found.',
+                method: 'get',
+                uri: '/this_path_does_not_exist/'
+            });
+        });
+    });
+
+    it('Throws error when bad response is provided', function () {
+        return preq.get({ uri: server.hostPort + '/service/no_response' })
+        .then(function () {
+            throw new Error('400 should be thrown');
+        }, function(e) {
+            assert.deepEqual(e.status, 400);
+            assert.deepEqual(e.headers['content-type'], 'application/problem+json');
+            assert.deepEqual(e.body.uri, '/service/no_response');
+        });
+    });
+
+    it('Gzips content and provides correct content-length', function () {
+        return preq.get({
+            uri: server.hostPort + '/service/gzip_response',
+            headers: {
+                'accept-encoding': 'gzip'
+            }
+        })
+        .then(function (res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-length'], undefined);
+        });
+    });
+
+    after(function() { return server.stop(); });
+});

--- a/test/framework/hyperswitch/test_config.yaml
+++ b/test/framework/hyperswitch/test_config.yaml
@@ -1,0 +1,74 @@
+spec_root: &spec_root
+  title: "The test service spec root"
+  # Some more general RESTBase info
+  paths:
+    /service/recursive/{title}:
+      get:
+        x-request-handler:
+          - get_from_api:
+              request:
+                uri: /service/recursive/{title}
+        x-monitor: false
+
+    /service/head/{title}:
+      get:
+        x-request-handler:
+          - get_from_api:
+              return:
+                status: 200
+                headers:
+                  test: 'test'
+                body: 'some_body'
+        x-monitor: false
+
+    /service/validation/{number}:
+      get:
+        parameters:
+          - name: number
+            in: path
+            type: integer
+            required: true
+        x-request-handler:
+          - get_from_api:
+              return:
+                status: 200
+                headers:
+                  test: 'test'
+                body: 'some_body'
+        x-monitor: false
+
+    /service/no_response:
+      get:
+        x-request-handler:
+          - get_from_api:
+              return:
+                status: 400
+        x-monitor: false
+
+    /service/gzip_response:
+      get:
+        x-request-handler:
+          - get_from_api:
+              return:
+                status: 200
+                headers:
+                  content-type: text/plain
+                  content-length: 200
+                body: 'abcdef'
+        x-monitor: false
+
+
+# Finally, a standard service-runner config.
+info:
+  name: hyperswitch
+
+services:
+  - name: test_service
+    module: ./lib/server
+    conf:
+      port: 12345
+      spec: *spec_root
+      salt: secret
+      default_page_size: 1
+      user_agent: HyperSwitch-testsuite
+

--- a/test/framework/utils/assert.js
+++ b/test/framework/utils/assert.js
@@ -16,4 +16,15 @@ function deepEqual(result, expected, message) {
     }
 }
 
+function notDeepEqual(result, expected, message) {
+    try {
+        assert.notDeepEqual(result, expected, message);
+    } catch (e) {
+        console.log('Not expected:\n' + JSON.stringify(expected,null,2));
+        console.log('Result:\n' + JSON.stringify(result,null,2));
+        throw e;
+    }
+}
+
 module.exports.deepEqual = deepEqual;
+module.exports.notDeepEqual = notDeepEqual;


### PR DESCRIPTION
As a part of `HyperSwitch` work we need to improve framework code coverage by tests that are not related to `RESTBase`. This patch adds some more tests to the `framework` folder. 

Also, we've kinda supported catch matching in handlers not by status, but it didn't work. Now it's fixed.