### PR TITLE
Temporarily log & don't cache remaining requests from rest.wikimedia.org

### DIFF
--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -7,6 +7,31 @@ var Title = require('mediawiki-title').Title;
 
 module.exports = function(hyper, req, next, options, specInfo) {
     var rp = req.params;
+    /**
+     * Temporary logging & handling for rest.wikimedia.org requests.
+     */
+    if (req.headers.host && req.headers.host === 'rest.wikimedia.org') {
+        // 1:10 sampled logging until we know that the rate is really low.
+        if (Math.random() < 0.1) {
+            hyper.log('warn/normalize/rest_wikimedia_org', {
+                msg: 'Request to rest.wikimedia.org',
+            });
+        }
+        var origNext = next;
+        // Make sure no rest.wikimedia.org requests are cached, as they aren't
+        // purged in Varnish frontends.
+        next = function(hyper, req) {
+            return origNext(hyper, req)
+            .then(function(res) {
+                if (res) {
+                    res.headers = res.headers || {};
+                    res.headers['cache-control'] = 'no-cache';
+                }
+                return res;
+            });
+        };
+    }
+
     if (rp.title) {
         return mwUtil.getSiteInfo(hyper, req)
         .then(function(siteInfo) {
@@ -34,7 +59,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
                     .then(function(res) {
                         if (res) {
                             res.headers = res.headers || {};
-                            res.headers['cache-control'] = 'no-cache, must-revalidate';
+                            res.headers['cache-control'] = 'no-cache';
                         }
                         return res;
                     });
@@ -80,7 +105,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
                     .then(function(res) {
                         if (res) {
                             res.headers = res.headers || {};
-                            res.headers['cache-control'] = 'no-cache, must-revalidate';
+                            res.headers['cache-control'] = 'no-cache';
                         }
                         return res;
                     });


### PR DESCRIPTION
Before shutting down rest.wikimedia.org, we need to gauge remaining use, and
possibly alert remaining users.

This patch

- sets up logging for rest.wikimedia.org requests, and
- makes sure that none of those responses are cached, as they aren't purged
  either.