### PR TITLE
Mathoid: store texvcinfo check results and reuse them

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -55,6 +55,10 @@ paths:
     x-modules:
       - spec:
           paths:
+            /mathoid:
+              x-modules:
+                - path: sys/mathoid.js
+                  options: '{{options.mathoid}}'
             /table:
               x-modules:
                 - type: npm

--- a/projects/wikimedia.org_sqlite.yaml
+++ b/projects/wikimedia.org_sqlite.yaml
@@ -55,6 +55,10 @@ paths:
     x-modules:
       - spec:
           paths:
+            /mathoid:
+              x-modules:
+                - path: sys/mathoid.js
+                  options: '{{options.mathoid}}'
             /table:
               x-modules:
                 - type: npm

--- a/sys/mathoid.js
+++ b/sys/mathoid.js
@@ -89,17 +89,18 @@ MathoidService.prototype.checkInput = function(hyper, req) {
                 'content-type': 'application/json',
                 'x-resource-location': hash
             };
-            return P.all([
+            return P.join(
                 hyper.put({
                     uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.check', hash]),
                     headers: checkRes.headers,
                     body: checkRes.body
                 }),
-                indirectionP
-            ]);
-        }).then(function() {
-            checkRes.headers['cache-control'] = self.options['cache-control'];
-            return checkRes;
+                indirectionP,
+                function() {
+                    checkRes.headers['cache-control'] = self.options['cache-control'];
+                    return checkRes;
+                }
+            );
         });
     });
 

--- a/sys/mathoid.js
+++ b/sys/mathoid.js
@@ -48,10 +48,6 @@ MathoidService.prototype.checkInput = function(hyper, req) {
                 });
             });
         });
