### PR TITLE
Mathoid: Enable PNG support

### DIFF
--- a/test/features/mathoid.js
+++ b/test/features/mathoid.js
@@ -12,6 +12,8 @@ describe('Mathoid', function() {
     var f = 'c^2 = a^2 + b^2';
     var nf = 'c^{2}=a^{2}+b^{2}';
     var uri = server.config.hostPort + '/wikimedia.org/v1/media/math';
+    var formats = ['mml', 'svg', 'png'];
+    var hash;
 
     this.timeout(20000);
 
@@ -25,6 +27,7 @@ describe('Mathoid', function() {
             body: { q: f }
         }).then(function(res) {
             slice.halt();
+            hash = res.headers['x-resource-location'];
             assert.localRequests(slice, false);
             assert.remoteRequests(slice, true);
             assert.checkString(res.headers['cache-control'], 'no-cache');
@@ -75,5 +78,17 @@ describe('Mathoid', function() {
             assert.checkString(res.headers['cache-control'], 'no-cache');
         });
     });
+
+    for (var i = 0; i < formats.length; i++) {
+        var format = formats[i];
+        it('gets the render in ' + format, function() {
+            return preq.get({
+                uri: uri + '/render/' + format + '/' + hash
+            }).then(function(res) {
+                assert.checkString(res.headers['content-type'], new RegExp(format));
+                assert.ok(res.body);
+            });
+        });
+    }
 
 });

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -86,6 +86,7 @@ paths:
       produces:
         - image/svg+xml
         - application/mathml+xml
+        - image/png
       parameters:
         - name: format
           in: path
@@ -150,25 +151,8 @@ paths:
         - mathoid:
             request:
               method: post
-              uri: '{{options.host}}/complete'
+              uri: /wikimedia.org/sys/mathoid/render/{request.params.format}
               headers:
                 content-type: application/json
+                x-resource-location: '{{ request.params.hash }}'
               body: '{{postdata.body}}'
-        - store_svg:
-            request:
-              method: put
-              uri: /wikimedia.org/sys/key_value/mathoid.svg/{$.request.params.hash}
-              headers: "{{ merge(mathoid.body.svg.headers, { 'x-resource-location': request.params.hash }) }}"
-              body: '{{mathoid.body.svg.body}}'
-          store_mml:
-            request:
-              method: put
-              uri: /wikimedia.org/sys/key_value/mathoid.mml/{$.request.params.hash}
-              headers: "{{ merge(mathoid.body.mml.headers, { 'x-resource-location': request.params.hash }) }}"
-              body: '{{ mathoid.body.mml.body }}'
-        - return:
-            return:
-              status: 200
-              headers: "{{ merge(mathoid.body[request.params.format].headers, { 'x-resource-location': request.params.hash, 'cache-control': options.cache-control }) }}"
-              body: '{{ mathoid.body[request.params.format].body }}'
-

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -95,6 +95,7 @@ paths:
           enum:
             - svg
             - mml
+            - png
         - name: hash
           in: path
           description: The hash string of the previous POST data
@@ -123,6 +124,11 @@ paths:
             body:
               keyType: string
               valueType: string
+        - init_png:
+            uri: /wikimedia.org/sys/key_value/mathoid.png
+            body:
+              keyType: string
+              valueType: blob
       x-request-handler:
         - check_storage:
             request:


### PR DESCRIPTION
Mathoid sends the PNG in binary form to the caller. However, when wrapping the PNG response body in a JSON for its `/complete` endpoint, it gets serialised to a plain `{type: 'Buffer', data: [...]}` object. To circumvent that and be able to still make only one request for all of the renders, requesting the renders from Mathoid and storing them in separate buckets has been moved to the mathoid module, where the PNG render gets converted back into a Buffer and stored (and served) properly.

Note: cannot be merged and deployed before https://gerrit.wikimedia.org/r/#/c/276734/ is merged.

Bug: [T71702](https://phabricator.wikimedia.org/T71702)