### PR TITLE
Use new config format to make modules export valid swagger spec

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -4,43 +4,40 @@
 # in the root_spec further down.
 default_project: &default_project
   x-modules:
-    /:
-      - path: projects/wmf_default.yaml
-        options: &default_options
-          table:
-            hosts: [localhost]
-            keyspace: system
-            username: cassandra
-            password: cassandra
-            defaultConsistency: one # or 'localQuorum' for production
-            storage_groups:
-              - name: default.group.local
-                domains: /./
-          parsoid:
-            host: http://parsoid-beta.wmflabs.org
-          action:
-            apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
-          graphoid:
-            host: http://graphoid.wikimedia.org
-          mathoid:
-            host: http://mathoid-tester.wmflabs.org
-            # 10 days Varnish caching, one day client-side
-            cache-control: s-maxage=864000, max-age=86400
-          mobileapps:
-            host: http://appservice.wmflabs.org
+    - path: projects/wmf_default.yaml
+      options: &default_options
+        table:
+          hosts: [localhost]
+          keyspace: system
+          username: cassandra
+          password: cassandra
+          defaultConsistency: one # or 'localQuorum' for production
+          storage_groups:
+            - name: default.group.local
+              domains: /./
+        parsoid:
+          host: http://parsoid-beta.wmflabs.org
+        action:
+          apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
+        graphoid:
+          host: http://graphoid.wikimedia.org
+        mathoid:
+          host: http://mathoid-tester.wmflabs.org
+          # 10 days Varnish caching, one day client-side
+          cache-control: s-maxage=864000, max-age=86400
+        mobileapps:
+          host: http://appservice.wmflabs.org
 
 # A different project template, sharing configuration options.
 wikimedia.org: &wikimedia.org
   x-modules:
-    /:
-      - path: projects/wikimedia.org.yaml
-        options: *default_options
+    - path: projects/wikimedia.org.yaml
+      options: *default_options
 
 wiktionary_project: &wiktionary_project
   x-modules:
-    /:
-      - path: projects/wmf_wiktionary.yaml
-        options: *default_options
+    - path: projects/wmf_wiktionary.yaml
+      options: *default_options
 
 # The root of the spec tree. Domains tend to share specs by referencing them
 # using YAML references.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,21 +28,20 @@ services:
         paths:
           /{domain:localhost}:
             x-modules:
-              /:
-                - path: projects/example.yaml
-                  options:
-                    action:
-                      # XXX Check API URL!
-                      apiUriTemplate: http://localhost/w/api.php
-                    parsoid:
-                      # XXX Check Parsoid URL!
-                      host: http://localhost:8142
-                    table:
-                      dbname: db.sqlite3
-                      pool_idle_timeout: 20000
-                      retry_delay: 250
-                      retry_limit: 10
-                      show_sql: false
+              - path: projects/example.yaml
+                options:
+                  action:
+                    # XXX Check API URL!
+                    apiUriTemplate: http://localhost/w/api.php
+                  parsoid:
+                    # XXX Check Parsoid URL!
+                    host: http://localhost:8142
+                  table:
+                    dbname: db.sqlite3
+                    pool_idle_timeout: 20000
+                    retry_delay: 250
+                    retry_limit: 10
+                    show_sql: false
 
 # Finally, a standard service-runner config.
 info:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -4,68 +4,64 @@
 # in the root_spec further down.
 default_project: &default_project
   x-modules:
-    /:
-      - path: test/test_module.yaml
-        options:
-          events:
-            purge:
-              host: 127.0.0.1
-              port: 4321
-      - path: projects/wmf_default.yaml
-        options: &default_options
-          table:
-            hosts: [localhost]
-            keyspace: system
-            username: cassandra
-            password: cassandra
-            defaultConsistency: one # or 'localQuorum' for production
-            storage_groups:
-              - name: test.group.local
-                domains: /./
-            dbname: test.db.sqlite3 # ignored in cassandra, but useful in SQLite testing
-          parsoid:
-            host: http://parsoid-beta.wmflabs.org
-          action:
-            apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
-          graphoid:
-            host: http://graphoid-beta.wmflabs.org
-          mathoid:
-            host: http://mathoid-tester.wmflabs.org
-            # 10 days Varnish caching, one day client-side
-            cache-control: s-maxage=864000, max-age=86400
-          mobileapps:
-            host: http://appservice.wmflabs.org
-          events:
-            purge:
-              host: 127.0.0.1
-              port: 4321
+    - path: test/test_module.yaml
+      options:
+        events:
+          purge:
+            host: 127.0.0.1
+            port: 4321
+    - path: projects/wmf_default.yaml
+      options: &default_options
+        table:
+          hosts: [localhost]
+          keyspace: system
+          username: cassandra
+          password: cassandra
+          defaultConsistency: one # or 'localQuorum' for production
+          storage_groups:
+            - name: test.group.local
+              domains: /./
+          dbname: test.db.sqlite3 # ignored in cassandra, but useful in SQLite testing
+        parsoid:
+          host: http://parsoid-beta.wmflabs.org
+        action:
+          apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
+        graphoid:
+          host: http://graphoid-beta.wmflabs.org
+        mathoid:
+          host: http://mathoid-tester.wmflabs.org
+          # 10 days Varnish caching, one day client-side
+          cache-control: s-maxage=864000, max-age=86400
+        mobileapps:
+          host: http://appservice.wmflabs.org
+        events:
+          purge:
+            host: 127.0.0.1
+            port: 4321
 
 labs_project: &labs_project
   x-modules:
-    /:
-      - path: test/test_module.yaml
-      - path: projects/wmf_default.yaml
-        options:
-          <<: *default_options
-          action:
-            apiUriTemplate: "{{'http://{domain}/w/api.php'}}"
+    - path: test/test_module.yaml
+    - path: projects/wmf_default.yaml
+      options:
+        <<: *default_options
+        action:
+          apiUriTemplate: "{{'http://{domain}/w/api.php'}}"
 
 # A different project template, sharing configuration options.
 wikimedia.org: &wikimedia.org
   x-modules:
-    /:
-      - path: test/test_module.yaml
-      - path: projects/wikimedia.org.yaml
-        options:
-          <<: *default_options
-          pageviews:
-            host: https://wikimedia.org/api/rest_v1/metrics
+    - path: test/test_module.yaml
+    - path: projects/wikimedia.org.yaml
+      options:
+        <<: *default_options
+        pageviews:
+          host: https://wikimedia.org/api/rest_v1/metrics
 
 wiktionary_project: &wiktionary_project
   x-modules:
-    /:
-      - path: projects/wmf_wiktionary.yaml
-        options: *default_options
+    - path: projects/wmf_wiktionary.yaml
+      options: *default_options
 
 # Hacky way to parametrize RESTBase tests. TODO: Move to config?
 test:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "htcp-purge": "^0.1.2",
     "content-type": "git+https://github.com/wikimedia/content-type#master",