-    }).then(function(res) {
-        // we have a record, return that
-        res.headers['cache-control'] = self.options['cache-control'];
-        return res;
     }).catch({ status: 404 }, function() {
         // if we are here, it means this is a new input formula
         // so call mathoid
@@ -87,6 +83,7 @@ MathoidService.prototype.checkInput = function(hyper, req) {
             // store the result
             checkRes.headers = {
                 'content-type': 'application/json',
+                'cache-control': 'no-cache',
                 'x-resource-location': hash
             };
             return P.join(
@@ -97,7 +94,6 @@ MathoidService.prototype.checkInput = function(hyper, req) {
                 }),
                 indirectionP,
                 function() {
-                    checkRes.headers['cache-control'] = self.options['cache-control'];
                     return checkRes;
                 }
             );

--- a/sys/mathoid.js
+++ b/sys/mathoid.js
@@ -1,0 +1,140 @@
+'use strict';
+
+
+var P = require('bluebird');
+var HyperSwitch = require('hyperswitch');
+var URI = HyperSwitch.URI;
+var HTTPError = HyperSwitch.HTTPError;
+
+
+function MathoidService(options) {
+
+    this.options = options;
+
+}
+
+
+MathoidService.prototype.checkInput = function(hyper, req) {
+
+    var self = this;
+    var rp = req.params;
+    var hash;
+    var origHash;
+    var checkRes;
+
+    // start by calculating the hash
+    return hyper.post({
+        uri: new URI([rp.domain, 'sys', 'post_data', 'mathoid.input', 'hash']),
+        body: { q: req.body.q, type: rp.type }
+    }).then(function(res) {
+        hash = origHash = res.body;
+        // short-circuit if it's a no-cache request
+        if (req.headers && /no-cache/.test(req.headers['cache-control'])) {
+            return P.reject(new HTTPError({ status: 404 }));
+        }
+        // check the post storage
+        return hyper.get({
+            uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.check', hash])
+        }).catch({ status: 404 }, function(err) {
+            // let's try to find an indirection
+            return hyper.get({
+                uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.hash_table', hash])
+            }).then(function(hashRes) {
+                // we have a normalised version of the formula
+                hash = hashRes.body;
+                // grab that version from storage
+                return hyper.get({
+                    uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.check', hash])
+                });
+            });
+        });
+    }).then(function(res) {
+        // we have a record, return that
+        res.headers['cache-control'] = self.options['cache-control'];
+        return res;
+    }).catch({ status: 404 }, function() {
+        // if we are here, it means this is a new input formula
+        // so call mathoid
+        return hyper.post({
+            uri: self.options.host + '/texvcinfo',
+            headers: { 'content-type': 'application/json' },
+            body: {
+                q: req.body.q,
+                type: rp.type
+            }
+        }).then(function(res) {
+            checkRes = res;
+            // store the normalised version
+            return hyper.put({
+                uri: new URI([rp.domain, 'sys', 'post_data', 'mathoid.input', '']),
+                headers: { 'content-type': 'application/json' },
+                body: {
+                    q: res.body.checked,
+                    type: rp.type
+                }
+            });
+        }).then(function(res) {
+            var indirectionP = P.resolve();
+            hash = res.body;
+            // add the indirection to the hash table if the hashes don't match
+            if (hash !== origHash) {
+                indirectionP = hyper.put({
+                    uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.hash_table', origHash]),
+                    headers: { 'content-type': 'text/plain' },
+                    body: hash
+                });
+            }
+            // store the result
+            checkRes.headers = {
+                'content-type': 'application/json',
+                'x-resource-location': hash
+            };
+            return P.all([
+                hyper.put({
+                    uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.check', hash]),
+                    headers: checkRes.headers,
+                    body: checkRes.body
+                }),
+                indirectionP
+            ]);
+        }).then(function() {
+            checkRes.headers['cache-control'] = self.options['cache-control'];
+            return checkRes;
+        });
+    });
+
+};
+
+
+module.exports = function(options) {
+
+    var mathoidSrv = new MathoidService(options);
+
+    return {
+        spec: {
+            paths: {
+                '/check/{type}': {
+                    post: {
+                        operationId: 'checkInput'
+                    }
+                }
+            }
+        },
+        operations: {
+            checkInput: mathoidSrv.checkInput.bind(mathoidSrv)
+        },
+        resources: [
+            {
+                uri: '/{domain}/sys/post_data/mathoid.input'
+            }, {
+                uri: '/{domain}/sys/key_value/mathoid.hash_table',
+                body: { valueType: 'string' }
+            }, {
+                uri: '/{domain}/sys/key_value/mathoid.check',
+                body: { valueType: 'json' }
+            }
+        ]
+    };
+
+};
+

--- a/sys/post_data.js
+++ b/sys/post_data.js
@@ -45,6 +45,16 @@ function calculateHash(storedData) {
                  .digest('hex');
 }
 
+PostDataBucket.prototype.calculateHash = function(hyper, req) {
+    return {
+        status: 200,
+        headers: {
+            'content-type': 'text/plain'
+        },
+        body: calculateHash(req.body || {})
+    };
+};
+
 PostDataBucket.prototype.putRevision = function(hyper, req) {
     var rp = req.params;
     var storedData = req.body || {};
@@ -89,7 +99,8 @@ module.exports = function(options) {
         operations: {
             createBucket: postDataBucket.createBucket.bind(postDataBucket),
             getRevision: postDataBucket.getRevision.bind(postDataBucket),
-            putRevision: postDataBucket.putRevision.bind(postDataBucket)
+            putRevision: postDataBucket.putRevision.bind(postDataBucket),
+            calculateHash: postDataBucket.calculateHash.bind(postDataBucket)
         }
     };
 };

--- a/sys/post_data.yaml
+++ b/sys/post_data.yaml
@@ -15,3 +15,7 @@ paths:
   /{bucket}/{key}{/tid}:
     get:
       operationId: getRevision
+
+  /{bucket}/hash:
+    post:
+      operationId: calculateHash

--- a/test/features/mathoid.js
+++ b/test/features/mathoid.js
@@ -1,0 +1,75 @@
+'use strict';
+
+
+var assert = require('../utils/assert.js');
+var server = require('../utils/server.js');
+var preq   = require('preq');
+var P = require('bluebird');
+
+
+describe('Mathoid', function() {
+
+    var f = 'c^2 = a^2 + b^2';
+    var nf = 'c^{2}=a^{2}+b^{2}';
+    var uri = server.config.hostPort + '/wikimedia.org/v1/media/math';
+
+    this.timeout(20000);
+
+    before(function () { return server.start(); });
+
+    it('checks the formula with Mathoid', function() {
+        var slice = server.config.logStream.slice();
+        return preq.post({
+            uri: uri + '/check/tex',
+            headers: { 'content-type': 'application/json' },
+            body: { q: f }
+        }).then(function(res) {
+            slice.halt();
+            assert.localRequests(slice, false);
+            assert.remoteRequests(slice, true);
+        });
+    });
+
+    it('retrieves the check output from storage', function() {
+        var slice = server.config.logStream.slice();
+        return preq.post({
+            uri: uri + '/check/tex',
+            headers: { 'content-type': 'application/json' },
+            body: { q: f }
+        }).then(function(res) {
+            slice.halt();
+            assert.localRequests(slice, true);
+            assert.remoteRequests(slice, false);
+        });
+    });
+
+    it('retrieves the check output of the normalised version', function() {
+        var slice = server.config.logStream.slice();
+        return preq.post({
+            uri: uri + '/check/tex',
+            headers: { 'content-type': 'application/json' },
+            body: { q: nf }
+        }).then(function(res) {
+            slice.halt();
+            assert.localRequests(slice, true);
+            assert.remoteRequests(slice, false);
+        });
+    });
+
+    it('ignores stored version for no-cache', function() {
+        var slice = server.config.logStream.slice();
+        return preq.post({
+            uri: uri + '/check/tex',
+            headers: {
+                'content-type': 'application/json',
+                'cache-control': 'no-cache'
+            },
+            body: { q: f }
+        }).then(function(res) {
+            slice.halt();
+            assert.localRequests(slice, false);
+            assert.remoteRequests(slice, true);
+        });
+    });
+
+});

--- a/test/features/mathoid.js
+++ b/test/features/mathoid.js
@@ -27,6 +27,7 @@ describe('Mathoid', function() {
             slice.halt();
             assert.localRequests(slice, false);
             assert.remoteRequests(slice, true);
+            assert.checkString(res.headers['cache-control'], 'no-cache');
         });
     });
 
