### PR TITLE
Consistently use the child hyperswitch's logger / metrics reporter

### DIFF
--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -380,7 +380,7 @@ HyperSwitch.prototype._request = function(req, options) {
 
         reqHandlerPromise = childHyperSwitch._wrapInMetrics(reqHandlerPromise, match, req)
         .then(function(res) {
-            childHyperSwitch.log('trace', {
+            childHyperSwitch.log('trace/hyper/response', {
                 req: req,
                 res: res,
                 request_id: childHyperSwitch.reqId

--- a/lib/hyperswitch.js
+++ b/lib/hyperswitch.js
@@ -378,9 +378,9 @@ HyperSwitch.prototype._request = function(req, options) {
             reqHandlerPromise = P.try(handler, [childHyperSwitch, childReq]);
         }
 
-        reqHandlerPromise = self._wrapInMetrics(reqHandlerPromise, match, req)
+        reqHandlerPromise = childHyperSwitch._wrapInMetrics(reqHandlerPromise, match, req)
         .then(function(res) {
-            self.log('trace', {
+            childHyperSwitch.log('trace', {
                 req: req,
                 res: res,
                 request_id: childHyperSwitch.reqId


### PR DESCRIPTION
We are passing child loggers & metrics reporters into hyperswitch, which are
then used to set up the new child hyperswitch instance. The intention is to
separate logs / metrics for internal, internal update & external requests.

However, we neglected to then consistently use the child hyperswitch's logger
and metrics reporter, causing top-level entry points to all end up in the
default logger / metrics reporter, rather than being separated properly into
classes.