### PR TITLE
Update statsd config defaults for wikimedia example

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -98,7 +98,7 @@ logging:
   #  port: <%= @logstash_port %>
 
 metrics:
-  #type: txstatsd
-  #host: localhost
-  #port: 8125
-  #batch: true
+  type: statsd
+  host: localhost
+  port: 8125
+  batch: true


### PR DESCRIPTION
- Use statsd module by default.
- Enable batching to minimize overheads.