### PR TITLE
Disable pregeneration for non-main namespaces

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -2,8 +2,10 @@
 
 var uuid = require('cassandra-uuid').TimeUuid;
 var contentType = require('content-type');
-var HTTPError = require('hyperswitch').HTTPError;
 var jwt = require('jsonwebtoken');
+var HyperSwitch = require('hyperswitch');
+var HTTPError = HyperSwitch.HTTPError;
+var URI = HyperSwitch.URI;
 
 var mwUtil = {};
 
@@ -142,6 +144,28 @@ mwUtil.decodePagingToken = function(hyper, token) {
             }
         });
     }
+};
+
+var siteInfoCache = {};
+mwUtil.getSiteInfo = function(hyper, req) {
+    var rp = req.params;
+    if (!siteInfoCache[rp.domain]) {
+        siteInfoCache[rp.domain] = hyper.post({
+            uri: new URI([rp.domain, 'sys', 'action', 'siteinfo']),
+            body: {
+                siprop: 'general|namespaces|namespacealiases'
+            }
+        })
+        .then(function(res) {
+            return {
+                lang: res.body.query.general.lang,
+                legaltitlechars: res.body.query.general.legaltitlechars,
+                namespaces: res.body.query.namespaces,
+                namespacealiases: res.body.query.namespacealiases
+            };
+        });
+    }
+    return siteInfoCache[rp.domain];
 };
 
 module.exports = mwUtil;

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -1,111 +1,91 @@
 "use strict";
 
 var HyperSwitch = require('hyperswitch');
-var P = require('bluebird');
-var URI = HyperSwitch.URI;
+var mwUtil = require('./mwUtil');
 var HTTPError = HyperSwitch.HTTPError;
 var Title = require('mediawiki-title').Title;
