### PR TITLE
Added If-Match header to spec and log remaining users

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -634,6 +634,9 @@ PSP.transformRevision = function(hyper, req, from, to) {
         } else if (req.body && req.body.html) {
             // Fall back to an inline meta tag in the HTML
             tid = extractTidMeta(req.body.html);
+            hyper.log('warn/parsoid/etag', {
+                msg: 'Client did not supply etag, fallback to mw:TimeUuid meta element'
+            });
         }
         if (!tid) {
             throw new HTTPError({

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -51,8 +51,8 @@ paths:
         - name: if-match
           in: header
           description: |
-            An `ETag` header of the original render indicating it's revision and timeuuid.
-            Required if the `title` and `revision` parameters are present.
+            The `ETag` header of the original render indicating it's revision and timeuuid.
+            Required if both `title` and `revision` parameters are present.
           type: string
           required: false
       responses:

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -48,6 +48,13 @@ paths:
           description: Normalise the DOM to yield cleaner wikitext?
           type: boolean
           required: false
+        - name: if-match
+          in: header
+          description: |
+            An `ETag` header of the original render indicating it's revision and timeuuid.
+            Required if the `title` and `revision` parameters are present.
+          type: string
+          required: false
       responses:
         '200':
           description: MediaWiki Wikitext.


### PR DESCRIPTION
As sending the `If-Match` header is a canonical way of setting the render tid, we should mention it in the spec and allow users send it from the swagger sandbox. 

Also, log all users that don't send the header yet and rely on mw:TimeUuid fallback.

Related to https://phabricator.wikimedia.org/T128525