### PR TITLE
JSCS: use preferred value for 'requireCamelCaseOrUpperCaseIdentifiers' rule

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -10,7 +10,9 @@
     "catch"
   ],
   "validateIndentation": 4,
-  "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
+  "requireCamelCaseOrUpperCaseIdentifiers": {
+    "ignoreProperties": true
+  },
   "requireCapitalizedComments": null,
   "maximumLineLength": 100,
   "validateQuoteMarks": null,


### PR DESCRIPTION
As stated at http://jscs.info/rule/requireCamelCaseOrUpperCaseIdentifiers the "ignoreProperties" value is deprecated, an object with "ignoreProperties" as a key should be used instead.