-
-var siteInfoCache = {};
 
 module.exports = function(hyper, req, next, options, specInfo) {
     var rp = req.params;
     if (rp.title) {
-        if (!siteInfoCache[rp.domain]) {
-            siteInfoCache[rp.domain] = hyper.post({
-                uri: new URI([rp.domain, 'sys', 'action', 'siteinfo']),
+        return mwUtil.getSiteInfo(hyper, req)
+        .then(function(siteInfo) {
+            return Title.newFromText(rp.title, siteInfo);
+        })
+        .catch(function(e) {
+            throw new HTTPError({
+                status: 400,
                 body: {
-                    siprop: 'general|namespaces|namespacealiases'
+                    type: 'bad_request',
+                    detail: e.message
                 }
-            })
-            .then(function(res) {
-                return {
-                    lang: res.body.query.general.lang,
-                    legaltitlechars: res.body.query.general.legaltitlechars,
-                    namespaces: res.body.query.namespaces,
-                    namespacealiases: res.body.query.namespacealiases
-                };
             });
-        }
-        return siteInfoCache[rp.domain].then(function(siteInfo) {
-            return P.try(function() {
-                return Title.newFromText(rp.title, siteInfo);
-            })
-            .catch(function(e) {
-                throw new HTTPError({
-                    status: 400,
-                    body: {
-                        type: 'bad_request',
-                        detail: e.message
-                    }
-                });
-            })
-            .then(function(result) {
-                var resultText = result.getPrefixedDBKey();
-                if (resultText !== rp.title) {
-                    if (result.getNamespace().isUser() || result.getNamespace().isUserTalk()) {
-                        // Due to gender variations of User and User_Talk namespaces in some langs
-                        // use canonical name for storage, but don't redirect. Don't cache either
-                        rp.title = resultText;
-                        return next(hyper, req)
-                        .then(function(res) {
-                            if (res) {
-                                res.headers = res.headers || {};
-                                res.headers['cache-control'] = 'no-cache, must-revalidate';
-                            }
-                            return res;
-                        });
-                    } else {
-                        /* TODO: we don't want to enable redirects yet, so log the redirect instead
-                         and disable caching of the response
-
-                         rp.title = result;
-                         var pathBeforeTitle = specInfo.path
-                         .substring(0, specInfo.path.indexOf('{title}'));
-                         pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
-                         var pathAfterTitle = req.uri.toString().replace(pathBeforeTitle, '');
-                         var backCount = (pathAfterTitle.match(/\//g) || []).length;
-                         var backString = Array.apply(null, { length: backCount }).map(function() {
-                         return '../';
-                         }).join('');
-                         var pathPatternAfterTitle = specInfo.path
-                         .substring(specInfo.path.indexOf('{title}') - 1);
-                         var contentLocation = backString
-                         + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
-                         return P.resolve({
-                         status: 301,
-                         headers: {
-                         location: contentLocation
-                         }
-                         });*/
-                        if (rp.title.replace(/ /g, '_') !== resultText) {
-                            // Log all of these, should be relatively rare.
-                            hyper.log('warn/normalize/non_space', {
-                                msg: 'Normalized non-space chars',
-                                from: rp.title,
-                                to: resultText,
-                            });
-                        } else if (Math.random() < 0.05) {
-                            // 5% chance of logging to bound volume.
-                            hyper.log('warn/normalize/space', {
-                                msg: 'Normalized requested title',
-                                from: rp.title,
-                                to: resultText,
-                            });
+        })
+        .then(function(result) {
+            var resultText = result.getPrefixedDBKey();
+            if (resultText !== rp.title) {
+                if (result.getNamespace().isUser() || result.getNamespace().isUserTalk()) {
+                    // Due to gender variations of User and User_Talk namespaces in some langs
+                    // use canonical name for storage, but don't redirect. Don't cache either
+                    rp.title = resultText;
+                    return next(hyper, req)
+                    .then(function(res) {
+                        if (res) {
+                            res.headers = res.headers || {};
+                            res.headers['cache-control'] = 'no-cache, must-revalidate';
                         }
-                        return next(hyper, req)
-                        .then(function(res) {
-                            if (res) {
-                                res.headers = res.headers || {};
-                                res.headers['cache-control'] = 'no-cache, must-revalidate';
-                            }
-                            return res;
+                        return res;
+                    });
+                } else {
+                    /* TODO: we don't want to enable redirects yet, so log the redirect instead
+                     and disable caching of the response
+
+                     rp.title = result;
+                     var pathBeforeTitle = specInfo.path
+                     .substring(0, specInfo.path.indexOf('{title}'));
+                     pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
+                     var pathAfterTitle = req.uri.toString().replace(pathBeforeTitle, '');
+                     var backCount = (pathAfterTitle.match(/\//g) || []).length;
+                     var backString = Array.apply(null, { length: backCount }).map(function() {
+                     return '../';
+                     }).join('');
+                     var pathPatternAfterTitle = specInfo.path
+                     .substring(specInfo.path.indexOf('{title}') - 1);
+                     var contentLocation = backString
+                     + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
+                     return P.resolve({
+                     status: 301,
+                     headers: {
+                     location: contentLocation
+                     }
+                     });*/
+                    if (rp.title.replace(/ /g, '_') !== resultText) {
+                        // Log all of these, should be relatively rare.
+                        hyper.log('warn/normalize/non_space', {
+                            msg: 'Normalized non-space chars',
+                            from: rp.title,
+                            to: resultText,
+                        });
+                    } else if (Math.random() < 0.05) {
+                        // 5% chance of logging to bound volume.
+                        hyper.log('warn/normalize/space', {
+                            msg: 'Normalized requested title',
+                            from: rp.title,
+                            to: resultText,
                         });
                     }
-                } else {
-                    return next(hyper, req);
+                    return next(hyper, req)
+                    .then(function(res) {
+                        if (res) {
+                            res.headers = res.headers || {};
+                            res.headers['cache-control'] = 'no-cache, must-revalidate';
+                        }
+                        return res;
+                    });
                 }
-            });
+            } else {
+                return next(hyper, req);
+            }
         });
     } else {
         return next(hyper, req);

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -6,6 +6,7 @@
 
 var P = require('bluebird');
 var HyperSwitch = require('hyperswitch');
+var Title = require('mediawiki-title').Title;
 var URI = HyperSwitch.URI;
 var HTTPError = HyperSwitch.HTTPError;
 
@@ -108,60 +109,68 @@ var PSP = ParsoidService.prototype;
 // TEMP TEMP TEMP!!!
 // Wiktionary / summary invalidation and mobileapps pregeneration
 PSP._dependenciesUpdate = function(hyper, req) {
-    var self = this;
     var rp = req.params;
-    var summaryPromise = P.resolve();
-    if (rp.domain.indexOf('wiktionary') === -1) {
-        // non-wiktionary, update summary
-        summaryPromise = hyper.get({
-            uri: new URI([rp.domain, 'v1', 'page', 'summary', rp.title]),
-            headers: {
-                'cache-control': 'no-cache'
+    return mwUtil.getSiteInfo(hyper, req)
+    .then(function(siteInfo) {
+        var rp = req.params;
+        var isMainNamespace = Title.newFromText(rp.title, siteInfo).getNamespace().isMain();
+        var updates = [];
+        if (isMainNamespace) {
+            var summaryPromise = P.resolve();
+            if (rp.domain.indexOf('wiktionary') === -1) {
+                // non-wiktionary, update summary
+                summaryPromise = hyper.get({
+                    uri: new URI([rp.domain, 'v1', 'page', 'summary', rp.title]),
+                    headers: {
+                        'cache-control': 'no-cache'
+                    }
+                });
+            } else if (/en.wiktionary/.test(rp.domain)) {
+                // wiktionary update, we are interested only in en.wiktionary
+                summaryPromise = hyper.get({
+                    uri: new URI([rp.domain, 'v1', 'page', 'definition', rp.title]),
+                    headers: {
+                        'cache-control': 'no-cache'
+                    }
+                });
             }
-        });
-    } else if (/en.wiktionary/.test(rp.domain)) {
-        // wiktionary update, we are interested only in en.wiktionary
-        summaryPromise = hyper.get({
-            uri: new URI([rp.domain, 'v1', 'page', 'definition', rp.title]),
-            headers: {
-                'cache-control': 'no-cache'
-            }
-        });
-    }
-    summaryPromise = summaryPromise.catch(function(e) {
-        if (e.status !== 501 && e.status !== 404) {
-            hyper.log('error/' + rp.domain.indexOf('wiktionary') < 0 ?
-            'summary' : 'definition', e);
+            summaryPromise = summaryPromise.catch(function(e) {
+                if (e.status !== 501 && e.status !== 404) {
+                    hyper.log('error/' + rp.domain.indexOf('wiktionary') < 0 ?
+                    'summary' : 'definition', e);
+                }
+            });
+            updates.push(summaryPromise);
         }
+
+        // Emit resource change events
+        var publicBaseURI = '//' + rp.domain + '/api/rest_v1/page';
+        updates.push(hyper.post({
+            uri: new URI([rp.domain, 'sys', 'events', '']),
+            body: [
+                { meta: { uri: publicBaseURI + '/html/' + encodeURIComponent(rp.title) } },
+                { meta: { uri: publicBaseURI + '/html/' + encodeURIComponent(rp.title)
+                + '/' + rp.revision } },
+                { meta: { uri: publicBaseURI + '/data-parsoid/' + encodeURIComponent(rp.title) } },
+                { meta: { uri: publicBaseURI + '/data-parsoid/' + encodeURIComponent(rp.title)
+                + '/' + rp.revision } },
+            ]
+        }));
+
+        if (isMainNamespace) {
+            updates.push(hyper.get({
+                uri: new URI([rp.domain, 'sys', 'mobileapps', 'mobile-sections', rp.title]),
+                headers: {
+                    'cache-control': 'no-cache',
+                }
+            }));
+        }
+
+        return P.all(updates);
+    })
+    .catch(function(e) {
+        hyper.log('warn/mobileapps', e);
     });
-
-
-    // Emit resource change events
-    var publicBaseURI = '//' + rp.domain + '/api/rest_v1/page';
-    var resourceChangePromise = hyper.post({
-        uri: new URI([rp.domain, 'sys', 'events', '']),
-        body: [
-            { meta: { uri: publicBaseURI + '/html/' + encodeURIComponent(rp.title) } },
-            { meta: { uri: publicBaseURI + '/html/' + encodeURIComponent(rp.title)
-                        + '/' + rp.revision } },
-            { meta: { uri: publicBaseURI + '/data-parsoid/' + encodeURIComponent(rp.title) } },
-            { meta: { uri: publicBaseURI + '/data-parsoid/' + encodeURIComponent(rp.title)
-                        + '/' + rp.revision } },
-        ]
-    });
-
-    return P.join(
-        resourceChangePromise,
-        summaryPromise,
-        hyper.get({
-            uri: new URI([rp.domain, 'sys', 'mobileapps', 'mobile-sections', rp.title]),
-            headers: {
-                'cache-control': 'no-cache',
-            }
-        }).catch(function(e) {
-            hyper.log('warn/mobileapps', e);
-        })
-    );
 };
 
 /**

--- a/test/features/pagecontent/access_checks.js
+++ b/test/features/pagecontent/access_checks.js
@@ -64,18 +64,6 @@ describe('Access checks', function() {
                 }
             }
         })
-        // TEMP: summary also needs update
-        .post('').reply(200, {
-            'batchcomplete': '',
-            'query': {
-                'pages': {
-                    '11089416': {
-                        'title': deletedPageTitle,
-                        'extract': 'test'
-                    }
-                }
-            }
-        })
         // Other requests return nothing as if the page is deleted.
         .post('').reply(200, emptyResponse);
         // Fetch the page


### PR DESCRIPTION
Disable summary, definition and mobile content pregeneration for all namespaces other than main.

The changes looks huge, but in reality it's mostly indentation.

Bug: https://phabricator.wikimedia.org/T129532

cc @wikimedia/services 