### PR TITLE
Added a table module to switch storage with config option

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -7,6 +7,7 @@ default_project: &default_project
     - path: projects/wmf_default.yaml
       options: &default_options
         table:
+          backend: cassandra
           hosts: [localhost]
           keyspace: system
           username: cassandra

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,6 +47,7 @@ services:
                     # XXX Check Parsoid URL!
                     host: http://localhost:8142
                   table:
+                    backend: sqlite
                     dbname: db.sqlite3
                     pool_idle_timeout: 20000
                     retry_delay: 250

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -13,6 +13,7 @@ default_project: &default_project
     - path: projects/wmf_default.yaml
       options: &default_options
         table:
+          backend: cassandra
           hosts: [localhost]
           keyspace: system
           username: cassandra

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "mocha-lcov-reporter": "^1.0.0",
     "nock": "^5.2.1",
     "restbase-mod-table-sqlite": "^0.1.14",
-    "swagger-test": "0.3.0",
-    "temp": "^0.8.3"
+    "swagger-test": "0.3.0"
   },
   "deploy": {
     "node": "4.3.0",

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -45,9 +45,7 @@ paths:
           paths:
             /table:
               x-modules:
-                - type: npm
-                  name: restbase-mod-table-sqlite
-                  version: 1.0.0
+                - path: sys/table.js
                   options:
                     conf: '{{options.table}}'
             /key_value:

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -63,8 +63,7 @@ paths:
                   options: '{{options.mathoid}}'
             /table:
               x-modules:
-                - type: npm
-                  name: restbase-mod-table-cassandra
+                - path: sys/table.js
                   options:
                     conf: '{{options.table}}'
             /key_value:

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -62,9 +62,7 @@ paths:
           paths:
             /table: &sys_table
               x-modules:
-                - type: npm
-                  name: restbase-mod-table-cassandra
-                  # See:  https://github.com/wikimedia/restbase-mod-table-cassandra/blob/master/Readme.md#configuration
+                - path: sys/table.js
                   options:
                     conf: '{{options.table}}'
             /key_value: &sys_key_value

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -62,8 +62,7 @@ paths:
           paths:
             /table: &sys_table
               x-modules:
-                - type: npm
-                  name: restbase-mod-table-cassandra
+                - path: sys/table.js
                   options:
                     conf: '{{options.table}}'
             /key_value: &sys_key_value

--- a/sys/table.js
+++ b/sys/table.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/*
+ * A simple wrapper module over storage modules which allows to switch between storage
+ * implementation using a config option.
+ */
 
 module.exports = function(options) {
     options.conf.backend = options.conf.backend || 'cassandra';

--- a/sys/table.js
+++ b/sys/table.js
@@ -1,0 +1,13 @@
+"use strict";
+
+
+module.exports = function(options) {
+    options.conf.backend = options.conf.backend || 'cassandra';
+
+    if (options.conf.backend !== 'cassandra'
+            && options.conf.backend !== 'sqlite') {
+        throw new Error('Unsupported backend version specified: ' + options.backend);
+    }
+
+    return require('restbase-mod-table-' + options.conf.backend)(options);
+};

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -9,7 +9,6 @@ var logStream = require('./logStream');
 var fs        = require('fs');
 var assert    = require('./assert');
 var yaml      = require('js-yaml');
-var temp      = require('temp').track();
 
 var hostPort  = 'http://localhost:7231';
 var baseURL   = hostPort + '/en.wikipedia.org/v1';
@@ -28,14 +27,7 @@ function loadConfig(path) {
             throw new Error('Invalid RB_TEST_BACKEND env variable value. Allowed values: "cassandra", "sqlite"');
         }
         if (backendImpl === 'sqlite') {
-            // First, replace the module in all projects and move them to the temp directory
-            var tempDir = temp.mkdirSync('tempProjects');
-            fs.readdirSync(__dirname + '/../../projects').forEach(function(fileName) {
-                var fileStr = fs.readFileSync(__dirname + '/../../projects/' + fileName).toString()
-                        .replace(/restbase\-mod\-table\-cassandra/g, 'restbase-mod-table-sqlite');
-                fs.writeFileSync(tempDir + '/' + fileName, fileStr);
-            });
-            confString = confString.replace(/projects\//g, tempDir + '/');
+            confString = confString.replace(/backend: cassandra/, "backend: sqlite");
         }
     }
     return yaml.safeLoad(confString);


### PR DESCRIPTION
Introduced a simple wrapper for storage modules that allows to select backend implementation with a config option. After this is landed, and vagrant is updated, we can remove the `wmf_sqlite.yaml` and `wikimedia.org.sqlite.yaml` files. Also, we don't need to do the magic with temp files when running tests in sqlite mode.

cc @wikimedia/services 