### PR TITLE
Improve purging & caching

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -27,6 +27,8 @@ default_project: &default_project
           cache-control: s-maxage=864000, max-age=86400
         mobileapps:
           host: http://appservice.wmflabs.org
+        # 10 days Varnish caching, one day client-side
+        purged_cache_control: s-maxage=864000, max-age=86400
 
 # A different project template, sharing configuration options.
 wikimedia.org: &wikimedia.org
@@ -99,7 +101,7 @@ logging:
   #  port: <%= @logstash_port %>
 
 metrics:
-  type: statsd
-  host: localhost
-  port: 8125
-  batch: true
+  #type: txstatsd
+  #host: localhost
+  #port: 8125
+  #batch: true

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -101,7 +101,7 @@ logging:
   #  port: <%= @logstash_port %>
 
 metrics:
-  #type: txstatsd
-  #host: localhost
-  #port: 8125
-  #batch: true
+  type: statsd
+  host: localhost
+  port: 8125
+  batch: true

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -86,5 +86,6 @@ paths:
                 - path: sys/parsoid.js
                   options:
                     parsoidHost: '{{options.parsoid.host}}'
+                    response_cache_control: '{{options.purged_cache_control}}'
         options: '{{options}}'
 

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -52,7 +52,8 @@ paths:
               x-modules:
                 - path: v1/content.yaml
                 - path: v1/mobileapps.yaml
-                  options: '{{options.mobileapps}}'
+                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                                options.mobileapps)}}'
                 - path: v1/graphoid.yaml
                   options: '{{options.graphoid}}'
                 - path: v1/summary.js
@@ -137,7 +138,8 @@ paths:
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.yaml
-                  options: '{{options.mobileapps}}'
+                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                                options.mobileapps)}}'
             /events:
               x-modules:
                 - path: sys/events.js

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -57,7 +57,7 @@ paths:
                   options: '{{options.graphoid}}'
                 - path: v1/summary.js
                   options:
-                    response_cache-control: 'max-age=3600, s-maxage=3600'
+                    response_cache_control: '{{options.purged_cache_control}}'
             /transform:
               x-modules:
                 - path: v1/transform.yaml
@@ -102,11 +102,7 @@ paths:
                 - path: sys/parsoid.js
                   options:
                     parsoidHost: '{{options.parsoid.host}}'
-                    # To enable mobileApps purging - add these to the config.
-                    # (TODO: remove after actual purging is implemented
-                    #purge:
-                    #  host: '239.128.0.112'
-                    #  port: 4827
+                    response_cache_control: '{{options.purged_cache_control}}'
 
                     # A list of pages that we don't currently want to re-render on
                     # each edit. Most of these are huge bot-edited pages, which are

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -52,7 +52,7 @@ paths:
               x-modules:
                 - path: v1/content.yaml
                 - path: v1/mobileapps.yaml
-                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                  options: '{{merge({"response_cache_control": options.purged_cache_control},
                                 options.mobileapps)}}'
                 - path: v1/graphoid.yaml
                   options: '{{options.graphoid}}'
@@ -138,7 +138,7 @@ paths:
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.yaml
-                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                  options: '{{merge({"response_cache_control": options.purged_cache_control},
                                 options.mobileapps)}}'
             /events:
               x-modules:

--- a/projects/wmf_sqlite.yaml
+++ b/projects/wmf_sqlite.yaml
@@ -52,7 +52,7 @@ paths:
               x-modules:
                 - path: v1/content.yaml
                 - path: v1/mobileapps.yaml
-                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                  options: '{{merge({"response_cache_control": options.purged_cache_control},
                                 options.mobileapps)}}'
                 - path: v1/graphoid.yaml
                   options: '{{options.graphoid}}'
@@ -137,7 +137,7 @@ paths:
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.yaml
-                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                  options: '{{merge({"response_cache_control": options.purged_cache_control},
                                 options.mobileapps)}}'
             /events:
               x-modules:

--- a/projects/wmf_sqlite.yaml
+++ b/projects/wmf_sqlite.yaml
@@ -52,7 +52,8 @@ paths:
               x-modules:
                 - path: v1/content.yaml
                 - path: v1/mobileapps.yaml
