### PR TITLE
Returned paging tokens encoding/decoding back to RESTBase from Hyper

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -111,6 +111,10 @@ mwUtil.getLimit = function(hyper, req) {
  * @returns {string}
  */
 mwUtil.encodePagingToken = function(hyper, object) {
+    if (typeof hyper.config.salt !== 'string') {
+        throw new Error('Invalid salt config parameter. Must be a string');
+    }
+
     return jwt.sign({ next: object }, hyper.config.salt);
 };
 
@@ -122,6 +126,10 @@ mwUtil.encodePagingToken = function(hyper, object) {
  * @returns {Object}
  */
 mwUtil.decodePagingToken = function(hyper, token) {
+    if (typeof hyper.config.salt !== 'string') {
+        throw new Error('Invalid salt config parameter. Must be a string');
+    }
+
     try {
         var next = jwt.verify(token, hyper.config.salt);
         return next.next;

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -3,6 +3,7 @@
 var uuid = require('cassandra-uuid').TimeUuid;
 var contentType = require('content-type');
 var HTTPError = require('hyperswitch').HTTPError;
+var jwt = require('jsonwebtoken');
 
 var mwUtil = {};
 
@@ -102,5 +103,37 @@ mwUtil.getLimit = function(hyper, req) {
     return hyper.config.default_page_size;
 };
 
+/**
+ * Create a json web token.
+ *
+ * @param {HyperSwitch} hyper HyperSwitch context*
+ * @param {Object} object a JSON object to encode
+ * @returns {string}
+ */
+mwUtil.encodePagingToken = function(hyper, object) {
+    return jwt.sign({ next: object }, hyper.config.salt);
+};
+
+/**
+ * Decode signed token and decode the orignal token
+ *
+ * @param {HyperSwitch} hyper HyperSwitch context
+ * @param {string} token paging request token
+ * @returns {Object}
+ */
+mwUtil.decodePagingToken = function(hyper, token) {
+    try {
+        var next = jwt.verify(token, hyper.config.salt);
+        return next.next;
+    } catch (e) {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'invalid_paging_token',
+                title: 'Invalid paging token'
+            }
+        });
+    }
+};
 
 module.exports = mwUtil;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "htcp-purge": "^0.1.2",
     "content-type": "git+https://github.com/wikimedia/content-type#master",
-    "hyperswitch": "^0.2.0"
+    "hyperswitch": "^0.2.0",
+    "jsonwebtoken": "^5.5.4"
   },
   "devDependencies": {
     "js-yaml": "^3.5.2",

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -143,7 +143,7 @@ PRS.prototype.listTitles = function(hyper, req, options) {
     };
 
     if (req.query.page) {
-        Object.assign(listReq.body, hyper.decodeToken(req.query.page));
+        Object.assign(listReq.body, mwUtil.decodePagingToken(hyper, req.query.page));
     }
 
     return hyper.get(listReq)
@@ -160,7 +160,7 @@ PRS.prototype.listTitles = function(hyper, req, options) {
         if (res.body.next) {
             next = {
                 next: {
-                    href: "?page=" + hyper.encodeToken(res.body.next)
+                    href: "?page=" + mwUtil.encodePagingToken(hyper, res.body.next)
                 }
             };
         }
@@ -412,7 +412,7 @@ PRS.prototype.listTitleRevisions = function(hyper, req) {
         limit: hyper.config.default_page_size
     };
     if (req.query.page) {
-        revisionRequest.next = hyper.decodeToken(req.query.page);
+        revisionRequest.next = mwUtil.decodePagingToken(hyper, req.query.page);
     }
     return hyper.get({
         uri: this.tableURI(rp.domain),
@@ -432,7 +432,7 @@ PRS.prototype.listTitleRevisions = function(hyper, req) {
         if (res.body.next) {
             res.body._links = {
                 next: {
-                    href: "?page=" + hyper.encodeToken(res.body.next)
+                    href: "?page=" + mwUtil.encodePagingToken(hyper, res.body.next)
                 }
             };
         }
@@ -456,7 +456,7 @@ PRS.prototype.listRevisions = function(hyper, req) {
         }
     };
     if (req.query.page) {
-        Object.assign(listReq.body, hyper.decodeToken(req.query.page));
+        Object.assign(listReq.body, mwUtil.decodePagingToken(hyper, req.query.page));
     }
     return hyper.get(listReq)
     .then(function(res) {
@@ -470,7 +470,7 @@ PRS.prototype.listRevisions = function(hyper, req) {
         if (res.body.next) {
             next = {
                 next: {
-                    href: "?page=" + hyper.encodeToken(res.body.next)
+                    href: "?page=" + mwUtil.encodePagingToken(hyper, res.body.next)
                 }
             };
         }

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -489,7 +489,7 @@ PSP.listRevisions = function(format, hyper, req) {
     };
 
     if (req.query.page) {
-        revReq.body.next = hyper.decodeToken(req.query.page);
+        revReq.body.next = mwUtil.decodePagingToken(hyper, req.query.page);
     }
 
     return hyper.get(revReq)
@@ -497,7 +497,7 @@ PSP.listRevisions = function(format, hyper, req) {
         if (res.body.next) {
             res.body._links = {
                 next: {
-                    href: "?page=" + hyper.encodeToken(res.body.next)
+                    href: "?page=" + mwUtil.encodePagingToken(hyper, res.body.next)
                 }
             };
         }


### PR DESCRIPTION
The `encodeToken` and `decodeToken` functions were in `HyperSwitch` object only because they need to access the `salt`, however they don't really belong neither in `HyperSwitch` object, nor in the framework itself, because JWT signing is RESTBase-specific way of obtaining paging tokens.

Pulled back to RESTBase codebase.