### PR TITLE
Fixed cache-control header format

### DIFF
--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -57,7 +57,7 @@ paths:
                   options: '{{options.graphoid}}'
                 - path: v1/summary.js
                   options:
-                    response_cache-control: 'max-age: 3600, s-maxage: 3600'
+                    response_cache-control: 'max-age=3600, s-maxage=3600'
             /transform:
               x-modules:
                 - path: v1/transform.yaml

--- a/projects/wmf_sqlite.yaml
+++ b/projects/wmf_sqlite.yaml
@@ -57,7 +57,7 @@ paths:
                   options: '{{options.graphoid}}'
                 - path: v1/summary.js
                   options:
-                    response_cache-control: 'max-age: 3600, s-maxage: 3600'
+                    response_cache-control: 'max-age=3600, s-maxage=3600'
             /transform:
               x-modules:
                 - path: v1/transform.yaml

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -58,7 +58,7 @@ paths:
                   options: '{{options.graphoid}}'
                 - path: v1/definition.yaml
                   options:
-                    response_cache-control: 'max-age: 3600, s-maxage: 3600'
+                    response_cache-control: 'max-age=3600, s-maxage=3600'
                     host: '{{options.mobileapps.host}}'
             /transform:
               x-modules:

--- a/sys/pageviews_proxy.yaml
+++ b/sys/pageviews_proxy.yaml
@@ -10,7 +10,7 @@ paths:
               uri: '{{options.host}}/pageviews/per-article/{+rest}'
             return:
               status: '{{get_from_backend.status}}'
-              headers: '{{merge({"cache-control":"s-maxage: 3600, max-age: 3600"}, get_from_backend.headers)}}'
+              headers: '{{merge({"cache-control":"s-maxage=3600, max-age=3600"}, get_from_backend.headers)}}'
               body: '{{get_from_backend.body}}'
 
   /per-project/{+rest}:
@@ -21,7 +21,7 @@ paths:
               uri: '{{options.host}}/pageviews/aggregate/{+rest}'
             return:
               status: '{{get_from_backend.status}}'
-              headers: '{{merge({"cache-control":"s-maxage: 3600, max-age: 3600"}, get_from_backend.headers)}}'
+              headers: '{{merge({"cache-control":"s-maxage=3600, max-age=3600"}, get_from_backend.headers)}}'
               body: '{{get_from_backend.body}}'
 
   /top/{+rest}:
@@ -32,5 +32,5 @@ paths:
               uri: '{{options.host}}/pageviews/top/{+rest}'
             return:
               status: '{{get_from_backend.status}}'
-              headers: '{{merge({"cache-control":"s-maxage: 3600, max-age: 3600"}, get_from_backend.headers)}}'
+              headers: '{{merge({"cache-control":"s-maxage=3600, max-age=3600"}, get_from_backend.headers)}}'
               body: '{{get_from_backend.body}}'

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -52,7 +52,7 @@ paths:
                 cache-control: '{{cache-control}}'
             return: 
               status: '{{from_backend.status}}'
-              headers: '{{ merge({"cache-control": "s-maxage: 3600, max-age: 3600"}, from_backend.headers) }}'
+              headers: '{{ merge({"cache-control": "s-maxage=3600, max-age=3600"}, from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: true
       x-amples:
@@ -117,7 +117,7 @@ paths:
               uri: /{domain}/sys/mobileapps/mobile-sections-lead/{title}
             return: 
               status: '{{from_backend.status}}'
-              headers: '{{ merge({"cache-control": "s-maxage: 3600, max-age: 3600"}, from_backend.headers) }}'
+              headers: '{{ merge({"cache-control": "s-maxage=3600, max-age=3600"}, from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: false
 
@@ -170,7 +170,7 @@ paths:
               uri: /{domain}/sys/mobileapps/mobile-sections-remaining/{title}
             return: 
               status: '{{from_backend.status}}'
-              headers: '{{ merge({"cache-control": "s-maxage: 3600, max-age: 3600"}, from_backend.headers) }}'
+              headers: '{{ merge({"cache-control": "s-maxage=3600, max-age=3600"}, from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: false
 
@@ -221,6 +221,6 @@ paths:
                 cache-control: '{{cache-control}}'
             return:
               status: '{{from_backend.status}}'
-              headers: '{{ merge({"cache-control": "s-maxage: 3600, max-age: 3600"}, from_backend.headers) }}'
+              headers: '{{ merge({"cache-control": "s-maxage=3600, max-age=3600"}, from_backend.headers) }}'
               body: '{{from_backend.body}}'
       x-monitor: false


### PR DESCRIPTION
We've been sending the cache-control headers with `:` which apparently doesn't work in varnish, so switch to `=`.

cc @wikimedia/services 