-                  options: '{{options.mobileapps}}'
+                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                                options.mobileapps)}}'
                 - path: v1/graphoid.yaml
                   options: '{{options.graphoid}}'
                 - path: v1/summary.js
@@ -136,7 +137,8 @@ paths:
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.yaml
-                  options: '{{options.mobileapps}}'
+                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                                options.mobileapps)}}'
             /events:
               x-modules:
                 - path: sys/events.js

--- a/projects/wmf_sqlite.yaml
+++ b/projects/wmf_sqlite.yaml
@@ -57,7 +57,7 @@ paths:
                   options: '{{options.graphoid}}'
                 - path: v1/summary.js
                   options:
-                    response_cache-control: 'max-age=3600, s-maxage=3600'
+                    response_cache-control: '{{options.purged_cache_control}}'
             /transform:
               x-modules:
                 - path: v1/transform.yaml
@@ -101,11 +101,7 @@ paths:
                 - path: sys/parsoid.js
                   options:
                     parsoidHost: '{{options.parsoid.host}}'
-                    # To enable mobileApps purging - add these to the config.
-                    # (TODO: remove after actual purging is implemented
-                    #purge:
-                    #  host: '239.128.0.112'
-                    #  port: 4827
+                    response_cache_control: '{{options.purged_cache_control}}'
 
                     # A list of pages that we don't currently want to re-render on
                     # each edit. Most of these are huge bot-edited pages, which are

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -103,6 +103,7 @@ paths:
                 - path: sys/parsoid.js
                   options:
                     parsoidHost: '{{options.parsoid.host}}'
+                    response_cache_control: '{{options.purged_cache_control}}'
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.yaml

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -53,7 +53,7 @@ paths:
               x-modules:
                 - path: v1/content.yaml
                 - path: v1/mobileapps.yaml
-                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                  options: '{{merge({"response_cache_control": options.purged_cache_control},
                                     options.mobileapps)}}'
                 - path: v1/graphoid.yaml
                   options: '{{options.graphoid}}'
@@ -108,7 +108,7 @@ paths:
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.yaml
-                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                  options: '{{merge({"response_cache_control": options.purged_cache_control},
                                 options.mobileapps)}}'
             /events:
               x-modules:

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -59,7 +59,7 @@ paths:
                   options: '{{options.graphoid}}'
                 - path: v1/definition.yaml
                   options:
-                    response_cache-control: 'max-age=3600, s-maxage=3600'
+                    response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
             /transform:
               x-modules:

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -53,7 +53,8 @@ paths:
               x-modules:
                 - path: v1/content.yaml
                 - path: v1/mobileapps.yaml
-                  options: '{{options.mobileapps}}'
+                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                                    options.mobileapps)}}'
                 - path: v1/graphoid.yaml
                   options: '{{options.graphoid}}'
                 - path: v1/definition.yaml
@@ -107,7 +108,8 @@ paths:
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.yaml
-                  options: '{{options.mobileapps}}'
+                  options: '{{merge({"response_cache_control": options.purged_cache_control}, 
+                                options.mobileapps)}}'
             /events:
               x-modules:
               - path: sys/events.js

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -363,9 +363,6 @@ PSP.generateAndSave = function(hyper, req, format, currentContentRes) {
                     body: res.body[format].body
                 };
                 resp.headers.etag = mwUtil.makeETag(rp.revision, tid);
