### PR TITLE
Parsoid: Ensure res.headers is set before setting cache-control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -486,13 +486,13 @@ PSP.getFormat = function(format, hyper, req) {
     return contentReq
     .then(function(res) {
         mwUtil.normalizeContentType(res);
-        if (self.options.response_cache_control) {
-            res.headers['cache-control'] = self.options.response_cache_control;
-        }
         HyperSwitch.misc.addCSPHeaders(res, {
             domain: rp.domain,
             allowInline: true,
         });
+        if (self.options.response_cache_control) {
+            res.headers['cache-control'] = self.options.response_cache_control;
+        }
         return res;
     });
 };


### PR DESCRIPTION
When setting the `cache-control` header, the code only checked if
`self.options.response_cache_control` is set. However, some execution
paths do not yield a `res.headers` object, causing TypeError exceptions
when setting the `cache-control` header. To circumvent the issue, place
a call to `HyperSwitch.misc.addCSPHeaders()` first, as it creates the
object if hasn't been defined, thus ensuring `cache-control` can be
safely set afterwards.