### PR TITLE
Sample normalization logging with a 5% chance

### DIFF
--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -64,9 +64,14 @@ module.exports = function(hyper, req, next, options, specInfo) {
                             location: contentLocation
                         }
                     });*/
-                    hyper.log('warn/normalize', {
-                        msg: 'Normalized requested title from ' + rp.title + ' to ' + result
-                    });
+
+
+                    // 5% chance of logging to bound volume.
+                    if (Math.random() < 0.05) {
+                        hyper.log('warn/normalize', {
+                            msg: 'Normalized requested title from ' + rp.title + ' to ' + result
+                        });
+                    }
                     return next(hyper, req)
                     .then(function(res) {
                         if (res) {

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -69,7 +69,9 @@ module.exports = function(hyper, req, next, options, specInfo) {
                     // 5% chance of logging to bound volume.
                     if (Math.random() < 0.05) {
                         hyper.log('warn/normalize', {
-                            msg: 'Normalized requested title from ' + rp.title + ' to ' + result
+                            msg: 'Normalized requested title',
+                            from: rp.title,
+                            to: result,
                         });
                     }
                     return next(hyper, req)


### PR DESCRIPTION
The log volumes from normalizations are higher than expected, as big consumers
are still sending un-normalized requests. To avoid sending an excessive volume
of log events, this patch samples logs with a 5% chance.