### PR TITLE
Tests: Updated expected content-types

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -66,8 +66,8 @@ wiktionary_project: &wiktionary_project
 # Hacky way to parametrize RESTBase tests. TODO: Move to config?
 test:
   content_types:
-    html: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.1.0"
-    data-parsoid: application/json; charset=utf-8; profile="mediawiki.org/specs/data-parsoid/0.0.1"
+    html: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.2.0"
+    data-parsoid: application/json; charset=utf-8; profile="mediawiki.org/specs/data-parsoid/0.0.2"
     wikitext: text/plain; charset=utf-8; profile="mediawiki.org/specs/wikitext/1.0.0"
 
 


### PR DESCRIPTION
Due to Parsoid [https://www.mediawiki.org/wiki/Parsoid/Deployments#Wednesday.2C_Feb_24.2C_2016_around_1:15_pm_PT:_239d2e60_to_be_deployed](change) that bumps content-type versions we need to change expectations in RESTBase tests. 

Part of out tests run against labs and part against production, so right now both with and without this PR some of the tests fail.

cc @wikimedia/services