### PR TITLE
Remove deprecated scrubWikitext parameter

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -751,13 +751,7 @@ PSP.transformRevision = function(hyper, req, from, to) {
             body2[from] = req.body[from];
         }
 
-        // For now, simply pass this through.
-        // See https://phabricator.wikimedia.org/T106909 for the discussion
-        // about the longer term plan.
-        if (req.body.scrubWikitext || req.body.scrub_wikitext) {
-            body2.scrubWikitext = true;
-        }
-
+        body2.scrub_wikitext = req.body.scrub_wikitext;
         body2.body_only = req.body.body_only;
 
         // Let the stash flag through as well
@@ -848,12 +842,6 @@ PSP.callParsoidTransform = function callParsoidTransform(hyper, req, from, to) {
     var parsoidExtraPath = parsoidExtras.map(encodeURIComponent).join('/');
     if (parsoidExtraPath) { parsoidExtraPath = '/' + parsoidExtraPath; }
 
-    // ensure scrub_wikitext has been translated
-    if (req.body.scrub_wikitext || req.body.scrubWikitext) {
-        req.body.scrubWikitext = true;
-        delete req.body.scrub_wikitext;
-    }
-
     var parsoidReq = {
         uri: this.parsoidHost + '/' + rp.domain + '/v3/transform/'
             + from + '/to/' + parsoidTo + parsoidExtraPath,
@@ -919,7 +907,6 @@ PSP.makeTransform = function(from, to) {
             }
         }
 
-        var originalScrubWikitext = req.body.scrubWikitext;
         var transform;
         if (rp.revision && rp.revision !== '0') {
             transform = self.transformRevision(hyper, req, from, to);
@@ -957,12 +944,6 @@ PSP.makeTransform = function(from, to) {
             // remove the content-length header since that
             // is added automatically
             delete res.headers['content-length'];
-            // Log remaining scrubWikitext flag uses / users before removing it from the API
-            if (originalScrubWikitext) {
-                hyper.log('warn/parsoid/scrubWikitext', {
-                    msg: 'Client-supplied scrubWikitext flag encountered'
-                });
-            }
             return res;
         });
     };

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -930,11 +930,6 @@ paths:
           description: Normalise the DOM to yield cleaner wikitext?
           type: boolean
           required: false
-        - name: scrubWikitext
-          in: formData
-          description: Deprecated, use `scrub_wikitext` instead.
-          type: boolean
-          required: false
       responses:
         '200':
           description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec
@@ -966,7 +961,6 @@ paths:
                 if-match: '{if-match}'
               body:
                 html: '{html}'
-                scrubWikitext: '{scrubWikitext}'
                 scrub_wikitext: '{scrub_wikitext}'
       x-monitor: false
 


### PR DESCRIPTION
We've deprecated `scrubWikitext` parameter long ago. Recently I've added the logging of remaining users. After it's been deployed, there wasn't a single usage of a deprecated parameter for several days, so it's safe to remove it.

Additionally, we've switched to v3 parsoid API, that officially supports `scrub_wikitext` and not `scrubWikitext`. So stop using old format and switch to new (see https://www.mediawiki.org/wiki/Parsoid/API) 

cc @wikimedia/services 