### PR TITLE
Enable support for mhchem

### DIFF
--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -27,6 +27,7 @@ paths:
           enum:
             - tex
             - inline-tex
+            - chem
         - name: q
           in: formData
           description: The formula to check


### PR DESCRIPTION
* mhchem is a LaTeX package to support chemistry rendering
* it has been ported to mathjax
* it was enabled in mathoid in
https://github.com/wikimedia/mathoid/commit/c70ffd039949939f8c6df9ab32bbeb6b978d3842
 included in mathoid@0.5.0 from npm