### PR TITLE
API: Initial implementation for a cached related pages endpoint

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -27,6 +27,8 @@ default_project: &default_project
           cache-control: s-maxage=864000, max-age=86400
         mobileapps:
           host: http://appservice.wmflabs.org
+        related:
+          cache-control: s-maxage=86400, max-age=86400
         # 10 days Varnish caching, one day client-side
         purged_cache_control: s-maxage=864000, max-age=86400
 

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -59,6 +59,8 @@ paths:
                 - path: v1/summary.js
                   options:
                     response_cache_control: '{{options.purged_cache_control}}'
+                - path: v1/related.yaml
+                  options: '{{options.related}}'
             /transform:
               x-modules:
                 - path: v1/transform.yaml

--- a/projects/wmf_sqlite.yaml
+++ b/projects/wmf_sqlite.yaml
@@ -59,6 +59,8 @@ paths:
                 - path: v1/summary.js
                   options:
                     response_cache-control: '{{options.purged_cache_control}}'
+                - path: v1/related.yaml
+                  options: '{{options.related}}'
             /transform:
               x-modules:
                 - path: v1/transform.yaml

--- a/sys/action.js
+++ b/sys/action.js
@@ -140,8 +140,8 @@ function buildQueryResponse(apiReq, res) {
         throw new HTTPError({
             status: 404,
             body: {
-                type: 'not_found#page_revisions',
-                description: 'Page or revision not found.',
+                type: 'not_found',
+                description: 'Requested resource is not found.',
                 apiRequest: apiReq
             }
         });

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -302,21 +302,6 @@ PRS.prototype.fetchAndStoreMWRevision = function(hyper, req) {
             rp.title = dataResp.title;
             return self.getTitleRevision(hyper, req);
         });
-    }).catch(function(e) {
-        // If a bad revision is supplied, the action module
-        // returns a 500 with the 'Missing query pages' message
-        // so catch that and turn it into a 404 in our case
-        if (e.status === 500 && /^Missing query pages/.test(e.body.description)) {
-            throw new HTTPError({
-                status: 404,
-                body: {
-                    type: 'not_found#page_revisions',
-                    description: 'Page or revision not found.',
-                    apiRequest: apiReq
-                }
-            });
-        }
-        throw e;
     });
 };
 

--- a/v1/related.js
+++ b/v1/related.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var HyperSwitch = require('hyperswitch');
+var spec = HyperSwitch.utils.loadSpec(__dirname + '/related.yaml');
+
+module.exports = function(options) {
+    return {
+        spec: spec,
+        globals: {
+            options: options,
+            // Add a utility function to the global scope, so that it can be
+            // called in the response template.
+            httpsSource: function(items) {
+                items.forEach(function(item) {
+                    if (item.thumbnail && item.thumbnail.source) {
+                        item.thumbnail.source = item.thumbnail.source.replace(/^http:/, 'https:');
+                    }
+                });
+                return items;
+            }
+        }
+    };
+};
+

--- a/v1/related.yaml
+++ b/v1/related.yaml
@@ -1,0 +1,133 @@
+swagger: '2.0'
+info:
+  version: '1.0.0-beta'
+  title: MediaWiki Related Pages API
+  description: Related pages API
+  termsofservice: https://github.com/wikimedia/restbase#restbase
+  contact:
+    name: Services
+    email: services@lists.wikimedia.org
+    url: https://www.mediawiki.org/wiki/Services
+  license:
+    name: Apache licence, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /related/{title}:
+    get:
+      tags:
+        - Page content
+      summary: Get pages related to the given title
+      description: |
+        Returns summaries for 5 pages related to the given page. Summaries include
+        page title, namespace and id along with short text description of the page
+        and a thumbnail.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json
+      parameters:
+        - name: title
+          in: path
+          description: The page title.
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The related pages
+          schema:
+            $ref: '#/definitions/related'
+        '404':
+          description: Unknown page title
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+
+      x-request-handler:
+        # Storage miss. Call the Action API to get the textextract.
+        - api_request:
+            request:
+              method: 'post'
+              uri: /{domain}/sys/action/query
+              body:
+                format: 'json'
+                prop: 'pageterms|pageimages|pageprops'
+                ppprop: 'mainpage|disambiguation'
+                wbptterms: 'description'
+                generator: 'search'
+                gsrsearch: 'morelike:{request.params.title}'
+                gsrnamespace: 0
+                gsrwhat: 'text'
+                gsrinfo: ''
+                gsrprop: 'redirecttitle'
+                gsrlimit: 5
+                piprop: 'thumbnail'
+                pithumbsize: 640
+            response:
+              status: 200
+              headers:
+                content-type: application/json
+                cache-control: '{{options.cache-control}}'
+              body:
+                items: '{{httpsSource(api_request.body.items)}}'
+      x-monitor: false
+
+definitions:
+  # A https://tools.ietf.org/html/draft-nottingham-http-problem
+  problem:
+    required:
+      - type
+    properties:
+      type:
+        type: string
+      title:
+        type: string
+      detail:
+        type: string
+      instance:
+        type: string
+
+  related:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          type: object
+          properties:
+            pageid:
+              type: integer
+              description: Page ID
+            title:
+              type: string
+              description: Page title
+            ns:
+              type: integer
+              description: The page namespace number
+            index:
+              type: integer
+              description: Relevance index of this result
+            term:
+              type: object
+              properties:
+                description:
+                  type: array
+                  items:
+                    type: string
+                    description: First several sentences of an article in plain text
+            thumbnail:
+              type: object
+              properties:
+                source:
+                  type: string
+                  description: Thumbnail image URI
+                width:
+                  type: integer
+                  description: Thumbnail width
+                height:
+                  type: integer
+                  description: Thumnail height
+              required: ['source', 'width', 'height']
+          required: ['title', 'ns']

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -36,6 +36,11 @@ paths:
           description: The summary for the given page
           schema:
             $ref: '#/definitions/summary'
+          headers:
+            ETag:
+              description: >
+                Syntax: "{revision}/{tid}".
+                Example: "701384379/154d7bca-c264-11e5-8c2f-1b51b33b59fc"
         '404':
           description: Unknown page title
           schema:
@@ -44,11 +49,6 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
-          headers:
-            ETag:
-              description: >
-                Syntax: "{revision}/{tid}".
-                Example: "701384379/154d7bca-c264-11e5-8c2f-1b51b33b59fc"
 
       x-setup-handler:
         # Set up a simple key-value bucket.


### PR DESCRIPTION
Primary implementation for the related pages API. Right now it's not storing the result, just setting a `cache-control` headers and proxying the request to MW API. 

The main issue is thumbnail size, but clients could mangle the thumb uri.

Bug: https://phabricator.wikimedia.org/T125983
cc @wikimedia/services 