### PR TITLE
Data-parsoid and page title cleanup

### DIFF
--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -76,7 +76,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: Page title.
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
       responses:
@@ -153,7 +153,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: Page title.
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
         - name: page
@@ -188,7 +188,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: Page title.
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
         - name: sections
@@ -292,7 +292,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: Page title.
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
         - name: base_etag
@@ -384,7 +384,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
         - name: page
@@ -427,7 +427,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
         - name: revision
@@ -503,114 +503,6 @@ paths:
                 sections: '{{sections}}'
       x-monitor: false
 
-  /data-parsoid/{title}:
-    get:
-      tags:
-        - Page content
-      summary: Get latest data-parsoid metadata for a title.
-      description: |
-        Data-parsoid is metadata used by
-        [Parsoid](https://www.mediawiki.org/wiki/Parsoid) to support clean
-        round-tripping conversions between HTML and Wikitext. Among other
-        things, it contains the original Wikitext offsets of each HTML
-        element, keyed by element ID. The format is unstable.
-
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
-      parameters:
-        - name: title
-          in: path
-          description: the title of page content
-          type: string
-          required: true
-      produces:
-        - application/json
-      responses:
-        '200':
-          description: data-parsoid JSON blob
-          schema:
-            $ref: '#/definitions/data-parsoid'
-        '404':
-          description: Unknown page title
-          schema:
-            $ref: '#/definitions/problem'
-        default:
-          description: Error
-          schema:
-            $ref: '#/definitions/problem'
-      x-request-handler:
-        - get_from_backend:
-            request:
-              uri: /{domain}/sys/parsoid/data-parsoid/{title}
-              headers:
-                cache-control: '{{cache-control}}'
-                if-unmodified-since: '{{if-unmodified-since}}'
-                x-restbase-mode: '{{x-restbase-mode}}'
-                x-restbase-parentrevision: '{{x-restbase-parentrevision}}'
-      x-monitor: true
-      x-amples:
-        - title: Get data-parsoid by title
-          request:
-            params:
-              domain: en.wikipedia.org
-              title: Foobar
-          response:
-            status: 200
-            headers:
-              etag: /.+/
-              content-type: application/json
-            body:
-              counter: /\d+/
-              ids: /.*/
-              sectionOffsets: /.*/
-
-  /data-parsoid/{title}/:
-    get:
-      tags:
-        - Page content
-      summary: List data-parsoid revisions for a page.
-      description: |
-        This currently only lists revisions stored in RESTBase.
-
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
-      produces:
-        - application/json
-      parameters:
-        - name: title
-          in: path
-          description: The page title
-          type: string
-          required: true
-        - name: page
-          in: query
-          description: Next page token, provided by _links.next.href property.
-          type: string
-          required: false
-      responses:
-        '200':
-          description: The list of revisions
-          schema:
-            $ref: '#/definitions/revisions'
-        '404':
-          description: Unknown page title
-          schema:
-            $ref: '#/definitions/problem'
-        default:
-          description: Error
-          schema:
-            $ref: '#/definitions/problem'
-      x-request-handler:
-        - get_from_backend:
-            request:
-              uri: /{domain}/sys/parsoid/data-parsoid/{title}/
-              headers:
-                cache-control: '{{cache-control}}'
-                if-unmodified-since: '{{if-unmodified-since}}'
-                x-restbase-mode: '{{x-restbase-mode}}'
-                x-restbase-parentrevision: '{{x-restbase-parentrevision}}'
-            query:
-              page: '{{page}}'
-      x-monitor: false
-
   /data-parsoid/{title}/{revision}/{tid}:
     get:
       tags:
@@ -633,7 +525,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
         - name: revision
@@ -796,7 +688,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title.
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
         - name: base_etag

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -17,7 +17,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
       responses:
@@ -85,7 +85,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
       responses:
@@ -139,7 +139,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
       responses:
@@ -192,7 +192,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
       responses:

--- a/v1/pageviews.yaml
+++ b/v1/pageviews.yaml
@@ -62,9 +62,9 @@ paths:
           type: string
           enum: ['all-agents', 'user', 'spider', 'bot']
           required: true
-        - name: article
+        - name: title
           in: path
-          description: 'The name of any article in the specified project. Any spaces should be replaced with underscores. It also should be URI-encoded, so that non-URI-safe characters like %, / or ? are accepted. Example: Are_You_the_One%3F'
+          description: 'The title of any article in the specified project. Any spaces should be replaced with underscores. It also should be URI-encoded, so that non-URI-safe characters like %, / or ? are accepted. Example: Are_You_the_One%3F'
           type: string
           required: true
         - name: granularity
@@ -95,7 +95,7 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
-              uri: '{{options.host}}/pageviews/per-article/{project}/{access}/{agent}/{article}/{granularity}/{start}/{end}'
+              uri: '{{options.host}}/pageviews/per-article/{project}/{access}/{agent}/{title}/{granularity}/{start}/{end}'
       x-monitor: false
 
   /pageviews/aggregate/{project}/{access}/{agent}/{granularity}/{start}/{end}:

--- a/v1/related.yaml
+++ b/v1/related.yaml
@@ -28,7 +28,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title.
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
       responses:

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -28,7 +28,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title.
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
       responses:

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -29,7 +29,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: false
         - name: revision
@@ -108,7 +108,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: false
         - name: revision
@@ -271,7 +271,7 @@ paths:
       parameters:
         - name: title
           in: path
-          description: The page title
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
         - name: revision


### PR DESCRIPTION
- Remove data-parsoid listing & by-title retrieval. We missed these entry
  points in the last pass.
- Explicitly mention the use of underscores in the documentation for all
  `title` parameters.