@@ -40,6 +41,7 @@ describe('Mathoid', function() {
             slice.halt();
             assert.localRequests(slice, true);
             assert.remoteRequests(slice, false);
+            assert.checkString(res.headers['cache-control'], 'no-cache');
         });
     });
 
@@ -53,6 +55,7 @@ describe('Mathoid', function() {
             slice.halt();
             assert.localRequests(slice, true);
             assert.remoteRequests(slice, false);
+            assert.checkString(res.headers['cache-control'], 'no-cache');
         });
     });
 
@@ -69,6 +72,7 @@ describe('Mathoid', function() {
             slice.halt();
             assert.localRequests(slice, false);
             assert.remoteRequests(slice, true);
+            assert.checkString(res.headers['cache-control'], 'no-cache');
         });
     });
 

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -151,7 +151,8 @@ function checkString(result, expected, message) {
     if (expected.constructor === RegExp) {
         assert.ok(expected.test(result), '' + expected + '.test(' + result + ') fails');
     } else {
-        assert.deepStrictEqual(result, expected, expected + ' !== ' + result);
+        var de = assert.deepStrictEqual || assert.deepEqual;
+        de(result, expected, expected + ' !== ' + result);
     }
 }
 

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -147,6 +147,14 @@ function fails(promise, onRejected) {
     return promise.catch(trackFailure).then(check);
 }
 
