### PR TITLE
Completely removed parsoid-lb endpoint from the codebase

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -17,7 +17,7 @@ default_project: &default_project
               - name: default.group.local
                 domains: /./
           parsoid:
-            host: http://parsoid-lb.eqiad.wikimedia.org
+            host: http://parsoid-beta.wmflabs.org
           action:
             apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
           graphoid:

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -33,7 +33,6 @@ paths:
         name: cookie
         x-internal-request-whitelist:
           - /http:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
-          - http://parsoid-lb.eqiad.wikimedia.org
       header_match:
         description: Checks client ip against one of the predefined whitelists
         x-error-message: This client is not allowed to use the endpoint

--- a/projects/wikimedia.org_sqlite.yaml
+++ b/projects/wikimedia.org_sqlite.yaml
@@ -33,7 +33,6 @@ paths:
         name: cookie
         x-internal-request-whitelist:
           - /http:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
-          - http://parsoid-lb.eqiad.wikimedia.org
       header_match:
         description: Checks client ip against one of the predefined whitelists
         x-error-message: This client is not allowed to use the endpoint

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -33,7 +33,6 @@ paths:
         name: cookie
         x-internal-request-whitelist:
           - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
-          - http://parsoid-lb.eqiad.wikimedia.org
           - http://parsoid-beta.wmflabs.org
       header_match:
         description: Checks client ip against one of the predefined whitelists

--- a/projects/wmf_sqlite.yaml
+++ b/projects/wmf_sqlite.yaml
@@ -33,7 +33,6 @@ paths:
         name: cookie
         x-internal-request-whitelist:
           - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
-          - http://parsoid-lb.eqiad.wikimedia.org
           - http://parsoid-beta.wmflabs.org
       header_match:
         description: Checks client ip against one of the predefined whitelists

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -34,7 +34,6 @@ paths:
         name: cookie
         x-internal-request-whitelist:
           - /https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
-          - http://parsoid-lb.eqiad.wikimedia.org
           - http://parsoid-beta.wmflabs.org
       header_match:
         description: Checks client ip against one of the predefined whitelists


### PR DESCRIPTION
We've switched all tests to beta parsoid long time ago, but still used `parsoid-lb` endpoint for manual local testing. Now it's being decommissioned, so I'm removing it completely from the codebase. 

The main reason for keeping it was that beta parsoid was not configured to work with en.wikipedia, but now that blocker is fixed, so beta parsoid can be used for manual local testing too.

Bug: https://phabricator.wikimedia.org/T110474

cc @wikimedia/services