### PR TITLE
Cleanup: Removed unused capability to provide TID as timestamp

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -50,27 +50,20 @@ mwUtil.parseETag = function(etag) {
     }
 };
 
-/**
- * Creates a deterministic version 1 UUID from a given date
- * @param {Date|string|Number} date a Date
- * @returns {string} a deterministic v1 UUID
- */
-mwUtil.tidFromDate = function(date) {
-    if (typeof date === 'object') {
-        // Convert Date object to numeric milliseconds
-        date = date.getTime();
-    } else if (typeof date === 'string') {
-        // Convert date string to numeric milliseconds
-        date = Date.parse(date);
+mwUtil.coerceTid = function(tidString, bucket) {
+    if (uuid.test(tidString)) {
+        return tidString;
     }
-    if (isNaN(+date)) {
-        throw new Error('Invalid date');
-    }
-    // Create a new, deterministic timestamp
-    return uuid.min(date,
-    0,
-    new Buffer([0x01, 0x23, 0x45, 0x67, 0x89, 0xab]),
-    new Buffer([0x12, 0x34])).toString();
+
+    // Out of luck
+    throw new HTTPError({
+        status: 400,
+        body: {
+            type: (bucket || 'bucket') + '/invalid_tid',
+            title: 'Invalid tid parameter',
+            tid: tidString
+        }
+    });
 };
 
 /**


### PR DESCRIPTION
We've had ability to pass TID to buckets as timestamp strings, but we've never used this capability, so I'm removing it.