### PR TITLE
Tests: Update content type in monitoring tests

### DIFF
--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -96,7 +96,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.1.0"
+                content-type: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.2.0"
 
   /{domain}/v1/page/html/{title}/{revision}:
     get:
@@ -147,7 +147,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.1.0"
+                content-type: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.2.0"
 
 definitions:
   defaultError:


### PR DESCRIPTION
Follow up on parsoid content-type update: forgot to update expected content-types in 2 tests.