+function checkString(result, expected, message) {
+    if (expected.constructor === RegExp) {
+        assert.ok(expected.test(result), '' + expected + '.test(' + result + ') fails');
+    } else {
+        assert.deepStrictEqual(result, expected, expected + ' !== ' + result);
+    }
+}
+
 module.exports.ok             = assert.ok;
 module.exports.fails          = fails;
 module.exports.deepEqual      = deepEqual;
@@ -157,4 +165,4 @@ module.exports.contentType    = contentType;
 module.exports.localRequests  = localRequests;
 module.exports.remoteRequests = remoteRequests;
 module.exports.findParsoidRequest = findParsoidRequest;
-
+module.exports.checkString    = checkString;

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -63,34 +63,13 @@ paths:
             body:
               success: true
               checked: /.+/
-      x-setup-handler:
-        - init:
-            uri: /wikimedia.org/sys/post_data/mathoid.input
       x-request-handler:
-        - check_input:
+        - get_from_sys:
             request:
-              uri: '{{ options.host }}/texvcinfo'
-              headers:
-                content-type: application/json
-              body:
-                q: '{{ request.body.q }}'
-                type: '{{ request.params.type }}'
-        - post_store:
-            request:
-              method: put
-              uri: /wikimedia.org/sys/post_data/mathoid.input/
-              headers:
-                content-type: application/json
-              body:
-                q: '{{ check_input.body.checked }}'
-                type: '{{ request.params.type }}'
-            return:
-              status: 200
-              headers:
-                content-type: application/json
-                cache-control: '{{ options.cache-control }}'
-                x-resource-location: '{{ post_store.body }}'
-              body: '{{ check_input.body }}'
+              method: post
+              uri: /wikimedia.org/sys/mathoid/check/{type}
+              headers: '{{ request.headers }}'
+              body: '{{ request.body }}'
 
   /math/render/{format}/{hash}:
     get:

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -70,10 +70,6 @@ paths:
               uri: /wikimedia.org/sys/mathoid/check/{type}
               headers: '{{ request.headers }}'
               body: '{{ request.body }}'
-            return:
-              status: 200
-              headers: "{{ merge({ 'cache-control': 'no-cache' }, get_from_sys.headers) }}"
-              body: '{{ get_from_sys.body }}'
 
   /math/render/{format}/{hash}:
     get:

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -59,7 +59,7 @@ paths:
             headers:
               content-type: /^application\/json/
               x-resource-location: /.+/
-              cache-control: /s-maxage/
+              cache-control: 'no-cache'
             body:
               success: true
               checked: /.+/
@@ -70,6 +70,10 @@ paths:
               uri: /wikimedia.org/sys/mathoid/check/{type}
               headers: '{{ request.headers }}'
               body: '{{ request.body }}'
+            return:
+              status: 200
+              headers: "{{ merge({ 'cache-control': 'no-cache' }, get_from_sys.headers) }}"
+              body: '{{ get_from_sys.body }}'
 
   /math/render/{format}/{hash}:
     get:


### PR DESCRIPTION
Mathoid's `/texvcinfo` endpoint check the correctness of a formula and normalises it. Because of the normalisation, we weren't reusing its result, since different formulae can have different TeX representations but the same render. Unfortunately, that implied that Mathoid had to be called on each request for a formula check. This PR introduces the `mathoid.js` sys module which de-duplicates such cases. First, storage is checked for the texvcinfo result of the provided formula. If one cannot be found, an indirection record is looked up in a special, hash-mapping table. In case an indirection exists, that hash is used to complete the request (the texvcinfo table is queried again). Only if all of the above fails, Mathoid is called.

Also:
- add a route to the `post_data` module which calculates the hash
- fix a minor edge case in testing utils
- add tests for the `mathoid` module
- release v0.11.4

Bug: [T128593](https://phabricator.wikimedia.org/T128593)