### PR TITLE
Removed non-needed require

### DIFF
--- a/sys/key_rev_latest_value.js
+++ b/sys/key_rev_latest_value.js
@@ -3,7 +3,6 @@
 var zlib = require('zlib');
 var P = require('bluebird');
 var uuid = require('cassandra-uuid').TimeUuid;
-var preq = require('preq');
 
 var HyperSwitch = require('hyperswitch');
 var URI = HyperSwitch.URI;


### PR DESCRIPTION
A leftover `preq` require from development is unused, but in production preq is not installed as a dependency, so restbase startup fails. 

cc @wikimedia/services 