### PR TITLE
Metrics naming consistency: Rename 'private' to 'internal'

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -398,7 +398,7 @@ function main(options) {
         log: options.logger.log.bind(options.logger),
         metrics: options.metrics,
         child_metrics: {
-            internal: options.metrics.makeChild('private'),
+            internal: options.metrics.makeChild('internal'),
             internal_update: options.metrics.makeChild('internal_update'),
         }
     };


### PR DESCRIPTION
Should only be merged / deployed in coordination with a rename of the graphite
metrics.