-                if (self.options.response_cache_control) {
-                    resp.headers['cache-control'] = self.options.response_cache_control;
-                }
                 return self.wrapContentReq(hyper, req, P.resolve(resp), format, tid);
             });
         } else {
@@ -489,6 +486,9 @@ PSP.getFormat = function(format, hyper, req) {
     return contentReq
     .then(function(res) {
         mwUtil.normalizeContentType(res);
+        if (self.options.response_cache_control) {
+            res.headers['cache-control'] = self.options.response_cache_control;
+        }
         HyperSwitch.misc.addCSPHeaders(res, {
             domain: rp.domain,
             allowInline: true,

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -86,7 +86,7 @@ paths:
               headers:
                 content-type: '{{storage.headers.content-type}}'
                 etag: '{{storage.headers.etag}}'
-                cache-control: '{{options.response_cache-control}}'
+                cache-control: '{{options.response_cache_control}}'
               body: '{{storage.body}}'
 
         # Storage miss. Call mobile content service to get the definition.
@@ -99,18 +99,26 @@ paths:
               headers:
                 content-type: application/json
               body: '{{extract.body}}'
-        - store_and_return:
+        - store:
             request:
               method: put
               uri: /{domain}/sys/key_value/term.definition/{request.params.term}
               headers: '{{extract.headers}}'
               body: '{{extract.body}}'
+        - emit_change_event:
+            request:
+              method: post
+              uri: /{domain}/sys/events/
+              body:
+                - meta:
+                    uri: //{request.params.domain}/api/rest_v1/page/definition/{request.params.title}
+          response:
             return:
               status: 200
               headers:
                 content-type: '{{extract.headers.content-type}}'
-                etag: '{{store_and_return.headers.etag}}'
-                cache-control: '{{options.response_cache-control}}'
+                etag: '{{store.headers.etag}}'
+                cache-control: '{{options.response_cache_control}}'
               body: '{{extract.body}}'
 
       x-monitor: true

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -52,7 +52,8 @@ paths:
                 cache-control: '{{cache-control}}'
             return: 
               status: '{{from_backend.status}}'
-              headers: '{{ merge({"cache-control": "s-maxage=3600, max-age=3600"}, from_backend.headers) }}'
+              headers: '{{ merge({"cache-control": options.response_cache_control},
+                            from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: true
       x-amples:
@@ -117,7 +118,8 @@ paths:
               uri: /{domain}/sys/mobileapps/mobile-sections-lead/{title}
             return: 
               status: '{{from_backend.status}}'
-              headers: '{{ merge({"cache-control": "s-maxage=3600, max-age=3600"}, from_backend.headers) }}'
+              headers: '{{ merge({"cache-control": options.response_cache_control},
+                            from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: false
 
@@ -170,7 +172,8 @@ paths:
               uri: /{domain}/sys/mobileapps/mobile-sections-remaining/{title}
             return: 
               status: '{{from_backend.status}}'
-              headers: '{{ merge({"cache-control": "s-maxage=3600, max-age=3600"}, from_backend.headers) }}'
+              headers: '{{ merge({"cache-control": options.response_cache_control}, 
+                            from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: false
 

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -18,11 +18,9 @@ paths:
         - Page content
       summary: Get a text extract & thumb summary of a page.
       description: |
-        Returns the summary of the latest page content available in storage.
-        Currently the summary includes the text for the first several sentences and
-        the thumbnail URL.
-
-        Provide a `Cache-Control: no-cache` header to request the latest data.
+        The summary response includes a text extract of the first several
+        sentences, as well as information about a thumbnail that represents
+        the page.
 
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       produces:
@@ -88,7 +86,7 @@ paths:
               headers:
                 content-type: '{{storage.headers.content-type}}'
                 etag: '{{storage.headers.etag}}'
-                cache-control: '{{options.response_cache-control}}'
+                cache-control: '{{options.response_cache_control}}'
               body: '{{storage.body}}'
 
         # Storage miss. Call the Action API to get the textextract.
@@ -118,7 +116,14 @@ paths:
                 # See https://phabricator.wikimedia.org/T117082#1787617.
                 #timestamp: '{{request.params.timestamp}}'
 
-        - store_and_return:
+        - emit_change_event:
+            request:
+              method: post
+              uri: /{domain}/sys/events/
+              body:
+                - meta:
+                    uri: //{request.params.domain}/api/rest_v1/page/summary/{request.params.title}
+          store_and_return:
             request:
               method: put
               uri: /{domain}/sys/key_value/summary/{request.params.title}
@@ -130,7 +135,7 @@ paths:
               headers:
                 content-type: '{{extract.headers.content-type}}'
                 etag: '{{store_and_return.headers.etag}}'
-                cache-control: '{{options.response_cache-control}}'
+                cache-control: '{{options.response_cache_control}}'
               body: '{{extract.body}}'
 
       x-monitor: true


### PR DESCRIPTION
- Introduce a shared `purged_cache_control` config option, which is used to
  configure the `cache-control` headers returned by all purged entry points.
- Rename per-module cache header configs to response_cache_control.
- Add purging and caching to summary and parsoid HTML end points.