### PR TITLE
Explicitly depend on jscs to avoid peerDependency warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4",
     "mocha-jscs": "^4.0.0",
+    "jscs": "^2.11.0",
     "mocha-jshint": "^2.2.6",
     "mocha-lcov-reporter": "^1.0.0",
     "nock": "^5.2.1",


### PR DESCRIPTION
There's a warning on each `npm install`, this will avoid the warning.