### PR TITLE
Strip out the domain when calculating redirect location

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -88,8 +88,10 @@ spec_root: &spec_root
             forward_headers: true
           - pattern: /^https?:\/\//
   paths:
-    /{domain:en.wikipedia.org}: *default_project
     /{domain:test.wikipedia.org}: *default_project
+    # The order is important for tests.
+    # For example redirect tests require en.wiki being not the first wiki in the list.
+    /{domain:en.wikipedia.org}: *default_project
     /{domain:test2.wikipedia.org}: *default_project
     /{domain:commons.wikimedia.org}: *default_project
 

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -79,9 +79,9 @@ module.exports = function(hyper, req, next, options, specInfo) {
                         .substring(0, specInfo.path.indexOf('{title}'));
                     pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
                     // Omit the domain prefix as it could be wrong for node shared between domains
-                    pathBeforeTitle = pathBeforeTitle.replace(/\/[^\/]+\//, '');
+                    pathBeforeTitle = pathBeforeTitle.replace(/^\/[^\/]+\//, '');
                     var pathSuffix = req.uri.toString()
-                        .replace(/\/[^\/]+\//, '')
+                        .replace(/^\/[^\/]+\//, '')
                         .replace(pathBeforeTitle, '');
                     var pathSuffixCount = (pathSuffix.match(/\//g) || []).length;
                     var backString = Array.apply(null, { length: pathSuffixCount }).map(function() {

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -78,7 +78,11 @@ module.exports = function(hyper, req, next, options, specInfo) {
                     var pathBeforeTitle = specInfo.path
                         .substring(0, specInfo.path.indexOf('{title}'));
                     pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
-                    var pathSuffix = req.uri.toString().replace(pathBeforeTitle, '');
+                    // Omit the domain prefix as it could be wrong for node shared between domains
+                    pathBeforeTitle = pathBeforeTitle.replace(/\/[^\/]+\//, '');
+                    var pathSuffix = req.uri.toString()
+                        .replace(/\/[^\/]+\//, '')
+                        .replace(pathBeforeTitle, '');
                     var pathSuffixCount = (pathSuffix.match(/\//g) || []).length;
                     var backString = Array.apply(null, { length: pathSuffixCount }).map(function() {
                         return '../';


### PR DESCRIPTION
When nodes are shared the domain part in the spec path can be wrong, so strip it out before calculating the redirect location. This is needed to make current deploy repo work.

cc @wikimedia/services 