### PR TITLE
Docs: Added summary to math and pageview endpoints

### DIFF
--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -6,6 +6,7 @@ paths:
   /math/check/{type}:
     post:
       tags: ['Math']
+      summary: Check and normalize a TeX formula.
       description: |
         Checks the supplied TeX formula for correctness and returns the
         normalised formula representation as well as information about
@@ -94,6 +95,7 @@ paths:
   /math/render/{format}/{hash}:
     get:
       tags: ['Math']
+      summary: Get rendered formula in the given format.
       description: |
         Given a request hash, renders a TeX formula into its mathematic
         representation in the given format. When a request is issued to the

--- a/v1/pageviews.yaml
+++ b/v1/pageviews.yaml
@@ -16,6 +16,7 @@ paths:
     get:
       tags:
         - Pageviews data
+      summary: List pageview-related API entry points.
       description: |
         This is the root of all pageview data endpoints.  The list of paths that this returns includes ways to query by article, project, top articles, etc.  If browsing the interactive documentation, see the specifics for each endpoint below.
 
@@ -37,6 +38,7 @@ paths:
     get:
       tags:
         - Pageviews data
+      summary: Get pageview counts for a page.
       description: |
         Given a Mediawiki article and a date range, returns a daily timeseries of its pageview counts. You can also filter by access method and/or agent type
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
@@ -100,6 +102,7 @@ paths:
     get:
       tags:
         - Pageviews data
+      summary: Get pageview counts for a project.
       description: |
         Given a date range, returns a timeseries of pageview counts. You can filter by project, access method and/or agent type. You can choose between daily and hourly granularity as well
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
@@ -181,6 +184,7 @@ paths:
     get:
       tags:
         - Pageviews data
+      summary: Get the most viewed articles for a project.
       description: |
         Lists the 1000 most viewed articles for a given project and timespan (year, month or day). You can filter by access method
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)


### PR DESCRIPTION
The summary is a short description of the API shown on the right side of collapsed entry point doc in the [swagger docs](https://en.wikipedia.org/api/rest_v1/?doc=). We have them everywhere except mathoid and pageviews.

cc @wikimedia/services @milimetric 