### PR TITLE
Redirect file pages to commons if they were not found in local wiki

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -90,6 +90,7 @@ spec_root: &spec_root
     /{domain:en.wikipedia.org}: *default_project
     /{domain:test.wikipedia.org}: *default_project
     /{domain:test2.wikipedia.org}: *default_project
+    /{domain:commons.wikimedia.org}: *default_project
 
     # labs, used for most tests
     /{domain:en.wikipedia.beta.wmflabs.org}: *labs_project

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -166,6 +166,18 @@ mwUtil.decodeBody = function(contentResponse) {
     });
 };
 
+function findSharedRepoDomain(siteInfoRes) {
+    var sharedRepo = (siteInfoRes.body.query.repos || []).find(function(repo) {
+        return repo.name === 'shared';
+    });
+    if (sharedRepo) {
+        var domainMatch = /^((:?https?:)?\/\/[^/]+)/.exec(sharedRepo.descBaseUrl);
+        if (domainMatch) {
+            return domainMatch[0];
+        }
+    }
+}
+
 var siteInfoCache = {};
 mwUtil.getSiteInfo = function(hyper, req) {
     var rp = req.params;
@@ -181,7 +193,8 @@ mwUtil.getSiteInfo = function(hyper, req) {
                 lang: res.body.query.general.lang,
                 legaltitlechars: res.body.query.general.legaltitlechars,
                 namespaces: res.body.query.namespaces,
-                namespacealiases: res.body.query.namespacealiases
+                namespacealiases: res.body.query.namespacealiases,
+                sharedRepoRootURI: findSharedRepoDomain(res)
             };
         });
     }

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -4,6 +4,22 @@ var HyperSwitch = require('hyperswitch');
 var mwUtil = require('./mwUtil');
 var HTTPError = HyperSwitch.HTTPError;
 var Title = require('mediawiki-title').Title;
+var P = require('bluebird');
+
+function normalizeTitle(title, siteInfo) {
+    return P.try(function() {
+        return Title.newFromText(title, siteInfo);
+    })
+    .catch(function(e) {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'bad_request',
+                detail: e.message
+            }
+        });
+    });
+}
 
 module.exports = function(hyper, req, next, options, specInfo) {
     var rp = req.params;
@@ -32,87 +48,100 @@ module.exports = function(hyper, req, next, options, specInfo) {
         };
     }
 
