### PR TITLE
Chunked storage response streaming

### DIFF
--- a/sys/key_rev_large_value.js
+++ b/sys/key_rev_large_value.js
@@ -232,11 +232,11 @@ ChunkedBucket.prototype.getRevision = function(hyper, req) {
                     limit: 1
                 }
             })
-            .then(res => {
+            .then(function(res) {
                 byteStream.write(res.body.items[0].value);
             });
         })
-        .then(() => byteStream.end());
+        .then(function() { return byteStream.end(); });
 
         return {
             status: 200,

--- a/sys/key_rev_large_value.js
+++ b/sys/key_rev_large_value.js
@@ -217,7 +217,13 @@ ChunkedBucket.prototype.getRevision = function(hyper, req) {
                 byteStream.write(res.body.items[0].value);
             });
         })
-        .then(function() { return byteStream.end(); });
+        .then(function() { byteStream.end(); })
+        .catch(function(e) {
+            hyper.log('error/key_rev_large_value/body', e);
+            // FIXME: Figure out a way to abort the response, but don't signal
+            // success via .end().
+        });
+
 
         return {
             status: 200,

--- a/sys/key_rev_large_value.js
+++ b/sys/key_rev_large_value.js
@@ -152,25 +152,6 @@ ChunkedBucket.prototype.createBucket = function(hyper, req) {
     .then(function() { return { status: 201 }; });
 };
 
-// Format a revision response. Shared between different ways to retrieve a
-// revision (latest & with explicit revision).
-function returnRevision(req, metadata) {
-    return function(dbResult) {
-        if (dbResult.body && dbResult.body.items && dbResult.body.items.length) {
-            var row = dbResult.body.items[0];
-        } else {
-            throw new HTTPError({
-                status: 404,
-                body: {
-                    type: 'not_found',
-                    uri: req.uri,
-                    method: req.method
-                }
-            });
-        }
-    };
-}
-
 function coerceTid(tidString) {
     if (uuid.test(tidString)) {
         return tidString;

--- a/sys/key_rev_large_value.js
+++ b/sys/key_rev_large_value.js
@@ -200,6 +200,8 @@ ChunkedBucket.prototype.getRevision = function(hyper, req) {
     return this._getMetadata(hyper, req)
     .then(function(metadata) {
         var byteStream = new stream.PassThrough();
+
+        // Start off the body stream in the background.
         P.each(range(metadata.num_chunks), function(chunkId) {
             return hyper.get({
                 uri: chunkURI,
@@ -224,7 +226,7 @@ ChunkedBucket.prototype.getRevision = function(hyper, req) {
             // success via .end().
         });
 
-
+        // Return the response, with the stream as the body.
         return {
             status: 200,
             headers: metadata.headers,


### PR DESCRIPTION
This patch changes the behavior of read requests to stream body chunks as they
become available, rather than collecting & concatenating all chunks before
returning a response.

This patch also bumps up the default chunk size to 1.8mb, in line with the
benchmark results from https://phabricator.wikimedia.org/T122028. This won't
provide special compression efficiency with deflate, but will provide a decent
combination of compression ratio and scalability using brotli compression.
