### PR TITLE
Action module: Bug fix: define the correct returner function

### DIFF
--- a/sys/action.js
+++ b/sys/action.js
@@ -218,7 +218,7 @@ ActionService.prototype.siteinfo = function(hyper, req) {
         action: 'query',
         meta: 'siteinfo',
         format: 'json'
-    }, function(res) { return res; });
+    }, function(apiReq, res) { return res; });
 };
 
 


### PR DESCRIPTION
wikimedia/restbase@18799139 introduced the `ActionService.siteinfo()` method which relies on `ActionService._doRequest()` to perform the request. However, the continuation function passed to it had the wrong signature. This PR fixes the issue.