### PR TITLE
Enable redirects for non-normalized titles

### DIFF
--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -60,12 +60,12 @@ module.exports = function(hyper, req, next, options, specInfo) {
         .then(function(result) {
             var resultText = result.getPrefixedDBKey();
             if (resultText !== rp.title) {
+                rp.title = resultText;
                 if (req.method === 'post' // Don't redirect POSTs as it's not cached anyway
-                || result.getNamespace().isUser()
-                || result.getNamespace().isUserTalk()) {
+                        || result.getNamespace().isUser()
+                        || result.getNamespace().isUserTalk()) {
                     // Due to gender variations of User and User_Talk namespaces in some langs
                     // use canonical name for storage, but don't redirect. Don't cache either
-                    rp.title = resultText;
                     return next(hyper, req)
                     .then(function(res) {
                         if (res) {
@@ -75,13 +75,12 @@ module.exports = function(hyper, req, next, options, specInfo) {
                         return res;
                     });
                 } else {
-                    rp.title = resultText;
                     var pathBeforeTitle = specInfo.path
                         .substring(0, specInfo.path.indexOf('{title}'));
                     pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
-                    var pathAfterTitle = req.uri.toString().replace(pathBeforeTitle, '');
-                    var backCount = (pathAfterTitle.match(/\//g) || []).length;
-                    var backString = Array.apply(null, { length: backCount }).map(function() {
+                    var pathSuffix = req.uri.toString().replace(pathBeforeTitle, '');
+                    var pathSuffixCount = (pathSuffix.match(/\//g) || []).length;
+                    var backString = Array.apply(null, { length: pathSuffixCount }).map(function() {
                         return '../';
                     }).join('');
                     var pathPatternAfterTitle = specInfo.path

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -3,6 +3,7 @@
 var HyperSwitch = require('hyperswitch');
 var mwUtil = require('./mwUtil');
 var HTTPError = HyperSwitch.HTTPError;
+var URI = HyperSwitch.URI;
 var Title = require('mediawiki-title').Title;
 var P = require('bluebird');
 
@@ -60,8 +61,8 @@ module.exports = function(hyper, req, next, options, specInfo) {
             var resultText = result.getPrefixedDBKey();
             if (resultText !== rp.title) {
                 if (req.method === 'post' // Don't redirect POSTs as it's not cached anyway
-                    || result.getNamespace().isUser()
-                    || result.getNamespace().isUserTalk()) {
+                || result.getNamespace().isUser()
+                || result.getNamespace().isUserTalk()) {
                     // Due to gender variations of User and User_Talk namespaces in some langs
                     // use canonical name for storage, but don't redirect. Don't cache either
                     rp.title = resultText;
@@ -74,58 +75,30 @@ module.exports = function(hyper, req, next, options, specInfo) {
                         return res;
                     });
                 } else {
-                    /* TODO: we don't want to enable redirects yet, so log the redirect instead
-                     and disable caching of the response
-
-                     rp.title = result;
-                     var pathBeforeTitle = specInfo.path
-                     .substring(0, specInfo.path.indexOf('{title}'));
-                     pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
-                     var pathAfterTitle = req.uri.toString().replace(pathBeforeTitle, '');
-                     var backCount = (pathAfterTitle.match(/\//g) || []).length;
-                     var backString = Array.apply(null, { length: backCount }).map(function() {
-                     return '../';
-                     }).join('');
-                     var pathPatternAfterTitle = specInfo.path
-                     .substring(specInfo.path.indexOf('{title}') - 1);
-                     var contentLocation = backString
-                     + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
-                     return P.resolve({
-                     status: 301,
-                     headers: {
-                     location: contentLocation
-                     }
-                     });*/
-                    if (rp.title.replace(/ /g, '_') !== resultText) {
-                        // Log all of these, should be relatively rare.
-                        hyper.log('warn/normalize/non_space', {
-                            msg: 'Normalized non-space chars',
-                            from: rp.title,
-                            to: resultText,
-                        });
-                    } else if (Math.random() < 0.05) {
-                        // 5% chance of logging to bound volume.
-                        hyper.log('warn/normalize/space', {
-                            msg: 'Normalized requested title',
-                            from: rp.title,
-                            to: resultText,
-                        });
-                    }
-                    nextRequest = next(hyper, req)
-                    .then(function(res) {
-                        if (res) {
-                            res.headers = res.headers || {};
-                            res.headers['cache-control'] = 'no-cache';
+                    rp.title = resultText;
+                    var pathBeforeTitle = specInfo.path
+                        .substring(0, specInfo.path.indexOf('{title}'));
+                    pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
+                    var pathAfterTitle = req.uri.toString().replace(pathBeforeTitle, '');
+                    var backCount = (pathAfterTitle.match(/\//g) || []).length;
+                    var backString = Array.apply(null, { length: backCount }).map(function() {
+                        return '../';
+                    }).join('');
+                    var pathPatternAfterTitle = specInfo.path
+                        .substring(specInfo.path.indexOf('{title}') - 1);
+                    var contentLocation = backString
+                        + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
+                    return P.resolve({
+                        status: 301,
+                        headers: {
+                            location: contentLocation,
+                            'cache-control': options.redirect_cache_control
                         }
-                        return res;
                     });
                 }
-            } else {
-                nextRequest = next(hyper, req);
             }
-
             if (result.getNamespace().isFile() && siteInfo.sharedRepoRootURI) {
-                nextRequest = nextRequest.catch({ status: 404 }, function() {
+                return next(hyper, req).catch({ status: 404 }, function() {
                     // It's a file page and it might be in the shared repo.
                     // Redirect.
                     var redirectPath = req.uri + '';
@@ -140,7 +113,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
                     };
                 });
             }
-            return nextRequest;
+            return next(hyper, req);
         });
     });
 };

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -387,6 +387,16 @@ describe('page content access', function() {
             assert.deepEqual(e.body.detail, 'title-invalid-characters');
         });
     });
+
+    it('Should redirect to a normalized version of a title', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/html/Main Page'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-location'], server.config.bucketURL + '/html/Main_Page');
+        });
+    });
 });
 
 describe('page content hierarchy', function() {


### PR DESCRIPTION
It's time to start redirecting non-normalised titles. 

I've monitored the logs, and we're quite good - most of the clients send requests in proper format.
The only leftovers is some client from google cloud, but there's no way of finding out who is that. Also, a german search engine fireball.de requests summaries for some strange titles sometimes. We might consider contacting them, but it's also not a major client.

cc @wikimedia/services 