### PR TITLE
Events: Optionally prepend the protocol to the event URI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {

--- a/sys/events.js
+++ b/sys/events.js
@@ -27,7 +27,7 @@ EventService.prototype.emitEvent = function(hyper, req) {
             }
 
             return self.purger.purge(req.body.map(function(event) {
-                if (!event.meta || !event.meta.uri) {
+                if (!event.meta || !event.meta.uri || /^\/\/:/.test(event.meta.uri)) {
                     hyper.log('error/events/purge', {
                         message: 'Invalid event URI',
                         event: event

--- a/sys/events.js
+++ b/sys/events.js
@@ -27,13 +27,13 @@ EventService.prototype.emitEvent = function(hyper, req) {
             }
 
             return self.purger.purge(req.body.map(function(event) {
-                if (!event.meta || !event.meta.uri || !/^\/\//.test(event.meta.uri.toString())) {
+                if (!event.meta || !event.meta.uri || !/^\/\//.test(event.meta.uri)) {
                     hyper.log('error/events/purge', {
                         message: 'Invalid event URI',
                         event: event
                     });
                 } else {
-                    return 'http:' + event.meta.uri.toString();
+                    return 'http:' + event.meta.uri;
                 }
             })
             .filter(function(event) { return !!event; }));

--- a/sys/events.js
+++ b/sys/events.js
@@ -27,13 +27,17 @@ EventService.prototype.emitEvent = function(hyper, req) {
             }
 
             return self.purger.purge(req.body.map(function(event) {
-                if (!event.meta || !/^\/\/[^\/]+/.test(event.meta.uri)) {
+                if (!event.meta || !event.meta.uri) {
                     hyper.log('error/events/purge', {
                         message: 'Invalid event URI',
                         event: event
                     });
                 } else {
-                    return event.meta.uri.toString();
+                    var uri = event.meta.uri.toString();
+                    if (!/^https?:/.test(uri)) {
+                        uri = 'http:' + uri;
+                    }
+                    return uri;
                 }
             })
             .filter(function(event) { return !!event; }));

--- a/sys/events.js
+++ b/sys/events.js
@@ -27,17 +27,13 @@ EventService.prototype.emitEvent = function(hyper, req) {
             }
 
             return self.purger.purge(req.body.map(function(event) {
-                if (!event.meta || !event.meta.uri || /^\/\/:/.test(event.meta.uri)) {
+                if (!event.meta || !event.meta.uri || !/^\/\//.test(event.meta.uri.toString())) {
                     hyper.log('error/events/purge', {
                         message: 'Invalid event URI',
                         event: event
                     });
                 } else {
-                    var uri = event.meta.uri.toString();
-                    if (!/^https?:/.test(uri)) {
-                        uri = 'http:' + uri;
-                    }
-                    return uri;
+                    return 'http:' + event.meta.uri.toString();
                 }
             })
             .filter(function(event) { return !!event; }));

--- a/test/features/events/events.js
+++ b/test/features/events/events.js
@@ -70,7 +70,7 @@ describe('Change event emitting', function() {
         udpServer.on("message", function(msg) {
             try {
                 var uri = msg.slice(22, 22 + msg.readInt16BE(20)).toString();
-                assert.deepEqual(uri, 'https://en.wikipedia.org');
+                assert.deepEqual(uri, 'http://en.wikipedia.org');
                 udpServer.close();
                 done();
             } catch (e) {
@@ -87,7 +87,7 @@ describe('Change event emitting', function() {
             },
             body: [
                 { meta: {
-                        uri: 'https://en.wikipedia.org'
+                        uri: '//en.wikipedia.org'
                     }
                 },
                 { meta: { } },

--- a/test/features/events/events.js
+++ b/test/features/events/events.js
@@ -22,9 +22,9 @@ describe('Change event emitting', function() {
                         return message.slice(22, 22 + message.readInt16BE(20)).toString();
                     }).sort();
                     assert.deepEqual(receivedMessages,
-                    [ '//en.wikipedia.org/api/rest_v1/page/mobile-sections-lead/User%3APchelolo',
-                        '//en.wikipedia.org/api/rest_v1/page/mobile-sections-remaining/User%3APchelolo',
-                        '//en.wikipedia.org/api/rest_v1/page/mobile-sections/User%3APchelolo' ]);
+                    [ 'http://en.wikipedia.org/api/rest_v1/page/mobile-sections-lead/User%3APchelolo',
+                        'http://en.wikipedia.org/api/rest_v1/page/mobile-sections-remaining/User%3APchelolo',
+                        'http://en.wikipedia.org/api/rest_v1/page/mobile-sections/User%3APchelolo' ]);
                     udpServer.close();
                     done();
                 }
@@ -70,7 +70,7 @@ describe('Change event emitting', function() {
         udpServer.on("message", function(msg) {
             try {
                 var uri = msg.slice(22, 22 + msg.readInt16BE(20)).toString();
-                assert.deepEqual(uri, '//en.wikipedia.org');
+                assert.deepEqual(uri, 'https://en.wikipedia.org');
                 udpServer.close();
                 done();
             } catch (e) {
@@ -87,7 +87,7 @@ describe('Change event emitting', function() {
             },
             body: [
                 { meta: {
-                        uri: '//en.wikipedia.org'
+                        uri: 'https://en.wikipedia.org'
                     }
                 },
                 { meta: { } },


### PR DESCRIPTION
We need to send http protocol to varnish so that it works, so prepend it if protocol-relative uri was used in the event.