### PR TITLE
Deploy build: Fix the node version to 4.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "temp": "^0.8.3"
   },
   "deploy": {
-    "node": "4.2",
+    "node": "4.2.4",
     "target": "debian",
     "dependencies": {
       "_all": []


### PR DESCRIPTION
The deploy-repo script's nvm uses the latest 4.2.x when '4.2' is
specified, so fix the version to 4.2.4, which is what we use exactly in
production.