### PR TITLE
WIP: binary png support

### DIFF
--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -116,6 +116,7 @@ paths:
           enum:
             - svg
             - mml
+            - png
         - name: hash
           in: path
           description: The hash string of the previous POST data
@@ -144,6 +145,11 @@ paths:
             body:
               keyType: string
               valueType: string
+        - init_png:
+            uri: /wikimedia.org/sys/key_value/mathoid.png
+            body:
+              keyType: string
+              valueType: blob
       x-request-handler:
         - check_storage:
             request:


### PR DESCRIPTION
needs more work as discussed with @d00rman 
> the problem is that the binary format is not understood by restbase it returns something like {"type":"Buffer","data":[137,80,78,71... 
and is not interpreted as a png by the browser