### PR TITLE
Description update to use aqs_default in prod

### DIFF
--- a/projects/aqs_default.yaml
+++ b/projects/aqs_default.yaml
@@ -7,7 +7,7 @@ paths:
       version: 1.0.0-beta
       title: Analytics REST API
       description: >
-          Sample project for AQS RESTBase setup
+          AQS RESTBase setup
       x-is-api-root: true
 
     x-host-basePath: /api/rest_v1

--- a/sys/pageviews.js
+++ b/sys/pageviews.js
@@ -151,6 +151,7 @@ var normalizeResponse = function(res) {
     res.body = res.body || { items: [] };
     res.headers = res.headers || {};
     res.headers['cache-control'] = 's-maxage=3600, max-age=3600';
+    res.headers['content-type'] = 'application/json; charset=utf-8';
     return res;
 };
 


### PR DESCRIPTION
Also added content-type headers to all responses because hyperswitch
doesn't add any by default (it shouldn't).  See the mailing list:

https://lists.wikimedia.org/pipermail/analytics/2016-February/004908.html

Bug: T122249