### PR TITLE
Move to node 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
-    - "4.2"
+    - "4.3"
     - "5"
 
 sudo: false

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "temp": "^0.8.3"
   },
   "deploy": {
-    "node": "4.2.4",
+    "node": "4.3.0",
     "target": "debian",
     "dependencies": {
       "_all": []


### PR DESCRIPTION
We are now running node 4.3.0 in production, so instruct the build script and Travis use it.