### PR TITLE
MobileApps: propagate the headers received from the service

### DIFF
--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -52,9 +52,7 @@ paths:
                 cache-control: '{{cache-control}}'
             return: 
               status: '{{from_backend.status}}'
-              headers:
-                content-type: '{{content-type}}'
-                cache-control: 's-maxage: 3600, max-age: 3600'
+              headers: '{{ merge({"cache-control": "s-maxage: 3600, max-age: 3600"}, from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: true
       x-amples:
@@ -119,9 +117,7 @@ paths:
               uri: /{domain}/sys/mobileapps/mobile-sections-lead/{title}
             return: 
               status: '{{from_backend.status}}'
-              headers:
-                content-type: '{{content-type}}'
-                cache-control: 's-maxage: 3600, max-age: 3600'
+              headers: '{{ merge({"cache-control": "s-maxage: 3600, max-age: 3600"}, from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: false
 
@@ -174,9 +170,7 @@ paths:
               uri: /{domain}/sys/mobileapps/mobile-sections-remaining/{title}
             return: 
               status: '{{from_backend.status}}'
-              headers:
-                content-type: '{{content-type}}'
-                cache-control: 's-maxage: 3600, max-age: 3600'
+              headers: '{{ merge({"cache-control": "s-maxage: 3600, max-age: 3600"}, from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: false
 
@@ -227,8 +221,6 @@ paths:
                 cache-control: '{cache-control}'
             return:
               status: '{{from_backend.status}}'
-              headers:
-                content-type: '{{content-type}}'
-                cache-control: 's-maxage: 3600, max-age: 3600'
+              headers: '{{ merge({"cache-control": "s-maxage: 3600, max-age: 3600"}, from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: false


### PR DESCRIPTION
In PR #511 we added the caching headers to the mobile-sections end points' responses. However, these were overwriting the headers returned by the service itself (such as ETag). This brings them back and merges them with our cache-control response header.

Bug: [T113591](https://phabricator.wikimedia.org/T113591)