### PR TITLE
Emit events to the eventlogging service from RESTBase

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -13,7 +13,7 @@ default_project: &default_project
         events_emit:
           eventlogging_service:
             uri: http://127.0.0.1:8085/v1/events
-            topic: wmf.resource_change
+            topic: resource_change
     - path: projects/wmf_default.yaml
       options: &default_options
         table:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -6,10 +6,14 @@ default_project: &default_project
   x-modules:
     - path: test/test_module.yaml
       options:
-        events:
+        events_purge:
           purge:
             host: 127.0.0.1
             port: 4321
+        events_emit:
+          eventlogging_service:
+            uri: http://127.0.0.1:8085/v1/events
+            topic: resource_change
     - path: projects/wmf_default.yaml
       options: &default_options
         table:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -13,7 +13,7 @@ default_project: &default_project
         events_emit:
           eventlogging_service:
             uri: http://127.0.0.1:8085/v1/events
-            topic: resource_change
+            topic: wmf.resource_change
     - path: projects/wmf_default.yaml
       options: &default_options
         table:

--- a/sys/events.js
+++ b/sys/events.js
@@ -3,16 +3,32 @@
 var Purger    = require('htcp-purge');
 var P         = require('bluebird');
 var HTTPError = require('hyperswitch').HTTPError;
+var uuid = require('cassandra-uuid').TimeUuid;
 
 var EventService = function(options) {
     this.options = options;
+
+    if (options && options.eventlogging_service
+        && !options.eventlogging_service.uri) {
+        throw new Error('Incorrect configuration of events module. ' +
+            'EventLogging options should provide a uri');
+    }
+
+    if (options && options.eventlogging_service
+        && !options.eventlogging_service.topic) {
+        throw new Error('Incorrect configuration of events module. ' +
+            'EventLogging options should provide a topic');
+    }
 
     if (options && options.purge) {
         this.purger = new Purger({ routes: [ options.purge ] });
     }
 };
 
-EventService.prototype.emitEvent = function(hyper, req) {
+// Until the change propagation is in place we purge straight from
+// RESTBase, however after it's implemented we'd remove this and only emit
+// an event to the eventlogging service
+EventService.prototype._purge = function(hyper, req) {
     var self = this;
     if (this.purger) {
         P.try(function() {
@@ -42,7 +58,50 @@ EventService.prototype.emitEvent = function(hyper, req) {
             hyper.log('error/events/purge', e);
         });
     }
-    return P.resolve({ status: 200 });
+};
+
+EventService.prototype._emit = function(hyper, req) {
+    var self = this;
+    if (self.options && self.options.eventlogging_service) {
+        return P.try(function() {
+            var events = req.body.map(function(event) {
+                if (!event.meta || !event.meta.uri || !/^\/\//.test(event.meta.uri)) {
+                    hyper.log('error/events/emit', {
+                        message: 'Invalid event URI',
+                        event: event
+                    });
+                    return undefined;
+                }
+                event.meta.uri = 'http:' + event.meta.uri;
+                event.meta.topic = self.options.eventlogging_service.topic;
+                event.meta.request_id = hyper.reqId;
+                event.meta.id = uuid.now().toString();
+                event.meta.dt = new Date().toISOString();
+                event.meta.domain = req.params.domain;
+                return event;
+            })
+            .filter(function(event) { return !!event; });
+            if (events && events.length) {
+                return hyper.post({
+                    uri: self.options.eventlogging_service.uri,
+                    headers: {
+                        'content-type': 'application/json'
+                    },
+                    body: events
+                });
+            }
+        })
+        .catch(function(e) {
+            hyper.log('error/events/emit', e);
+        });
+    }
+};
+
+EventService.prototype.emitEvent = function(hyper, req) {
+    return P.join(
+        this._purge(hyper, req),
+        this._emit(hyper, req)
+    ).thenReturn({ status: 200 });
 };
 
 module.exports = function(options) {

--- a/sys/events.js
+++ b/sys/events.js
@@ -78,6 +78,10 @@ EventService.prototype._emit = function(hyper, req) {
                 event.meta.id = uuid.now().toString();
                 event.meta.dt = new Date().toISOString();
                 event.meta.domain = req.params.domain;
+                event.tags = event.tags || [];
+                if (event.tags.indexOf('restbase') < 0) {
+                    event.tags.push('restbase');
+                }
                 return event;
             })
             .filter(function(event) { return !!event; });

--- a/test/features/events/events.js
+++ b/test/features/events/events.js
@@ -128,7 +128,7 @@ describe('Change event emitting', function() {
                             assert.deepEqual(!!new Date(event.meta.dt), true);
                             assert.deepEqual(uuid.test(event.meta.id), true);
                             assert.deepEqual(!!event.meta.request_id, true);
-                            assert.deepEqual(event.meta.topic, 'wmf.resource_change');
+                            assert.deepEqual(event.meta.topic, 'resource_change');
                             assert.deepEqual(event.meta.uri, 'http://en.wikipedia.org/wiki/User:Pchelolo');
                             assert.deepEqual(event.tags, ['test', 'restbase']);
                             really_done();

--- a/test/features/events/events.js
+++ b/test/features/events/events.js
@@ -128,8 +128,9 @@ describe('Change event emitting', function() {
                             assert.deepEqual(!!new Date(event.meta.dt), true);
                             assert.deepEqual(uuid.test(event.meta.id), true);
                             assert.deepEqual(!!event.meta.request_id, true);
-                            assert.deepEqual(event.meta.topic, 'resource_change');
+                            assert.deepEqual(event.meta.topic, 'wmf.resource_change');
                             assert.deepEqual(event.meta.uri, 'http://en.wikipedia.org/wiki/User:Pchelolo');
+                            assert.deepEqual(event.tags, ['test', 'restbase']);
                             really_done();
                         } catch (e) {
                             really_done(e);
@@ -154,7 +155,8 @@ describe('Change event emitting', function() {
                 {
                     meta: {
                         uri: '//en.wikipedia.org/wiki/User:Pchelolo'
-                    }
+                    },
+                    tags: ['test']
                 },
                 {meta: {}},
                 {should_not_be: 'here'}

--- a/test/test_module.yaml
+++ b/test/test_module.yaml
@@ -122,13 +122,17 @@ paths:
               x-modules:
                 - path: sys/key_value.js
 
-            /events:
+            /events_purge:
               x-modules:
                 - path: sys/events.js
-                  options: '{{options.events}}'
+                  options: '{{options.events_purge}}'
             /events_no_config:
               x-modules:
                 - path: sys/events.js
+            /events_emit:
+              x-modules:
+                - path: sys/events.js
+                  options: '{{options.events_emit}}'
 
             /http/{uri}:
               get:


### PR DESCRIPTION
Without a config change it's a no-op, but in order to start going to the change propagation direction we need to start emitting the `resource_change` event from restbase, so that we could monitor what's going on with it, check how EventBus and EventLogging service respond to it and so on, so that when change propagation is there we can be confident that emitting part works well.

Considerations:
1. Before making a config change in prod verify that topics are set up in event logging. (cc @ottomata)
2. EventLogging service is already supported in vagrant, so a config change in vagrant is also needed.
3. In't not clear yet what to do with third party installs as we don't have a lightweight kafka replacement yet.

Bug: https://phabricator.wikimedia.org/T126571

cc @wikimedia/services @ottomata 