-    "hyperswitch": "git+https://github.com/Pchelolo/hyperswitch#router"
+    "hyperswitch": "^0.2.0"
   },
   "devDependencies": {
     "js-yaml": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "htcp-purge": "^0.1.2",
     "content-type": "git+https://github.com/wikimedia/content-type#master",
-    "hyperswitch": "^0.1.4"
+    "hyperswitch": "git+https://github.com/Pchelolo/hyperswitch#router"
   },
   "devDependencies": {
     "js-yaml": "^3.5.2",

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -20,55 +20,71 @@
 # between domains in the root_spec further down.
 paths:
   /{api:v1}:
-    info:
-      version: 1.0.0-beta
-      title: Wikimedia REST API
-      description: Welcome to your RESTBase API.
-
-    securityDefinitions:
-      mediawiki_auth:
-        description: Checks permissions using MW api
-        type: apiKey
-        in: header
-        name: cookie
-        x-internal-request-whitelist:
-          - http://localhost/w/api.php
-          - http://localhost:8142
-      header_match:
-        description: Checks client ip against one of the predefined whitelists
-        x-error-message: This client is not allowed to use the endpoint
-        x-whitelists:
-          internal:
-            - /^(?:localhost)|(?:127\.)/
-
     x-modules:
-      /: 
-        # The main content module, defining page/* and transform entry
-        # points.
-        - path: v1/content.yaml
+      - spec:
+          info:
+            version: 1.0.0-beta
+            title: Wikimedia REST API
+            description: Welcome to your RESTBase API.
+
+          securityDefinitions:
+            mediawiki_auth:
+              description: Checks permissions using MW api
+              type: apiKey
+              in: header
+              name: cookie
+              x-internal-request-whitelist:
+                - http://localhost/w/api.php
+                - http://localhost:8142
+            header_match:
+              description: Checks client ip against one of the predefined whitelists
+              x-error-message: This client is not allowed to use the endpoint
+              x-whitelists:
+                internal:
+                  - /^(?:localhost)|(?:127\.)/
+
+          paths:
+            /page:
+              x-modules:
+                - path: v1/content.yaml
+            /transform:
+              x-modules:
+                - path: v1/transform.yaml
 
   /{api:sys}:
     x-modules:
-      /table:
-        - type: npm
-          name: restbase-mod-table-sqlite
-          version: 1.0.0
-          options: 
-            conf: '{{options.table}}'
-      /key_value:
-        - path: sys/key_value.js
-      /key_rev_value:
-        - path: sys/key_rev_value.js
-      /page_revisions:
-        - path: sys/page_revisions.js
-      /post_data:
-        - path: sys/post_data.js
-      /action:
-        - path: sys/action.js
-          options: '{{options.action}}'
-      /page_save:
-        - path: sys/page_save.js
-      /parsoid:
-        - path: sys/parsoid.js
-          options:
-            parsoidHost: '{{options.parsoid.host}}'
+      - spec:
+          paths:
+            /table:
+              x-modules:
+                - type: npm
+                  name: restbase-mod-table-sqlite
+                  version: 1.0.0
+                  options:
+                    conf: '{{options.table}}'
+            /key_value:
+              x-modules:
+                - path: sys/key_value.js
+            /key_rev_value:
+              x-modules:
+                - path: sys/key_rev_value.js
+            /page_revisions:
+              x-modules:
+                - path: sys/page_revisions.js
+            /post_data:
+              x-modules:
+                - path: sys/post_data.js
+            /action:
+              x-modules:
+                - path: sys/action.js
+                  options: '{{options.action}}'
+            /page_save:
+              x-modules:
+                - path: sys/page_save.js
+            /parsoid:
+              x-modules:
+                - path: sys/parsoid.js
+                  options:
+                    parsoidHost: '{{options.parsoid.host}}'
+        options: '{{options}}'
+

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -1,72 +1,85 @@
 paths:
-  /{api:v1}: &default_project_paths_v1
-    # swagger options, overriding the shared ones from the merged specs (?)
-    info:
-      version: 1.0.0-beta
-      title: Wikimedia REST API
-      description: >
-          This API aims to provide coherent and low-latency access to
-          Wikimedia content and services. It is currently in beta testing, so
-          things aren't completely locked down yet. Each entry point has
-          explicit stability markers to inform you about development status
-          and change policy, according to [our API version
-          policy](https://www.mediawiki.org/wiki/API_versioning).
-
-          ### High-volume access
-            - Don't perform more than 500 requests/s to this API.
-            - Set a unique `User-Agent` header that allows us to contact you
-              quickly. Email addresses or URLs of contact pages work well.
-
-      termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
-      contact:
-        name: the Wikimedia Services team
-        url: http://mediawiki.org/wiki/RESTBase
-      license:
-        name: Apache2
-        url: http://www.apache.org/licenses/LICENSE-2.0
-
-    securityDefinitions: &wp/content-security/1.0.0
-      mediawiki_auth:
-        description: Checks permissions using MW api
-        type: apiKey
-        in: header
-        name: cookie
-        x-internal-request-whitelist:
-          - /http:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
-      header_match:
-        description: Checks client ip against one of the predefined whitelists
-        x-error-message: This client is not allowed to use the endpoint
-        x-whitelists:
-          internal:
-            - /^(?:::ffff:)?(?:10|127)\./
-        x-is-api: true
-    # Override the base path for host-based (proxied) requests. In our case,
-    # we proxy https://{domain}/api/rest_v1/ to the API.
-    x-host-basePath: /api/rest_v1
-
+  /{api:v1}:
     x-modules:
-      /media:
-        - path: v1/mathoid.yaml
-          options: '{{options.mathoid}}'
-      /metrics:
-        - path: v1/pageviews.yaml
+        # swagger options, overriding the shared ones from the merged specs (?)
+      - spec:
+          info:
+            version: 1.0.0-beta
+            title: Wikimedia REST API
+            description: >
+                This API aims to provide coherent and low-latency access to
+                Wikimedia content and services. It is currently in beta testing, so
+                things aren't completely locked down yet. Each entry point has
+                explicit stability markers to inform you about development status
+                and change policy, according to [our API version
+                policy](https://www.mediawiki.org/wiki/API_versioning).
+
+                ### High-volume access
+                  - Don't perform more than 500 requests/s to this API.
+                  - Set a unique `User-Agent` header that allows us to contact you
+                    quickly. Email addresses or URLs of contact pages work well.
+
+            termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+            contact:
+              name: the Wikimedia Services team
+              url: http://mediawiki.org/wiki/RESTBase
+            license:
+              name: Apache2
+              url: http://www.apache.org/licenses/LICENSE-2.0
+
+          securityDefinitions: &wp/content-security/1.0.0
+            mediawiki_auth:
+              description: Checks permissions using MW api
+              type: apiKey
+              in: header
+              name: cookie
+              x-internal-request-whitelist:
+                - /http:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
+            header_match:
+              description: Checks client ip against one of the predefined whitelists
+              x-error-message: This client is not allowed to use the endpoint
+              x-whitelists:
+                internal:
+                  - /^(?:::ffff:)?(?:10|127)\./
+          # Override the base path for host-based (proxied) requests. In our case,
+          # we proxy https://{domain}/api/rest_v1/ to the API.
+          x-host-basePath: /api/rest_v1
+
+          paths:
+            /media:
+              x-modules:
+                - path: v1/mathoid.yaml
+                  options: '{{options.mathoid}}'
+            /metrics:
+              x-modules:
+                - path: v1/pageviews.yaml
+        options: '{{options}}'
 
   /{api:sys}:
     x-modules:
-      /table:
-        - type: npm
-          name: restbase-mod-table-cassandra
-          options:
-            conf: '{{options.table}}'
-      /key_value:
-        - path: sys/key_value.js
-      /key_rev_value:
-        - path: sys/key_rev_value.js
-      /post_data: &sys_post_data
-        - path: sys/post_data.js
-      /pageviews:
-        - path: sys/pageviews_proxy.yaml
-          options: '{{options.pageviews}}'
-      /events:
-        - path: sys/events.js
-          options: '{{options.events}}'
+      - spec:
+          paths:
+            /table:
+              x-modules:
+                - type: npm
+                  name: restbase-mod-table-cassandra
+                  options:
+                    conf: '{{options.table}}'
+            /key_value:
+              x-modules:
+                - path: sys/key_value.js
+            /key_rev_value:
+              x-modules:
+                - path: sys/key_rev_value.js
+            /post_data: &sys_post_data
+              x-modules:
+                - path: sys/post_data.js
+            /pageviews:
+              x-modules:
+                - path: sys/pageviews_proxy.yaml
+                  options: '{{options.pageviews}}'
+            /events:
+              x-modules:
+                - path: sys/events.js
+                  options: '{{options.events}}'
+        options: '{{options}}'

--- a/projects/wikimedia.org_sqlite.yaml
+++ b/projects/wikimedia.org_sqlite.yaml
@@ -1,72 +1,86 @@
 paths:
   /{api:v1}: &default_project_paths_v1
-    # swagger options, overriding the shared ones from the merged specs (?)
-    info:
-      version: 1.0.0-beta
-      title: Wikimedia REST API
-      description: >
-          This API aims to provide coherent and low-latency access to
-          Wikimedia content and services. It is currently in beta testing, so
-          things aren't completely locked down yet. Each entry point has
-          explicit stability markers to inform you about development status
-          and change policy, according to [our API version
-          policy](https://www.mediawiki.org/wiki/API_versioning).
-
-          ### High-volume access
-            - Don't perform more than 500 requests/s to this API.
-            - Set a unique `User-Agent` header that allows us to contact you
-              quickly. Email addresses or URLs of contact pages work well.
-
-      termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
-      contact:
-        name: the Wikimedia Services team
-        url: http://mediawiki.org/wiki/RESTBase
-      license:
-        name: Apache2
-        url: http://www.apache.org/licenses/LICENSE-2.0
-
-    securityDefinitions: &wp/content-security/1.0.0
-      mediawiki_auth:
-        description: Checks permissions using MW api
-        type: apiKey
-        in: header
-        name: cookie
-        x-internal-request-whitelist:
-          - /http:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
-      header_match:
-        description: Checks client ip against one of the predefined whitelists
-        x-error-message: This client is not allowed to use the endpoint
-        x-whitelists:
-          internal:
-            - /^(?:::ffff:)?(?:10|127)\./
-        x-is-api: true
-    # Override the base path for host-based (proxied) requests. In our case,
-    # we proxy https://{domain}/api/rest_v1/ to the API.
-    x-host-basePath: /api/rest_v1
-
     x-modules:
-      /media:
-        - path: v1/mathoid.yaml
-          options: '{{options.mathoid}}'
-      /metrics:
-        - path: v1/pageviews.yaml
+        # swagger options, overriding the shared ones from the merged specs (?)
+      - spec:
+          info:
+            version: 1.0.0-beta
+            title: Wikimedia REST API
+            description: >
+                This API aims to provide coherent and low-latency access to
+                Wikimedia content and services. It is currently in beta testing, so
+                things aren't completely locked down yet. Each entry point has
+                explicit stability markers to inform you about development status
+                and change policy, according to [our API version
+                policy](https://www.mediawiki.org/wiki/API_versioning).
+
+                ### High-volume access
+                  - Don't perform more than 500 requests/s to this API.
+                  - Set a unique `User-Agent` header that allows us to contact you
+                    quickly. Email addresses or URLs of contact pages work well.
+
+            termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+            contact:
+              name: the Wikimedia Services team
+              url: http://mediawiki.org/wiki/RESTBase
+            license:
+              name: Apache2
+              url: http://www.apache.org/licenses/LICENSE-2.0
+
+          securityDefinitions: &wp/content-security/1.0.0
+            mediawiki_auth:
+              description: Checks permissions using MW api
+              type: apiKey
+              in: header
+              name: cookie
+              x-internal-request-whitelist:
+                - /http:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
+            header_match:
+              description: Checks client ip against one of the predefined whitelists
+              x-error-message: This client is not allowed to use the endpoint
+              x-whitelists:
+                internal:
+                  - /^(?:::ffff:)?(?:10|127)\./
+              x-is-api: true
+          # Override the base path for host-based (proxied) requests. In our case,
+          # we proxy https://{domain}/api/rest_v1/ to the API.
+          x-host-basePath: /api/rest_v1
+
+          paths:
+            /media:
+              x-modules:
+                - path: v1/mathoid.yaml
+                  options: '{{options.mathoid}}'
+            /metrics:
+              x-modules:
+                - path: v1/pageviews.yaml
+        options: '{{options}}'
 
   /{api:sys}:
     x-modules:
-      /table:
-        - type: npm
-          name: restbase-mod-table-sqlite
-          options:
-            conf: '{{options.table}}'
-      /key_value:
-        - path: sys/key_value.js
-      /key_rev_value:
-        - path: sys/key_rev_value.js
-      /post_data: &sys_post_data
-        - path: sys/post_data.js
-      /pageviews:
-        - path: sys/pageviews_proxy.yaml
-          options: '{{options.pageviews}}'
-      /events:
-        - path: sys/events.js
-          options: '{{options.events}}'
+      - spec:
+          paths:
+            /table:
+              x-modules:
+                - type: npm
+                  name: restbase-mod-table-sqlite
+                  options:
+                    conf: '{{options.table}}'
+            /key_value:
+              x-modules:
+                - path: sys/key_value.js
+            /key_rev_value:
+              x-modules:
+                - path: sys/key_rev_value.js
+            /post_data: &sys_post_data
+              x-modules:
+                - path: sys/post_data.js
+            /pageviews:
+              x-modules:
+                - path: sys/pageviews_proxy.yaml
+                  options: '{{options.pageviews}}'
+            /events:
+              x-modules:
+                - path: sys/events.js
+                  options: '{{options.events}}'
+        options: '{{options}}'

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -1,132 +1,149 @@
 paths:
-  /{api:v1}: &default_project_paths_v1
-    # swagger options, overriding the shared ones from the merged specs (?)
-    info:
-      version: 1.0.0-beta
-      title: Wikimedia REST API
-      description: >
-          This API aims to provide coherent and low-latency access to
-          Wikimedia content and services. It is currently in beta testing, so
-          things aren't completely locked down yet. Each entry point has
-          explicit stability markers to inform you about development status
-          and change policy, according to [our API version
-          policy](https://www.mediawiki.org/wiki/API_versioning).
+  /{api:v1}:
+    x-modules:
+        # swagger options, overriding the shared ones from the merged specs (?)
+      - spec:
+          info:
+            version: 1.0.0-beta
+            title: Wikimedia REST API
+            description: >
+                This API aims to provide coherent and low-latency access to
+                Wikimedia content and services. It is currently in beta testing, so
+                things aren't completely locked down yet. Each entry point has
+                explicit stability markers to inform you about development status
+                and change policy, according to [our API version
+                policy](https://www.mediawiki.org/wiki/API_versioning).
 
-          ### High-volume access
-            - Don't perform more than 200 requests/s to this API.
-            - Set a unique `User-Agent` header that allows us to contact you
-              quickly. Email addresses or URLs of contact pages work well.
+                ### High-volume access
+                  - Don't perform more than 200 requests/s to this API.
+                  - Set a unique `User-Agent` header that allows us to contact you
+                    quickly. Email addresses or URLs of contact pages work well.
 
-      termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
-      contact:
-        name: the Wikimedia Services team
-        url: http://mediawiki.org/wiki/RESTBase
-      license:
-        name: Apache2
-        url: http://www.apache.org/licenses/LICENSE-2.0
+            termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+            contact:
+              name: the Wikimedia Services team
+              url: http://mediawiki.org/wiki/RESTBase
+            license:
+              name: Apache2
+              url: http://www.apache.org/licenses/LICENSE-2.0
 
-    securityDefinitions: &wp/content-security/1.0.0
-      mediawiki_auth:
-        description: Checks permissions using MW api
-        type: apiKey
-        in: header
-        name: cookie
-        x-internal-request-whitelist:
-          - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
-          - http://parsoid-beta.wmflabs.org
-      header_match:
-        description: Checks client ip against one of the predefined whitelists
-        x-error-message: This client is not allowed to use the endpoint
-        x-whitelists:
-          internal:
-            - /^(?:::ffff:)?(?:10|127)\./
-        x-is-api: true
-    # Override the base path for host-based (proxied) requests. In our case,
-    # we proxy https://{domain}/api/rest_v1/ to the API.
-    x-host-basePath: /api/rest_v1
+          securityDefinitions: &wp/content-security/1.0.0
+            mediawiki_auth:
+              description: Checks permissions using MW api
+              type: apiKey
+              in: header
+              name: cookie
+              x-internal-request-whitelist:
+                - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
+                - http://parsoid-beta.wmflabs.org
+            header_match:
+              description: Checks client ip against one of the predefined whitelists
+              x-error-message: This client is not allowed to use the endpoint
+              x-whitelists:
+                internal:
+                  - /^(?:::ffff:)?(?:10|127)\./
+              x-is-api: true
+          # Override the base path for host-based (proxied) requests. In our case,
+          # we proxy https://{domain}/api/rest_v1/ to the API.
+          x-host-basePath: /api/rest_v1
 
-    x-modules: &default_project_paths_v1_modules
-      /: 
-        # The main content module, defining page/* and transform entry
-        # points.
-        - path: v1/content.yaml
-      /page:
-        - path: v1/mobileapps.yaml
-          options: '{{options.mobileapps}}'
-        - path: v1/graphoid.yaml
-          options: '{{options.graphoid}}'
-        - path: v1/summary.js
-          options:
-            response_cache-control: 'max-age: 3600, s-maxage: 3600'
-      /media:
-        - path: v1/mathoid.yaml
-          options: '{{options.mathoid}}'
+          paths:
+            /page:
+              x-modules:
+                - path: v1/content.yaml
+                - path: v1/mobileapps.yaml
+                  options: '{{options.mobileapps}}'
+                - path: v1/graphoid.yaml
+                  options: '{{options.graphoid}}'
+                - path: v1/summary.js
+                  options:
+                    response_cache-control: 'max-age: 3600, s-maxage: 3600'
+            /transform:
+              x-modules:
+                - path: v1/transform.yaml
+            /media:
+              x-modules:
+                - path: v1/mathoid.yaml
+                  options: '{{options.mathoid}}'
+        options: '{{options}}'
 
-  /{api:sys}: &default_project_paths_sys
-    x-modules: &default_project_paths_sys_modules
-      /table: &sys_table
-        - type: npm
-          name: restbase-mod-table-cassandra
-          # See: 
-          # https://github.com/wikimedia/restbase-mod-table-cassandra/blob/master/Readme.md#configuration
-          options:
-            conf: '{{options.table}}'
-      /key_value: &sys_key_value
-        - path: sys/key_value.js
-      /key_rev_value:
-        - path: sys/key_rev_value.js
-      /page_revisions:
-        - path: sys/page_revisions.js
-      /post_data: &sys_post_data
-        - path: sys/post_data.js
-      /action:
-        - path: sys/action.js
-          options: "{{options.action}}"
-      /page_save:
-        - path: sys/page_save.js
-      /parsoid:
-        - path: sys/parsoid.js
-          options:
-            parsoidHost: '{{options.parsoid.host}}'
-            # To enable mobileApps purging - add these to the config.
-            # (TODO: remove after actual purging is implemented
-            #purge:
-            #  host: '239.128.0.112'
-            #  port: 4827
+  /{api:sys}:
+    x-modules:
+      - spec:
+          paths:
+            /table: &sys_table
+              x-modules:
+                - type: npm
+                  name: restbase-mod-table-cassandra
+                  # See:  https://github.com/wikimedia/restbase-mod-table-cassandra/blob/master/Readme.md#configuration
+                  options:
+                    conf: '{{options.table}}'
+            /key_value: &sys_key_value
+              x-modules:
+                - path: sys/key_value.js
+            /key_rev_value:
+              x-modules:
+                - path: sys/key_rev_value.js
+            /page_revisions:
+              x-modules:
+                - path: sys/page_revisions.js
+            /post_data: &sys_post_data
+              x-modules:
+                - path: sys/post_data.js
+            /action:
+              x-modules:
+                - path: sys/action.js
+                  options: "{{options.action}}"
+            /page_save:
+              x-modules:
+                - path: sys/page_save.js
+            /parsoid:
+              x-modules:
+                - path: sys/parsoid.js
+                  options:
+                    parsoidHost: '{{options.parsoid.host}}'
+                    # To enable mobileApps purging - add these to the config.
+                    # (TODO: remove after actual purging is implemented
+                    #purge:
+                    #  host: '239.128.0.112'
+                    #  port: 4827
 
-            # A list of pages that we don't currently want to re-render on
-            # each edit. Most of these are huge bot-edited pages, which are
-            # rarely viewed in any case. 
-            rerenderBlacklist:
-              www.wikidata.org:
-                Q21558717: true
-                Q21505108: true
-                Q21481867: true
-                Q21521425: true
-              en.wikipedia.org:
-                Wikipedia:Administrators'_noticeboard/Incidents: true
-                User:JamesR/AdminStats: true
-                User:Kudpung/Dashboard: true
-                # Various dashboards
-                User:Breawycker/Wikipedia: true
-                User:Sonia/dashboard: true
-                User:Ocaasi/dashboard: true
-                User:Nolelover: true
-                User:Calmer_Waters: true
-                User:Technical_13/dashboard: true
-              ur.wikipedia.org:
-                نام_مقامات_ایل: true
-                نام_مقامات_ڈی: true
-                نام_مقامات_جے: true
-                نام_مقامات_جی: true
-                نام_مقامات_ایچ: true
-                نام_مقامات_ایم: true
-                نام_مقامات_ایس: true
-              commons.wikipedia.org:
-                Commons:Quality_images_candidates/candidate_list: true
-      /mobileapps:
-        - path: sys/mobileapps.yaml
-          options: '{{options.mobileapps}}'
-      /events:
-        - path: sys/events.js
-          options: '{{options.events}}'
+                    # A list of pages that we don't currently want to re-render on
+                    # each edit. Most of these are huge bot-edited pages, which are
+                    # rarely viewed in any case.
+                    rerenderBlacklist:
+                      www.wikidata.org:
+                        Q21558717: true
+                        Q21505108: true
+                        Q21481867: true
+                        Q21521425: true
+                      en.wikipedia.org:
+                        Wikipedia:Administrators'_noticeboard/Incidents: true
+                        User:JamesR/AdminStats: true
+                        User:Kudpung/Dashboard: true
+                        # Various dashboards
+                        User:Breawycker/Wikipedia: true
+                        User:Sonia/dashboard: true
+                        User:Ocaasi/dashboard: true
+                        User:Nolelover: true
+                        User:Calmer_Waters: true
+                        User:Technical_13/dashboard: true
+                      ur.wikipedia.org:
+                        نام_مقامات_ایل: true
+                        نام_مقامات_ڈی: true
+                        نام_مقامات_جے: true
+                        نام_مقامات_جی: true
+                        نام_مقامات_ایچ: true
+                        نام_مقامات_ایم: true
+                        نام_مقامات_ایس: true
+                      commons.wikipedia.org:
+                        Commons:Quality_images_candidates/candidate_list: true
+            /mobileapps:
+              x-modules:
+                - path: sys/mobileapps.yaml
+                  options: '{{options.mobileapps}}'
+            /events:
+              x-modules:
+                - path: sys/events.js
+                  options: '{{options.events}}'
+        options: '{{options}}'

--- a/projects/wmf_sqlite.yaml
+++ b/projects/wmf_sqlite.yaml
@@ -1,130 +1,148 @@
 paths:
   /{api:v1}: &default_project_paths_v1
-    # swagger options, overriding the shared ones from the merged specs (?)
-    info:
-      version: 1.0.0-beta
-      title: Wikimedia REST API
-      description: >
-          This API aims to provide coherent and low-latency access to
-          Wikimedia content and services. It is currently in beta testing, so
-          things aren't completely locked down yet. Each entry point has
-          explicit stability markers to inform you about development status
-          and change policy, according to [our API version
-          policy](https://www.mediawiki.org/wiki/API_versioning).
+    x-modules:
+        # swagger options, overriding the shared ones from the merged specs (?)
+      - spec:
+          info:
+            version: 1.0.0-beta
+            title: Wikimedia REST API
+            description: >
+                This API aims to provide coherent and low-latency access to
+                Wikimedia content and services. It is currently in beta testing, so
+                things aren't completely locked down yet. Each entry point has
+                explicit stability markers to inform you about development status
+                and change policy, according to [our API version
+                policy](https://www.mediawiki.org/wiki/API_versioning).
 
-          ### High-volume access
-            - Don't perform more than 200 requests/s to this API.
-            - Set a unique `User-Agent` header that allows us to contact you
-              quickly. Email addresses or URLs of contact pages work well.
+                ### High-volume access
+                  - Don't perform more than 200 requests/s to this API.
+                  - Set a unique `User-Agent` header that allows us to contact you
+                    quickly. Email addresses or URLs of contact pages work well.
 
-      termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
-      contact:
-        name: the Wikimedia Services team
-        url: http://mediawiki.org/wiki/RESTBase
-      license:
-        name: Apache2
-        url: http://www.apache.org/licenses/LICENSE-2.0
+            termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+            contact:
+              name: the Wikimedia Services team
+              url: http://mediawiki.org/wiki/RESTBase
+            license:
+              name: Apache2
+              url: http://www.apache.org/licenses/LICENSE-2.0
 
-    securityDefinitions: &wp/content-security/1.0.0
-      mediawiki_auth:
-        description: Checks permissions using MW api
-        type: apiKey
-        in: header
-        name: cookie
-        x-internal-request-whitelist:
-          - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
-          - http://parsoid-beta.wmflabs.org
-      header_match:
-        description: Checks client ip against one of the predefined whitelists
-        x-error-message: This client is not allowed to use the endpoint
-        x-whitelists:
-          internal:
-            - /^(?:::ffff:)?(?:10|127)\./
-        x-is-api: true
-    # Override the base path for host-based (proxied) requests. In our case,
-    # we proxy https://{domain}/api/rest_v1/ to the API.
-    x-host-basePath: /api/rest_v1
+          securityDefinitions: &wp/content-security/1.0.0
+            mediawiki_auth:
+              description: Checks permissions using MW api
+              type: apiKey
+              in: header
+              name: cookie
+              x-internal-request-whitelist:
+                - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
+                - http://parsoid-beta.wmflabs.org
+            header_match:
+              description: Checks client ip against one of the predefined whitelists
+              x-error-message: This client is not allowed to use the endpoint
+              x-whitelists:
+                internal:
+                  - /^(?:::ffff:)?(?:10|127)\./
+              x-is-api: true
+          # Override the base path for host-based (proxied) requests. In our case,
+          # we proxy https://{domain}/api/rest_v1/ to the API.
+          x-host-basePath: /api/rest_v1
 
-    x-modules: &default_project_paths_v1_modules
-      /: 
-        # The main content module, defining page/* and transform entry
-        # points.
-        - path: v1/content.yaml
-      /page:
-        - path: v1/mobileapps.yaml
-          options: '{{options.mobileapps}}'
-        - path: v1/graphoid.yaml
-          options: '{{options.graphoid}}'
-        - path: v1/summary.js
-          options:
-            response_cache-control: 'max-age: 3600, s-maxage: 3600'
-      /media:
-        - path: v1/mathoid.yaml
-          options: '{{options.mathoid}}'
+          paths:
+            /page:
+              x-modules:
+                - path: v1/content.yaml
+                - path: v1/mobileapps.yaml
+                  options: '{{options.mobileapps}}'
+                - path: v1/graphoid.yaml
+                  options: '{{options.graphoid}}'
+                - path: v1/summary.js
+                  options:
+                    response_cache-control: 'max-age: 3600, s-maxage: 3600'
+            /transform:
+              x-modules:
+                - path: v1/transform.yaml
+            /media:
+              x-modules:
+                - path: v1/mathoid.yaml
+                  options: '{{options.mathoid}}'
+        options: '{{options}}'
 
-  /{api:sys}: &default_project_paths_sys
-    x-modules: &default_project_paths_sys_modules
-      /table: &sys_table
-        - type: npm
-          name: restbase-mod-table-sqlite
-          options:
-            conf: '{{options.table}}'
-      /key_value: &sys_key_value
-        - path: sys/key_value.js
-      /key_rev_value:
-        - path: sys/key_rev_value.js
-      /page_revisions:
-        - path: sys/page_revisions.js
-      /post_data: &sys_post_data
-        - path: sys/post_data.js
-      /action:
-        - path: sys/action.js
-          options: "{{options.action}}"
-      /page_save:
-        - path: sys/page_save.js
-      /parsoid:
-        - path: sys/parsoid.js
-          options:
-            parsoidHost: '{{options.parsoid.host}}'
-            # To enable mobileApps purging - add these to the config.
-            # (TODO: remove after actual purging is implemented
-            #purge:
-            #  host: '239.128.0.112'
-            #  port: 4827
+  /{api:sys}:
+    x-modules:
+      - spec:
+          paths:
+            /table: &sys_table
+              x-modules:
+                - type: npm
+                  name: restbase-mod-table-sqlite
+                  options:
+                    conf: '{{options.table}}'
+            /key_value: &sys_key_value
+              x-modules:
+                - path: sys/key_value.js
+            /key_rev_value:
+              x-modules:
+                - path: sys/key_rev_value.js
+            /page_revisions:
+              x-modules:
+                - path: sys/page_revisions.js
+            /post_data: &sys_post_data
+              x-modules:
+                - path: sys/post_data.js
+            /action:
+              x-modules:
+                - path: sys/action.js
+                  options: "{{options.action}}"
+            /page_save:
+              x-modules:
+                - path: sys/page_save.js
+            /parsoid:
+              x-modules:
+                - path: sys/parsoid.js
+                  options:
+                    parsoidHost: '{{options.parsoid.host}}'
+                    # To enable mobileApps purging - add these to the config.
+                    # (TODO: remove after actual purging is implemented
+                    #purge:
+                    #  host: '239.128.0.112'
+                    #  port: 4827
 
-            # A list of pages that we don't currently want to re-render on
-            # each edit. Most of these are huge bot-edited pages, which are
-            # rarely viewed in any case. 
-            rerenderBlacklist:
-              www.wikidata.org:
-                Q21558717: true
-                Q21505108: true
-                Q21481867: true
-                Q21521425: true
-              en.wikipedia.org:
-                Wikipedia:Administrators'_noticeboard/Incidents: true
-                User:JamesR/AdminStats: true
-                User:Kudpung/Dashboard: true
-                # Various dashboards
-                User:Breawycker/Wikipedia: true
-                User:Sonia/dashboard: true
-                User:Ocaasi/dashboard: true
-                User:Nolelover: true
-                User:Calmer_Waters: true
-                User:Technical_13/dashboard: true
-              ur.wikipedia.org:
-                نام_مقامات_ایل: true
-                نام_مقامات_ڈی: true
-                نام_مقامات_جے: true
-                نام_مقامات_جی: true
-                نام_مقامات_ایچ: true
-                نام_مقامات_ایم: true
-                نام_مقامات_ایس: true
-              commons.wikipedia.org:
-                Commons:Quality_images_candidates/candidate_list: true
-      /mobileapps:
-        - path: sys/mobileapps.yaml
-          options: '{{options.mobileapps}}'
-      /events:
-        - path: sys/events.js
-          options: '{{options.events}}'
+                    # A list of pages that we don't currently want to re-render on
+                    # each edit. Most of these are huge bot-edited pages, which are
+                    # rarely viewed in any case.
+                    rerenderBlacklist:
+                      www.wikidata.org:
+                        Q21558717: true
+                        Q21505108: true
+                        Q21481867: true
+                        Q21521425: true
+                      en.wikipedia.org:
+                        Wikipedia:Administrators'_noticeboard/Incidents: true
+                        User:JamesR/AdminStats: true
+                        User:Kudpung/Dashboard: true
+                        # Various dashboards
+                        User:Breawycker/Wikipedia: true
+                        User:Sonia/dashboard: true
+                        User:Ocaasi/dashboard: true
+                        User:Nolelover: true
+                        User:Calmer_Waters: true
+                        User:Technical_13/dashboard: true
+                      ur.wikipedia.org:
+                        نام_مقامات_ایل: true
+                        نام_مقامات_ڈی: true
+                        نام_مقامات_جے: true
+                        نام_مقامات_جی: true
+                        نام_مقامات_ایچ: true
+                        نام_مقامات_ایم: true
+                        نام_مقامات_ایس: true
+                      commons.wikipedia.org:
+                        Commons:Quality_images_candidates/candidate_list: true
+            /mobileapps:
+              x-modules:
+                - path: sys/mobileapps.yaml
+                  options: '{{options.mobileapps}}'
+            /events:
+              x-modules:
+                - path: sys/events.js
+                  options: '{{options.events}}'
+        options: '{{options}}'

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -1,98 +1,114 @@
 swagger: '2.0'
 paths:
   /{api:v1}: &default_project_paths_v1
-    # swagger options, overriding the shared ones from the merged specs (?)
-    info:
-      version: 1.0.0-beta
-      title: Wikimedia REST API
-      description: >
-          This API aims to provide coherent and low-latency access to
-          Wikimedia content and services. It is currently in beta testing, so
-          things aren't completely locked down yet. Each entry point has
-          explicit stability markers to inform you about development status
-          and change policy, according to [our API version
-          policy](https://www.mediawiki.org/wiki/API_versioning).
+    x-modules:
+        # swagger options, overriding the shared ones from the merged specs (?)
+      - spec:
+          info:
+            version: 1.0.0-beta
+            title: Wikimedia REST API
+            description: >
+                This API aims to provide coherent and low-latency access to
+                Wikimedia content and services. It is currently in beta testing, so
+                things aren't completely locked down yet. Each entry point has
+                explicit stability markers to inform you about development status
+                and change policy, according to [our API version
+                policy](https://www.mediawiki.org/wiki/API_versioning).
 
-          ### High-volume access
-            - Don't perform more than 200 requests/s to this API.
-            - Set a unique `User-Agent` header that allows us to contact you
-              quickly. Email addresses or URLs of contact pages work well.
+                ### High-volume access
+                  - Don't perform more than 200 requests/s to this API.
+                  - Set a unique `User-Agent` header that allows us to contact you
+                    quickly. Email addresses or URLs of contact pages work well.
 
-      termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
-      contact:
-        name: the Wikimedia Services team
-        url: http://mediawiki.org/wiki/RESTBase
-      license:
-        name: Apache2
-        url: http://www.apache.org/licenses/LICENSE-2.0
+            termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+            contact:
+              name: the Wikimedia Services team
+              url: http://mediawiki.org/wiki/RESTBase
+            license:
+              name: Apache2
+              url: http://www.apache.org/licenses/LICENSE-2.0
 
-    securityDefinitions: &wp/content-security/1.0.0
-      mediawiki_auth:
-        description: Checks permissions using MW api
-        type: apiKey
-        in: header
-        name: cookie
-        x-internal-request-whitelist:
-          - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
-          - http://parsoid-beta.wmflabs.org
-      header_match:
-        description: Checks client ip against one of the predefined whitelists
-        x-error-message: This client is not allowed to use the endpoint
-        x-whitelists:
-          internal:
-            - /^(?:::ffff:)?(?:10|127)\./
-        x-is-api: true
-    # Override the base path for host-based (proxied) requests. In our case,
-    # we proxy https://{domain}/api/rest_v1/ to the API.
-    x-host-basePath: /api/rest_v1
+          securityDefinitions: &wp/content-security/1.0.0
+            mediawiki_auth:
+              description: Checks permissions using MW api
+              type: apiKey
+              in: header
+              name: cookie
+              x-internal-request-whitelist:
+                - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
+                - http://parsoid-beta.wmflabs.org
+            header_match:
+              description: Checks client ip against one of the predefined whitelists
+              x-error-message: This client is not allowed to use the endpoint
+              x-whitelists:
+                internal:
+                  - /^(?:::ffff:)?(?:10|127)\./
+              x-is-api: true
+          # Override the base path for host-based (proxied) requests. In our case,
+          # we proxy https://{domain}/api/rest_v1/ to the API.
+          x-host-basePath: /api/rest_v1
 
-    x-modules: &default_project_paths_v1_modules
-      /:
-        # The main content module, defining page/* and transform entry
-        # points.
-        - path: v1/content.yaml
-      /page:
-        - path: v1/mobileapps.yaml
-          options: '{{options.mobileapps}}'
-        - path: v1/graphoid.yaml
-          options: '{{options.graphoid}}'
-        - path: v1/definition.yaml
-          options:
-            response_cache-control: 'max-age: 3600, s-maxage: 3600'
-            host: '{{options.mobileapps.host}}'
-      /media:
-        - path: v1/mathoid.yaml
-          options: '{{options.mathoid}}'
+          paths:
+            /page:
+              x-modules:
+                - path: v1/content.yaml
+                - path: v1/mobileapps.yaml
+                  options: '{{options.mobileapps}}'
+                - path: v1/graphoid.yaml
+                  options: '{{options.graphoid}}'
+                - path: v1/definition.yaml
+                  options:
+                    response_cache-control: 'max-age: 3600, s-maxage: 3600'
+                    host: '{{options.mobileapps.host}}'
+            /transform:
+              x-modules:
+                - path: v1/transform.yaml
+            /media:
+              x-modules:
+                - path: v1/mathoid.yaml
+                  options: '{{options.mathoid}}'
+        options: '{{options}}'
 
-  /{api:sys}: &default_project_paths_sys
-    x-modules: &default_project_paths_sys_modules
-      /table: &sys_table
-        - type: npm
-          name: restbase-mod-table-cassandra
-          # See:
-          # https://github.com/wikimedia/restbase-mod-table-cassandra/blob/master/Readme.md#configuration
-          options:
-            conf: '{{options.table}}'
-      /key_value: &sys_key_value
-        - path: sys/key_value.js
-      /key_rev_value:
-        - path: sys/key_rev_value.js
-      /page_revisions:
-        - path: sys/page_revisions.js
-      /post_data: &sys_post_data
-        - path: sys/post_data.js
-      /action:
-        - path: sys/action.js
-          options: "{{options.action}}"
-      /page_save:
-        - path: sys/page_save.js
-      /parsoid:
-        - path: sys/parsoid.js
-          options:
-            parsoidHost: '{{options.parsoid.host}}'
-      /mobileapps:
-        - path: sys/mobileapps.yaml
-          options: '{{options.mobileapps}}'
-      /events:
-        - path: sys/events.js
-          options: '{{options.events}}'
+  /{api:sys}:
+    x-modules:
+      - spec:
+          paths:
+            /table: &sys_table
+              x-modules:
+                - type: npm
+                  name: restbase-mod-table-cassandra
+                  options:
+                    conf: '{{options.table}}'
+            /key_value: &sys_key_value
+              x-modules:
+                - path: sys/key_value.js
+            /key_rev_value:
+              x-modules:
+                - path: sys/key_rev_value.js
+            /page_revisions:
+              x-modules:
+                - path: sys/page_revisions.js
+            /post_data: &sys_post_data
+              x-modules:
+                - path: sys/post_data.js
+            /action:
+              x-modules:
+                - path: sys/action.js
+                  options: "{{options.action}}"
+            /page_save:
+              x-modules:
+                - path: sys/page_save.js
+            /parsoid:
+              x-modules:
+                - path: sys/parsoid.js
+                  options:
+                    parsoidHost: '{{options.parsoid.host}}'
+            /mobileapps:
+              x-modules:
+                - path: sys/mobileapps.yaml
+                  options: '{{options.mobileapps}}'
+            /events:
+              x-modules:
+              - path: sys/events.js
+                options: '{{options.events}}'
+        options: '{{options}}'

--- a/test/features/events/events.js
+++ b/test/features/events/events.js
@@ -44,6 +44,7 @@ describe('Change event emitting', function() {
         .delay(100)
         .finally(function() {
             udpServer.close();
+            done(new Error('Timeout!'));
         });
     });
 
@@ -96,6 +97,7 @@ describe('Change event emitting', function() {
         .delay(100)
         .finally(function() {
             udpServer.close();
+            done(new Error('Timeout!'));
         });
     });
 });

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -10,12 +10,12 @@ var server = require('../../utils/server');
 
 var rootSpec = {
     paths: {
-        '/{domain:en.wikipedia.org}': {
-            'x-modules': {
-                '/v1': [{
-                    path: 'v1/content.yaml',
-                }]
-            }
+        '/{domain:en.wikipedia.org}/{api:v1}/page': {
+            'x-modules': [
+                {
+                    path: 'v1/content.yaml'
+                }
+            ]
         }
     }
 };
@@ -34,9 +34,7 @@ describe('tree building', function() {
         });
         return router.loadSpec(rootSpec, fakeHyperSwitch)
         .then(function() {
-            //console.log(JSON.stringify(router.tree, null, 2));
             var handler = router.route('/en.wikipedia.org/v1/page/html/Foo');
-            //console.log(handler);
             assert.equal(!!handler.value.methods.get, true);
             assert.equal(handler.params.domain, 'en.wikipedia.org');
             assert.equal(handler.params.title, 'Foo');

--- a/test/features/specification/monitoring.js
+++ b/test/features/specification/monitoring.js
@@ -31,10 +31,6 @@ function constructTests(spec, options) {
     Object.keys(paths).forEach(function(pathStr) {
         if (!pathStr) return;
         Object.keys(paths[pathStr]).filter(function(method) {
-            if (paths[pathStr][method]['x-monitor'] === undefined) {
-                throw new Error('x-monitor not specified for endpoint.'
-                    + ' Path: ' + pathStr + ' Method: ' + method)
-            }
             return paths[pathStr][method]['x-monitor'];
         })
         .forEach(function(method) {

--- a/test/test_module.yaml
+++ b/test/test_module.yaml
@@ -3,133 +3,133 @@
 swagger: 2.0
 paths:
   /{api:v1}:
-    swagger: '2.0'
-    info:
-      version: 1.0.0-beta
-      title: Wikimedia testing APIs
-      x-is-api-root: true
-    securityDefinitions: &wp/content-security/1.0.0
-      header_match:
-        description: Checks client ip against one of the predefined whitelists
-        x-error-message: This client is not allowed to use the endpoint
-        x-whitelists:
-          internal:
-            - /^(?:::ffff:)?(?:10|127)\./
-        x-is-api: true
-    paths:
-      /service/test/{title}{/revision}:
-        get:
-          x-setup-handler:
-            - init_storage:
-                uri: /{domain}/sys/key_value/testservice.test
+    x-modules:
+      - spec:
+          info:
+            version: 1.0.0-beta
+            title: Wikimedia testing APIs
+            x-is-api-root: true
+          securityDefinitions: &wp/content-security/1.0.0
+            header_match:
+              description: Checks client ip against one of the predefined whitelists
+              x-error-message: This client is not allowed to use the endpoint
+              x-whitelists:
+                internal:
+                  - /^(?:::ffff:)?(?:10|127)\./
+              x-is-api: true
+          paths:
+            /service/test/{title}{/revision}:
+              get:
+                x-setup-handler:
+                  - init_storage:
+                      uri: /{domain}/sys/key_value/testservice.test
 
-          x-request-handler:
-            - get_from_storage:
-                request:
-                  uri: /{domain}/sys/key_value/testservice.test/{title}
-                  headers:
-                    'cache-control': '{{cache-control}}'
-                catch:
-                  status: 404
-                return_if:
-                  status: 200
-            - get_from_api:
-                request:
-                  uri: http://en.wikipedia.org/wiki/{+title}
-                  body: '{{request.body}}'
-            - store:
-                request:
-                  method: put
-                  uri: /{domain}/sys/key_value/testservice.test/{title}
-                  headers: '{{get_from_api.headers}}'
-                  body: '{{get_from_api.body}}'
-            - return_response:
-                return:
-                  status: '{{get_from_api.status}}'
-                  headers:
-                    'content-type': '{{get_from_api.headers.content-type}}'
-                    'etag': '{{store.headers.etag}}'
-                  body: '{{get_from_api.body}}'
+                x-request-handler:
+                  - get_from_storage:
+                      request:
+                        uri: /{domain}/sys/key_value/testservice.test/{title}
+                        headers:
+                          'cache-control': '{{cache-control}}'
+                      catch:
+                        status: 404
+                      return_if:
+                        status: 200
+                  - get_from_api:
+                      request:
+                        uri: http://en.wikipedia.org/wiki/{+title}
+                        body: '{{request.body}}'
+                  - store:
+                      request:
+                        method: put
+                        uri: /{domain}/sys/key_value/testservice.test/{title}
+                        headers: '{{get_from_api.headers}}'
+                        body: '{{get_from_api.body}}'
+                  - return_response:
+                      return:
+                        status: '{{get_from_api.status}}'
+                        headers:
+                          'content-type': '{{get_from_api.headers.content-type}}'
+                          'etag': '{{store.headers.etag}}'
+                        body: '{{get_from_api.body}}'
 
-          x-monitor: false
+                x-monitor: false
 
-      /service/test_parallel/{key1}/{key2}:
-        get:
-          x-request-handler:
-            - get_from_api1:
-                request:
-                  uri: http://en.wikipedia.org/wiki/{+key1}
-              get_from_api2:
-                request:
-                  uri: http://en.wikipedia.org/wiki/{+key2}
-            - return_response:
-                return:
-                  status: 200
-                  body:
-                    first: '{{global.get_from_api1}}'
-                    second: '{{global.get_from_api2}}'
-          x-monitor: true
-          x-amples:
-            - title: Retreives parallel content with simple service
-              request:
-                params:
-                  key1: User:GWicke/Date
-                  key2: User:GWicke/Date
-              response:
-                status: 200
-                body:
-                  first:
-                    status: 200
-                    headers:
-                      content-type: /^text\/html.+/
-                  second:
-                    status: 200
-                    headers:
-                      content-type: /^text\/html.+/
+            /service/test_parallel/{key1}/{key2}:
+              get:
+                x-request-handler:
+                  - get_from_api1:
+                      request:
+                        uri: http://en.wikipedia.org/wiki/{+key1}
+                    get_from_api2:
+                      request:
+                        uri: http://en.wikipedia.org/wiki/{+key2}
+                  - return_response:
+                      return:
+                        status: 200
+                        body:
+                          first: '{{global.get_from_api1}}'
+                          second: '{{global.get_from_api2}}'
+                x-monitor: true
+                x-amples:
+                  - title: Retreives parallel content with simple service
+                    request:
+                      params:
+                        key1: User:GWicke/Date
+                        key2: User:GWicke/Date
+                    response:
+                      status: 200
+                      body:
+                        first:
+                          status: 200
+                          headers:
+                            content-type: /^text\/html.+/
+                        second:
+                          status: 200
+                          headers:
+                            content-type: /^text\/html.+/
 
-      /post_data/:
-        post:
-          security:
-            - header_match:
-                - header: 'x-client-ip'
-                  patterns:
-                    - internal
-          x-request-handler:
-            - put_to_storage:
-                request:
-                  method: put
-                  uri: /{domain}/sys/post_data/post.test/
-                  headers: '{{request.headers}}'
-                  body: '{{request.body}}'
-          x-monitor: false
+            /post_data/:
+              post:
+                security:
+                  - header_match:
+                      - header: 'x-client-ip'
+                        patterns:
+                          - internal
+                x-request-handler:
+                  - put_to_storage:
+                      request:
+                        method: put
+                        uri: /{domain}/sys/post_data/post.test/
+                        headers: '{{request.headers}}'
+                        body: '{{request.body}}'
+                x-monitor: false
 
-      /post_data/{hash}:
-        get:
-          x-setup-handler:
-            - init_storage:
-                uri: /{domain}/sys/post_data/post.test
-          x-request-handler:
-            - get_from_storage:
-                request:
-                  uri: /{domain}/sys/post_data/post.test/{hash}
-          x-monitor: false
+            /post_data/{hash}:
+              get:
+                x-setup-handler:
+                  - init_storage:
+                      uri: /{domain}/sys/post_data/post.test
+                x-request-handler:
+                  - get_from_storage:
+                      request:
+                        uri: /{domain}/sys/post_data/post.test/{hash}
+                x-monitor: false
 
-      /buckets:
-        x-modules:
-          /key_rev_large_value:
-            - path: sys/key_rev_large_value.js
-          /key_rev_value:
-            - path: sys/key_rev_value.js
-          /key_value:
-            - path: sys/key_value.js
+            /buckets/key_rev_large_value:
+              x-modules:
+                - path: sys/key_rev_large_value.js
+            /buckets/key_rev_value:
+              x-modules:
+                - path: sys/key_rev_value.js
+            /buckets/key_value:
+              x-modules:
+                - path: sys/key_value.js
 
-      /events:
-        x-modules:
-          /:
-            - path: sys/events.js
-              options: '{{options.events}}'
-
-      /events_no_config:
-        x-modules:
-          /:
-            - path: sys/events.js
+            /events:
+              x-modules:
+                - path: sys/events.js
+                  options: '{{options.events}}'
+            /events_no_config:
+              x-modules:
+                - path: sys/events.js
+        options: '{{options}}'

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
-  /{module:page}/:
+  /:
     get:
       tags:
         - Page content
@@ -32,7 +32,7 @@ paths:
             $ref: '#/definitions/problem'
       x-monitor: false
 
-  /{module:page}/title/:
+  /title/:
     get:
       tags:
         - Page content
@@ -64,7 +64,7 @@ paths:
                 page: '{{page}}'
       x-monitor: false
 
-  /{module:page}/title/{title}:
+  /title/{title}:
     get:
       tags:
         - Page content
@@ -136,7 +136,7 @@ paths:
                   tid: /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
                   comment: /.*/
 
-  /{module:page}/title/{title}/:
+  /title/{title}/:
     get:
       tags:
         - Page content
@@ -178,7 +178,7 @@ paths:
                 page: '{{page}}'
       x-monitor: false
 
-  /{module:page}/html/:
+  /html/:
     get:
       tags:
         - Page content
@@ -210,7 +210,7 @@ paths:
                 page: '{{page}}'
       x-monitor: false
 
-  /{module:page}/html/{title}:
+  /html/{title}:
     get:
       tags:
         - Page content
@@ -402,7 +402,7 @@ paths:
               body: '{{request.body}}'
       x-monitor: false
 
-  /{module:page}/html/{title}/:
+  /html/{title}/:
     get:
       tags:
         - Page content
@@ -446,7 +446,7 @@ paths:
                 page: '{{page}}'
       x-monitor: false
 
-  /{module:page}/html/{title}/{revision}{/tid}:
+  /html/{title}/{revision}{/tid}:
     get:
       tags:
         - Page content
@@ -535,7 +535,7 @@ paths:
                 sections: '{{sections}}'
       x-monitor: false
 
-  /{module:page}/data-parsoid/:
+  /data-parsoid/:
     get:
       tags:
         - Page content
@@ -576,7 +576,7 @@ paths:
                 page: '{{page}}'
       x-monitor: false
 
-  /{module:page}/data-parsoid/{title}:
+  /data-parsoid/{title}:
     get:
       tags:
         - Page content
@@ -636,7 +636,7 @@ paths:
               ids: /.*/
               sectionOffsets: /.*/
 
-  /{module:page}/data-parsoid/{title}/:
+  /data-parsoid/{title}/:
     get:
       tags:
         - Page content
@@ -684,7 +684,7 @@ paths:
               page: '{{page}}'
       x-monitor: false
 
-  /{module:page}/data-parsoid/{title}/{revision}{/tid}:
+  /data-parsoid/{title}/{revision}{/tid}:
     get:
       tags:
         - Page content
@@ -755,7 +755,7 @@ paths:
                 x-restbase-parentrevision: '{{x-restbase-parentrevision}}'
       x-monitor: false
 
-  /{module:page}/revision/:
+  /revision/:
     get:
       tags:
         - Page content
@@ -788,7 +788,7 @@ paths:
                 page: '{{page}}'
       x-monitor: false
 
-  /{module:page}/revision/{revision}:
+  /revision/{revision}:
     get:
       tags:
         - Page content
@@ -850,7 +850,7 @@ paths:
                   tid: /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
                   comment: /.*/
 
-  /{module:page}/wikitext/{title}:
+  /wikitext/{title}:
     post:
       tags:
         - Page content
@@ -943,314 +943,6 @@ paths:
               uri: /{domain}/sys/page_save/wikitext/{title}
               headers: '{{request.headers}}'
               body: '{{request.body}}'
-      x-monitor: false
-
-  /{module:transform}/html/to/wikitext{/title}{/revision}:
-    post:
-      tags:
-        - Transforms
-      summary: Transform HTML to Wikitext
-      description: |
-        Transform [Parsoid HTML](https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec)
-        to Wikitext.
-
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
-      consumes:
-        - multipart/form-data
-      produces:
-        - text/plain; profile="mediawiki.org/specs/wikitext/1.0.0"
-      parameters:
-        - name: title
-          in: path
-          description: The page title
-          type: string
-          required: false
-        - name: revision
-          in: path
-          description: The page revision
-          type: integer
-          required: false
-        - name: html
-          in: formData
-          description: The HTML to transform
-          type: string
-          required: true
-          x-textarea: true
-        - name: scrub_wikitext
-          in: formData
-          description: Normalise the DOM to yield cleaner wikitext?
-          type: boolean
-          required: false
-      responses:
-        '200':
-          description: MediaWiki Wikitext.
-          schema:
-            type: string
-        '403':
-          description: Access to the specific revision is restricted
-          schema:
-            $ref: '#/definitions/problem'
-        '404':
-          description: Unknown page title or revision
-          schema:
-            $ref: '#/definitions/problem'
-        '409':
-          description: Revision was restricted
-          schema:
-            $ref: '#/definitions/problem'
-        '410':
-          description: Page was deleted
-          schema:
-            $ref: '#/definitions/problem'
-        default:
-          description: Error
-          schema:
-            $ref: '#/definitions/problem'
-      x-request-handler:
-        - get_from_backend:
-            request:
-              uri: /{domain}/sys/parsoid/transform/html/to/wikitext{/title}{/revision}
-              headers:
-                if-match: '{{if-match}}'
-              body:
-                html: '{{html}}'
-                scrub_wikitext: '{{scrub_wikitext}}'
-      x-monitor: false
-
-  /{module:transform}/wikitext/to/html{/title}{/revision}:
-    post:
-      tags:
-        - Transforms
-      summary: Transform Wikitext to HTML
-      description: |
-        Transform wikitext to HTML. Note that if you set `stash: true`, you
-        also need to supply the title.
-
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
-      consumes:
-        - multipart/form-data
-      produces:
-        - text/html; profile="mediawiki.org/specs/html/1.1.0"
-      parameters:
-        - name: title
-          in: path
-          description: The page title
-          type: string
-          required: false
-        - name: revision
-          in: path
-          description: The page revision
-          type: integer
-          required: false
-        - name: wikitext
-          in: formData
-          description: The Wikitext to transform to HTML
-          type: string
-          required: true
-          x-textarea: true
-        - name: body_only
-          in: formData
-          description: Return only `body.innerHTML`
-          type: boolean
-          required: false
-        - name: stash
-          in: formData
-          description: Whether to temporarily stash the result of the transformation
-          type: boolean
-          required: false
-      responses:
-        '200':
-          description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec
-          schema:
-            type: string
-        '403':
-          description: access to the specific revision is restricted
-          schema:
-            $ref: '#/definitions/problem'
-        '404':
-          description: Unknown page title or revision
-          schema:
-            $ref: '#/definitions/problem'
-        '409':
-          description: Revision was restricted
-          schema:
-            $ref: '#/definitions/problem'
-        '410':
-          description: Page was deleted
-          schema:
-            $ref: '#/definitions/problem'
-        default:
-          description: Error
-          schema:
-            $ref: '#/definitions/problem'
-      x-request-handler:
-        - get_from_backend:
-            request:
-              uri: /{domain}/sys/parsoid/transform/wikitext/to/html{/title}{/revision}
-              body:
-                wikitext: '{{wikitext}}'
-                body_only: '{{body_only}}'
-                stash: '{{stash}}'
-      x-monitor: true
-      x-amples:
-        - title: Transform wikitext to html
-          request:
-            params:
-              domain: en.wikipedia.org
-              title: Foobar
-            body:
-              wikitext: == Heading ==
-              body_only: true
-          response:
-            status: 200
-            headers:
-              content-type: /^text\/html.+/
-            body: /^<h2.*> Heading <\/h2>$/
-
-# Keeping this in, as we'll re-introduce a html2html end point later.
-#  /{module:transform}/html/to/html{/title}{/revision}:
-#    post:
-#      tags:
-#        - Transforms
-#
-#      description: |
-#        Update / refresh / sanitize HTML
-#
-#        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
-#      consumes:
-#        - multipart/form-data
-#      produces:
-#        - text/html; profile="mediawiki.org/specs/html/1.1.0"
-#      parameters:
-#        - name: title
-#          in: path
-#          description: The page title
-#          type: string
-#          required: false
-#        - name: revision
-#          in: path
-#          description: The page revision
-#          type: integer
-#          required: false
-#        - name: html
-#          in: formData
-#          description: The HTML to transform
-#          type: string
-#          required: true
-#          x-textarea: true
-#        - name: body_only
-#          in: formData
-#          description: Return only `body.innerHTML`
-#          type: boolean
-#          required: false
-#      responses:
-#        '200':
-#          description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec
-#        '403':
-#          description: access to the specific revision is restricted
-#          schema:
-#            $ref: '#/definitions/problem'
-#        '404':
-#          description: Unknown page title or revision
-#          schema:
-#            $ref: '#/definitions/problem'
-#        '409':
-#          description: Revision was restricted
-#          schema:
-#            $ref: '#/definitions/problem'
-#        '410':
-#          description: Page was deleted
-#          schema:
-#            $ref: '#/definitions/problem'
-#        default:
-#          description: Error
-#          schema:
-#            $ref: '#/definitions/problem'
-#      x-request-handler:
-#        - get_from_backend:
-#            request:
-#              uri: /{domain}/sys/parsoid/transform/html/to/html{/title}{/revision}
-#              headers:
-#                if-match: '{{if-match}}'
-#              body:
-#                html: '{{html}}'
-#                body_only: '{{body_only}}'
-#      x-monitor: false
-
-  /{module:transform}/sections/to/wikitext/{title}/{revision}:
-    post:
-      tags:
-        - Transforms
-
-      summary: Transform modified HTML sections to Wikitext.
-      description: |
-        This entry point provides efficient HTML section edit functionality.
-        The client can send back only modified HTML sections, and retrieve the
-        full Wikitext of the page.
-
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
-      consumes:
-        - application/json
-        - multipart/form-data
-      produces:
-        - text/html; profile="mediawiki.org/specs/html/1.1.0"
-      parameters:
-        - name: title
-          in: path
-          description: The page title
-          type: string
-          required: true
-        - name: revision
-          in: path
-          description: The page revision
-          type: integer
-          required: true
-        - name: sections
-          in: body
-          description: Sections to transform
-          required: true
-          schema:
-            type: 'object'
-            properties:
-              sections:
-                example: '{"mwAg":"<h2>First Section replaced</h2><h2>Appended Section</h2>"}'
-            required:
-              - sections
-      responses:
-        '200':
-          description: Wikitext of the full page.
-          schema:
-            type: string
-        '400':
-          description: Illegal JSON provided or section id does not exist
-          schema:
-            $ref: '#/definitions/problem'
-        '403':
-          description: access to the specific revision is restricted
-          schema:
-            $ref: '#/definitions/problem'
-        '404':
-          description: Unknown page title or revision
-          schema:
-            $ref: '#/definitions/problem'
-        '409':
-          description: Revision was restricted
-          schema:
-            $ref: '#/definitions/problem'
-        '410':
-          description: Page was deleted
-          schema:
-            $ref: '#/definitions/problem'
-        default:
-          description: Error
-          schema:
-            $ref: '#/definitions/problem'
-      x-request-handler:
-        - get_from_backend:
-            request:
-              uri: /{domain}/sys/parsoid/transform/sections/to/wikitext/{title}/{revision}
-              body:
-                sections: '{{sections}}'
       x-monitor: false
 
 definitions:

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -1,0 +1,336 @@
+swagger: '2.0'
+info:
+  version: '1.0.0-beta'
+  title: MediaWiki Content API
+  description: Basic MediaWiki content api.
+  termsofservice: https://github.com/wikimedia/restbase#restbase
+  contact:
+    name: Services
+    email: services@lists.wikimedia.org
+    url: https://www.mediawiki.org/wiki/Services
+  license:
+    name: Apache licence, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /html/to/wikitext{/title}{/revision}:
+    post:
+      tags:
+        - Transforms
+      summary: Transform HTML to Wikitext
+      description: |
+        Transform [Parsoid HTML](https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec)
+        to Wikitext.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      consumes:
+        - multipart/form-data
+      produces:
+        - text/plain; profile="mediawiki.org/specs/wikitext/1.0.0"
+      parameters:
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: false
+        - name: revision
+          in: path
+          description: The page revision
+          type: integer
+          required: false
+        - name: html
+          in: formData
+          description: The HTML to transform
+          type: string
+          required: true
+          x-textarea: true
+        - name: scrub_wikitext
+          in: formData
+          description: Normalise the DOM to yield cleaner wikitext?
+          type: boolean
+          required: false
+      responses:
+        '200':
+          description: MediaWiki Wikitext.
+          schema:
+            type: string
+        '403':
+          description: Access to the specific revision is restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '404':
+          description: Unknown page title or revision
+          schema:
+            $ref: '#/definitions/problem'
+        '409':
+          description: Revision was restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '410':
+          description: Page was deleted
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: /{domain}/sys/parsoid/transform/html/to/wikitext{/title}{/revision}
+              headers:
+                if-match: '{{if-match}}'
+              body:
+                html: '{{html}}'
+                scrub_wikitext: '{{scrub_wikitext}}'
+      x-monitor: false
+
+  /wikitext/to/html{/title}{/revision}:
+    post:
+      tags:
+        - Transforms
+      summary: Transform Wikitext to HTML
+      description: |
+        Transform wikitext to HTML. Note that if you set `stash: true`, you
+        also need to supply the title.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      consumes:
+        - multipart/form-data
+      produces:
+        - text/html; profile="mediawiki.org/specs/html/1.1.0"
+      parameters:
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: false
+        - name: revision
+          in: path
+          description: The page revision
+          type: integer
+          required: false
+        - name: wikitext
+          in: formData
+          description: The Wikitext to transform to HTML
+          type: string
+          required: true
+          x-textarea: true
+        - name: body_only
+          in: formData
+          description: Return only `body.innerHTML`
+          type: boolean
+          required: false
+        - name: stash
+          in: formData
+          description: Whether to temporarily stash the result of the transformation
+          type: boolean
+          required: false
+      responses:
+        '200':
+          description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec
+          schema:
+            type: string
+        '403':
+          description: access to the specific revision is restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '404':
+          description: Unknown page title or revision
+          schema:
+            $ref: '#/definitions/problem'
+        '409':
+          description: Revision was restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '410':
+          description: Page was deleted
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: /{domain}/sys/parsoid/transform/wikitext/to/html{/title}{/revision}
+              body:
+                wikitext: '{{wikitext}}'
+                body_only: '{{body_only}}'
+                stash: '{{stash}}'
+      x-monitor: true
+      x-amples:
+        - title: Transform wikitext to html
+          request:
+            params:
+              domain: en.wikipedia.org
+              title: Foobar
+            body:
+              wikitext: == Heading ==
+              body_only: true
+          response:
+            status: 200
+            headers:
+              content-type: /^text\/html.+/
+            body: /^<h2.*> Heading <\/h2>$/
+
+# Keeping this in, as we'll re-introduce a html2html end point later.
+#  /html/to/html{/title}{/revision}:
+#    post:
+#      tags:
+#        - Transforms
+#
+#      description: |
+#        Update / refresh / sanitize HTML
+#
+#        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+#      consumes:
+#        - multipart/form-data
+#      produces:
+#        - text/html; profile="mediawiki.org/specs/html/1.1.0"
+#      parameters:
+#        - name: title
+#          in: path
+#          description: The page title
+#          type: string
+#          required: false
+#        - name: revision
+#          in: path
+#          description: The page revision
+#          type: integer
+#          required: false
+#        - name: html
+#          in: formData
+#          description: The HTML to transform
+#          type: string
+#          required: true
+#          x-textarea: true
+#        - name: body_only
+#          in: formData
+#          description: Return only `body.innerHTML`
+#          type: boolean
+#          required: false
+#      responses:
+#        '200':
+#          description: See wikipage https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec
+#        '403':
+#          description: access to the specific revision is restricted
+#          schema:
+#            $ref: '#/definitions/problem'
+#        '404':
+#          description: Unknown page title or revision
+#          schema:
+#            $ref: '#/definitions/problem'
+#        '409':
+#          description: Revision was restricted
+#          schema:
+#            $ref: '#/definitions/problem'
+#        '410':
+#          description: Page was deleted
+#          schema:
+#            $ref: '#/definitions/problem'
+#        default:
+#          description: Error
+#          schema:
+#            $ref: '#/definitions/problem'
+#      x-request-handler:
+#        - get_from_backend:
+#            request:
+#              uri: /{domain}/sys/parsoid/transform/html/to/html{/title}{/revision}
+#              headers:
+#                if-match: '{if-match}'
+#              body:
+#                html: '{html}'
+#                body_only: '{body_only}'
+#      x-monitor: false
+
+  /sections/to/wikitext/{title}/{revision}:
+    post:
+      tags:
+        - Transforms
+
+      summary: Transform modified HTML sections to Wikitext.
+      description: |
+        This entry point provides efficient HTML section edit functionality.
+        The client can send back only modified HTML sections, and retrieve the
+        full Wikitext of the page.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      consumes:
+        - application/json
+        - multipart/form-data
+      produces:
+        - text/html; profile="mediawiki.org/specs/html/1.1.0"
+      parameters:
+        - name: title
+          in: path
+          description: The page title
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: The page revision
+          type: integer
+          required: true
+        - name: sections
+          in: body
+          description: Sections to transform
+          required: true
+          schema:
+            type: 'object'
+            properties:
+              sections:
+                example: '{"mwAg":"<h2>First Section replaced</h2><h2>Appended Section</h2>"}'
+            required:
+              - sections
+      responses:
+        '200':
+          description: Wikitext of the full page.
+          schema:
+            type: string
+        '400':
+          description: Illegal JSON provided or section id does not exist
+          schema:
+            $ref: '#/definitions/problem'
+        '403':
+          description: access to the specific revision is restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '404':
+          description: Unknown page title or revision
+          schema:
+            $ref: '#/definitions/problem'
+        '409':
+          description: Revision was restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '410':
+          description: Page was deleted
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: /{domain}/sys/parsoid/transform/sections/to/wikitext/{title}/{revision}
+              body:
+                sections: '{{sections}}'
+      x-monitor: false
+
+definitions:
+  # A https://tools.ietf.org/html/draft-nottingham-http-problem
+  problem:
+    required:
+      - type
+    properties:
+      type:
+        type: string
+      title:
+        type: string
+      detail:
+        type: string
+      instance:
+        type: string


### PR DESCRIPTION
As we've discussed, current config situation is bad - all of the configs are invalid swagger specs. I've made a change to `HyperSwitch` to change the config format one more last time. Now every module exports a valid swagger spec, modules can be nested in whatever way user wants, and, what's most important, the API is very simple and straightforward: You have a valid swagger spec, and on a path you can either specify handlers, or load a set of modules which will be bound to the current path. Modules can also be inlined if you don't want to have too many files.

This is still work in progress, but I've created this PR to give a glance on how our configs will look like when it's all finished.