### PR TITLE
Use 302 redirect for commons pages

### DIFF
--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -108,7 +108,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
                     redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
                     redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1' + redirectPath;
                     return {
-                        status: 301,
+                        status: 302,
                         headers: {
                             location: redirectPath,
                             'cache-control': options.redirect_cache_control || 'no-cache'


### PR DESCRIPTION
301 is not correct here as local description page might be created instead of commons page. 

cc @wikimedia/services 