+    var nextRequest;
     if (rp.title) {
         return mwUtil.getSiteInfo(hyper, req)
         .then(function(siteInfo) {
-            return Title.newFromText(rp.title, siteInfo);
-        })
-        .catch(function(e) {
-            throw new HTTPError({
-                status: 400,
-                body: {
-                    type: 'bad_request',
-                    detail: e.message
-                }
-            });
-        })
-        .then(function(result) {
-            var resultText = result.getPrefixedDBKey();
-            if (resultText !== rp.title) {
-                if (req.method === 'post' // Don't redirect POSTs as it's not cached anyway
-                        || result.getNamespace().isUser()
-                        || result.getNamespace().isUserTalk()) {
-                    // Due to gender variations of User and User_Talk namespaces in some langs
-                    // use canonical name for storage, but don't redirect. Don't cache either
-                    rp.title = resultText;
-                    return next(hyper, req)
-                    .then(function(res) {
-                        if (res) {
-                            res.headers = res.headers || {};
-                            res.headers['cache-control'] = 'no-cache';
-                        }
-                        return res;
-                    });
-                } else {
-                    /* TODO: we don't want to enable redirects yet, so log the redirect instead
-                     and disable caching of the response
-
-                     rp.title = result;
-                     var pathBeforeTitle = specInfo.path
-                     .substring(0, specInfo.path.indexOf('{title}'));
-                     pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
-                     var pathAfterTitle = req.uri.toString().replace(pathBeforeTitle, '');
-                     var backCount = (pathAfterTitle.match(/\//g) || []).length;
-                     var backString = Array.apply(null, { length: backCount }).map(function() {
-                     return '../';
-                     }).join('');
-                     var pathPatternAfterTitle = specInfo.path
-                     .substring(specInfo.path.indexOf('{title}') - 1);
-                     var contentLocation = backString
-                     + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
-                     return P.resolve({
-                     status: 301,
-                     headers: {
-                     location: contentLocation
-                     }
-                     });*/
-                    if (rp.title.replace(/ /g, '_') !== resultText) {
-                        // Log all of these, should be relatively rare.
-                        hyper.log('warn/normalize/non_space', {
-                            msg: 'Normalized non-space chars',
-                            from: rp.title,
-                            to: resultText,
+            return normalizeTitle(rp.title, siteInfo)
+            .then(function(result) {
+                var resultText = result.getPrefixedDBKey();
+                if (resultText !== rp.title) {
+                    if (req.method === 'post' // Don't redirect POSTs as it's not cached anyway
+                    || result.getNamespace().isUser()
+                    || result.getNamespace().isUserTalk()) {
+                        // Due to gender variations of User and User_Talk namespaces in some langs
+                        // use canonical name for storage, but don't redirect. Don't cache either
+                        rp.title = resultText;
+                        return next(hyper, req)
+                        .then(function(res) {
+                            if (res) {
+                                res.headers = res.headers || {};
+                                res.headers['cache-control'] = 'no-cache';
+                            }
+                            return res;
                         });
-                    } else if (Math.random() < 0.05) {
-                        // 5% chance of logging to bound volume.
-                        hyper.log('warn/normalize/space', {
-                            msg: 'Normalized requested title',
-                            from: rp.title,
-                            to: resultText,
+                    } else {
+                        /* TODO: we don't want to enable redirects yet, so log the redirect instead
+                         and disable caching of the response
+
+                         rp.title = result;
+                         var pathBeforeTitle = specInfo.path
+                         .substring(0, specInfo.path.indexOf('{title}'));
+                         pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
+                         var pathAfterTitle = req.uri.toString().replace(pathBeforeTitle, '');
+                         var backCount = (pathAfterTitle.match(/\//g) || []).length;
+                         var backString = Array.apply(null, { length: backCount }).map(function() {
+                         return '../';
+                         }).join('');
+                         var pathPatternAfterTitle = specInfo.path
+                         .substring(specInfo.path.indexOf('{title}') - 1);
+                         var contentLocation = backString
+                         + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
+                         return P.resolve({
+                         status: 301,
+                         headers: {
+                         location: contentLocation
+                         }
+                         });*/
+
+                        if (rp.title.replace(/ /g, '_') !== resultText) {
+                            // Log all of these, should be relatively rare.
+                            hyper.log('warn/normalize/non_space', {
+                                msg: 'Normalized non-space chars',
+                                from: rp.title,
+                                to: resultText,
+                            });
+                        } else if (Math.random() < 0.05) {
+                            // 5% chance of logging to bound volume.
+                            hyper.log('warn/normalize/space', {
+                                msg: 'Normalized requested title',
+                                from: rp.title,
+                                to: resultText,
+                            });
+                        }
+
+                        nextRequest = next(hyper, req)
+                        .then(function(res) {
+                            if (res) {
+                                res.headers = res.headers || {};
+                                res.headers['cache-control'] = 'no-cache';
+                            }
+                            return res;
                         });
                     }
-                    return next(hyper, req)
-                    .then(function(res) {
-                        if (res) {
-                            res.headers = res.headers || {};
-                            res.headers['cache-control'] = 'no-cache';
-                        }
-                        return res;
+                } else {
+                    nextRequest = next(hyper, req);
+                }
+
+                if (result.getNamespace().isFile() && siteInfo.sharedRepoRootURI) {
+                    nextRequest = nextRequest.catch({ status: 404 }, function() {
+                        // It's a file page and it might be in the shared repo.
+                        // Redirect.
+                        var redirectPath = req.uri + '';
+                        redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
+                        redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1' + redirectPath;
+                        return {
+                            status: 301,
+                            headers: {
+                                location: redirectPath,
+                                'cache-control': options.redirect_cache_control
+                            }
+                        };
                     });
                 }
-            } else {
-                return next(hyper, req);
-            }
+
+                return nextRequest;
+            });
         });
     } else {
         return next(hyper, req);

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -49,101 +49,98 @@ module.exports = function(hyper, req, next, options, specInfo) {
     }
 
     var nextRequest;
-    if (rp.title) {
-        return mwUtil.getSiteInfo(hyper, req)
-        .then(function(siteInfo) {
-            return normalizeTitle(rp.title, siteInfo)
-            .then(function(result) {
-                var resultText = result.getPrefixedDBKey();
-                if (resultText !== rp.title) {
-                    if (req.method === 'post' // Don't redirect POSTs as it's not cached anyway
-                    || result.getNamespace().isUser()
-                    || result.getNamespace().isUserTalk()) {
-                        // Due to gender variations of User and User_Talk namespaces in some langs
-                        // use canonical name for storage, but don't redirect. Don't cache either
-                        rp.title = resultText;
-                        return next(hyper, req)
-                        .then(function(res) {
-                            if (res) {
-                                res.headers = res.headers || {};
-                                res.headers['cache-control'] = 'no-cache';
-                            }
-                            return res;
-                        });
-                    } else {
-                        /* TODO: we don't want to enable redirects yet, so log the redirect instead
-                         and disable caching of the response
-
-                         rp.title = result;
-                         var pathBeforeTitle = specInfo.path
-                         .substring(0, specInfo.path.indexOf('{title}'));
-                         pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
-                         var pathAfterTitle = req.uri.toString().replace(pathBeforeTitle, '');
-                         var backCount = (pathAfterTitle.match(/\//g) || []).length;
-                         var backString = Array.apply(null, { length: backCount }).map(function() {
-                         return '../';
-                         }).join('');
-                         var pathPatternAfterTitle = specInfo.path
-                         .substring(specInfo.path.indexOf('{title}') - 1);
-                         var contentLocation = backString
-                         + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
-                         return P.resolve({
-                         status: 301,
-                         headers: {
-                         location: contentLocation
-                         }
-                         });*/
-
-                        if (rp.title.replace(/ /g, '_') !== resultText) {
-                            // Log all of these, should be relatively rare.
-                            hyper.log('warn/normalize/non_space', {
-                                msg: 'Normalized non-space chars',
-                                from: rp.title,
-                                to: resultText,
-                            });
-                        } else if (Math.random() < 0.05) {
-                            // 5% chance of logging to bound volume.
-                            hyper.log('warn/normalize/space', {
-                                msg: 'Normalized requested title',
-                                from: rp.title,
-                                to: resultText,
-                            });
-                        }
-
-                        nextRequest = next(hyper, req)
-                        .then(function(res) {
-                            if (res) {
-                                res.headers = res.headers || {};
-                                res.headers['cache-control'] = 'no-cache';
-                            }
-                            return res;
-                        });
-                    }
-                } else {
-                    nextRequest = next(hyper, req);
-                }
-
-                if (result.getNamespace().isFile() && siteInfo.sharedRepoRootURI) {
-                    nextRequest = nextRequest.catch({ status: 404 }, function() {
-                        // It's a file page and it might be in the shared repo.
-                        // Redirect.
-                        var redirectPath = req.uri + '';
-                        redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
-                        redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1' + redirectPath;
-                        return {
-                            status: 301,
-                            headers: {
-                                location: redirectPath,
-                                'cache-control': options.redirect_cache_control
-                            }
-                        };
-                    });
-                }
-
-                return nextRequest;
-            });
-        });
-    } else {
+    if (!rp.title) {
         return next(hyper, req);
     }
+
+    return mwUtil.getSiteInfo(hyper, req)
+    .then(function(siteInfo) {
+        return normalizeTitle(rp.title, siteInfo)
+        .then(function(result) {
+            var resultText = result.getPrefixedDBKey();
+            if (resultText !== rp.title) {
+                if (req.method === 'post' // Don't redirect POSTs as it's not cached anyway
+                    || result.getNamespace().isUser()
+                    || result.getNamespace().isUserTalk()) {
+                    // Due to gender variations of User and User_Talk namespaces in some langs
+                    // use canonical name for storage, but don't redirect. Don't cache either
+                    rp.title = resultText;
+                    return next(hyper, req)
+                    .then(function(res) {
+                        if (res) {
+                            res.headers = res.headers || {};
+                            res.headers['cache-control'] = 'no-cache';
+                        }
+                        return res;
+                    });
+                } else {
+                    /* TODO: we don't want to enable redirects yet, so log the redirect instead
+                     and disable caching of the response
+
+                     rp.title = result;
+                     var pathBeforeTitle = specInfo.path
+                     .substring(0, specInfo.path.indexOf('{title}'));
+                     pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
+                     var pathAfterTitle = req.uri.toString().replace(pathBeforeTitle, '');
+                     var backCount = (pathAfterTitle.match(/\//g) || []).length;
+                     var backString = Array.apply(null, { length: backCount }).map(function() {
+                     return '../';
+                     }).join('');
+                     var pathPatternAfterTitle = specInfo.path
+                     .substring(specInfo.path.indexOf('{title}') - 1);
+                     var contentLocation = backString
+                     + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
+                     return P.resolve({
+                     status: 301,
+                     headers: {
+                     location: contentLocation
+                     }
+                     });*/
+                    if (rp.title.replace(/ /g, '_') !== resultText) {
+                        // Log all of these, should be relatively rare.
+                        hyper.log('warn/normalize/non_space', {
+                            msg: 'Normalized non-space chars',
+                            from: rp.title,
+                            to: resultText,
+                        });
+                    } else if (Math.random() < 0.05) {
+                        // 5% chance of logging to bound volume.
+                        hyper.log('warn/normalize/space', {
+                            msg: 'Normalized requested title',
+                            from: rp.title,
+                            to: resultText,
+                        });
+                    }
+                    nextRequest = next(hyper, req)
+                    .then(function(res) {
+                        if (res) {
+                            res.headers = res.headers || {};
+                            res.headers['cache-control'] = 'no-cache';
+                        }
+                        return res;
+                    });
+                }
+            } else {
+                nextRequest = next(hyper, req);
+            }
+
+            if (result.getNamespace().isFile() && siteInfo.sharedRepoRootURI) {
+                nextRequest = nextRequest.catch({ status: 404 }, function() {
+                    // It's a file page and it might be in the shared repo.
+                    // Redirect.
+                    var redirectPath = req.uri + '';
+                    redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
+                    redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1' + redirectPath;
+                    return {
+                        status: 301,
+                        headers: {
+                            location: redirectPath,
+                            'cache-control': options.redirect_cache_control
+                        }
+                    };
+                });
+            }
+            return nextRequest;
+        });
+    });
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "content-type": "git+https://github.com/wikimedia/content-type#master",
     "hyperswitch": "^0.4.0",
     "jsonwebtoken": "^5.5.4",
-    "mediawiki-title": "^0.3.0"
+    "mediawiki-title": "^0.3.3"
   },
   "devDependencies": {
     "js-yaml": "^3.5.2",

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -28,6 +28,8 @@ paths:
             description: Welcome to your RESTBase API.
           x-route-filters:
             - path: ./lib/normalize_title_filter.js
+              options:
+                redirect_cache_control: '{{options.purged_cache_control}}'
           paths:
             /page:
               x-modules:
@@ -35,6 +37,7 @@ paths:
             /transform:
               x-modules:
                 - path: v1/transform.yaml
+        options: '{{options}}'
 
   /{api:sys}:
     x-modules:

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -40,6 +40,8 @@ paths:
           x-host-basePath: /api/rest_v1
           x-route-filters:
             - path: ./lib/normalize_title_filter.js
+              options:
+                redirect_cache_control: '{{options.purged_cache_control}}'
           paths:
             /media:
               x-modules:

--- a/projects/wikimedia.org_sqlite.yaml
+++ b/projects/wikimedia.org_sqlite.yaml
@@ -31,6 +31,8 @@ paths:
           x-host-basePath: /api/rest_v1
           x-route-filters:
             - path: ./lib/normalize_title_filter.js
+              options:
+                redirect_cache_control: '{{options.purged_cache_control}}'
           paths:
             /media:
               x-modules:

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -31,6 +31,8 @@ paths:
           x-host-basePath: /api/rest_v1
           x-route-filters:
             - path: ./lib/normalize_title_filter.js
+              options:
+                redirect_cache_control: '{{options.purged_cache_control}}'
           paths:
             /page:
               x-modules:

--- a/projects/wmf_sqlite.yaml
+++ b/projects/wmf_sqlite.yaml
@@ -31,6 +31,8 @@ paths:
           x-host-basePath: /api/rest_v1
           x-route-filters:
             - path: ./lib/normalize_title_filter.js
+              options:
+                redirect_cache_control: '{{options.purged_cache_control}}'
           paths:
             /page:
               x-modules:

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -32,6 +32,8 @@ paths:
           x-host-basePath: /api/rest_v1
           x-route-filters:
             - path: ./lib/normalize_title_filter.js
+              options:
+                redirect_cache_control: '{{options.purged_cache_control}}'
           paths:
             /page:
               x-modules:

--- a/sys/action.js
+++ b/sys/action.js
@@ -216,7 +216,7 @@ ActionService.prototype.edit = function(hyper, req) {
 ActionService.prototype.siteinfo = function(hyper, req) {
     return this._doRequest(hyper, req, {
         action: 'query',
-        meta: 'siteinfo',
+        meta: 'siteinfo|filerepoinfo',
         format: 'json'
     }, function(apiReq, res) { return res; });
 };

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -308,6 +308,28 @@ describe('item requests', function() {
     //    });
     //});
 
+    it('should redirect to commons for missing file pages', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-location'],
+                'https://commons.wikimedia.org/api/rest_v1/page/html/File%3AThinkingMan_Rodin.jpg');
+        });
+    });
+
+    it('should not redirect if file is missing on commons', function() {
+        return preq.get({
+            uri: server.config.hostPort +
+                '/commons.wikimedia.org/v1/html/File:Some_File_That_Does_Not_Exist.jpg'
+        })
+        .then(function() {
+            throw new Error('Error should be thrown');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+        });
+    });
 });
 
 describe('page content access', function() {


### PR DESCRIPTION
In case the page was not found, and it's in `File` namespace, try to redirect the client to commons, if it's set up for this particular wiki.

Bug: https://phabricator.wikimedia.org/T118306