### PR TITLE
Don't redirect POST requests

### DIFF
--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -43,7 +43,8 @@ module.exports = function(hyper, req, next, options, specInfo) {
             .then(function(result) {
                 var resultText = result.getPrefixedDBKey();
                 if (resultText !== rp.title) {
-                    if (result.getNamespace().isUser() || result.getNamespace().isUserTalk()) {
+                    if (result.getNamespace().isUser()
+                            || result.getNamespace().isUserTalk()) {
                         // Due to gender variations of User and User_Talk namespaces in some langs
                         // use canonical name for storage, but don't redirect. Don't cache either
                         rp.title = resultText;
@@ -55,6 +56,10 @@ module.exports = function(hyper, req, next, options, specInfo) {
                             }
                             return res;
                         });
+                    } else if (req.method === 'post') {
+                        // Don't redirect POSTs as it's not cached anyway
+                        rp.title = resultText;
+                        return next(hyper, req);
                     } else {
                         /* TODO: we don't want to enable redirects yet, so log the redirect instead
                          and disable caching of the response

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -43,7 +43,8 @@ module.exports = function(hyper, req, next, options, specInfo) {
             .then(function(result) {
                 var resultText = result.getPrefixedDBKey();
                 if (resultText !== rp.title) {
-                    if (result.getNamespace().isUser()
+                    if (req.method === 'post' // Don't redirect POSTs as it's not cached anyway
+                            || result.getNamespace().isUser()
                             || result.getNamespace().isUserTalk()) {
                         // Due to gender variations of User and User_Talk namespaces in some langs
                         // use canonical name for storage, but don't redirect. Don't cache either
@@ -56,10 +57,6 @@ module.exports = function(hyper, req, next, options, specInfo) {
                             }
                             return res;
                         });
-                    } else if (req.method === 'post') {
-                        // Don't redirect POSTs as it's not cached anyway
-                        rp.title = resultText;
-                        return next(hyper, req);
                     } else {
                         /* TODO: we don't want to enable redirects yet, so log the redirect instead
                          and disable caching of the response


### PR DESCRIPTION
It doesn't make sense to redirect POST requests even if they're done with unnormalised title.
It's not cached, so we can normalise a title and continue processing.

cc @wikimedia/services 