### PR TITLE
Added a script to dump URIs used for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Dockerfile
 test.db.sqlite3
 sqlite.db
 db.sqlite3
+
+# uri dumps
+uri_dump

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -77,6 +77,11 @@ test:
 spec_root: &spec_root
   title: "The RESTBase root"
   # Some more general RESTBase info
+  x-request-filters:
+    - path: test/utils/uri_dump_filter.js
+      options:
+        dump_test_uris: false
+        filepath: uri_dump
   x-sub-request-filters:
     - type: default
       name: http

--- a/test/utils/link_creator.sh
+++ b/test/utils/link_creator.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+cd ${DIR}/../../
 
 rm -f uri_dump;
 
 # Enable logging in config
-sed -i.bak 's/dump_test_uris:\ false/dump_test_uris:\ true/' config.test.yaml
+sed 's/dump_test_uris:\ false/dump_test_uris:\ true/' config.test.yaml > temp.config.test.yaml
+export RB_TEST_CONFIG=${DIR}/../../temp.config.test.yaml
 
 # Run tests
 sh $DIR/run_tests.sh test sqlite
@@ -28,5 +30,4 @@ sed -i.bak 's/^\/\([[:alnum:]\.]*\)\/v1/https:\/\/\1\/api\/rest_v1/' uri_dump
 # Report and clean up.
 echo "Collected uris: `cat uri_dump | wc -l`"
 echo "The list of URIs could be found in 'uri_dump' file"
-sed -i.bak 's/dump_test_uris:\ true/dump_test_uris:\ false/' config.test.yaml
-rm -f config.test.yaml.bak uri_dump.bak
+rm -f temp.config.test.yaml uri_dump.bak

--- a/test/utils/link_creator.sh
+++ b/test/utils/link_creator.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+rm -f uri_dump;
+
+# Enable logging in config
+sed -i.bak 's/dump_test_uris:\ false/dump_test_uris:\ true/' config.test.yaml
+
+# Run tests
+sh $DIR/run_tests.sh test sqlite
+
+# Remove duplicates
+sort -u -o uri_dump.tmp uri_dump; mv uri_dump.tmp uri_dump
+
+# Delete URIs exposed only for tests
+sed -i.bak '/\/buckets\//d' uri_dump
+sed -i.bak '/foobar\.com/d' uri_dump
+sed -i.bak '/^\/$/d' uri_dump
+sed -i.bak '/fr\.wikipedia\.org/d' uri_dump
+sed -i.bak '/test\.wikipedia\.org/d' uri_dump
+sed -i.bak '/test2\.wikipedia\.org/d' uri_dump
+sed -i.bak '/User:Pchelolo\/Access_Check_Tests/d' uri_dump
+
+# Rewrite to the /api/rest_v1/ form
+sed -i.bak 's/^\/\([[:alnum:]\.]*\)\/v1/https:\/\/\1\/api\/rest_v1/' uri_dump
+
+# Report and clean up.
+echo "Collected uris: `cat uri_dump | wc -l`"
+echo "The list of URIs could be found in 'uri_dump' file"
+sed -i.bak 's/dump_test_uris:\ true/dump_test_uris:\ false/' config.test.yaml
+rm -f config.test.yaml.bak uri_dump.bak

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -49,7 +49,7 @@ var config = {
     labsBucketURL: labsBucketURL,
     labsApiURL: 'http://en.wikipedia.beta.wmflabs.org/w/api.php',
     logStream: logStream(),
-    conf: loadConfig(__dirname + '/../../config.test.yaml')
+    conf: loadConfig(process.env.RB_TEST_CONFIG ? process.env.RB_TEST_CONFIG : __dirname + '/../../config.test.yaml')
 };
 
 config.conf.num_workers = 0;

--- a/test/utils/uri_dump_filter.js
+++ b/test/utils/uri_dump_filter.js
@@ -1,0 +1,16 @@
+"use strict";
+
+var fs = require('fs');
+
+module.exports = function(hyper, req, next, options) {
+    if (options.dump_test_uris && req.method === 'get') {
+        var uri = req.uri.toString();
+        if (req.query && Object.keys(req.query).length) {
+            uri += '?' + Object.keys(req.query).map(function(queryParam) {
+                return queryParam + '=' + encodeURIComponent(req.query[queryParam]);
+            }).join('&');
+        }
+        fs.appendFileSync(options.filepath, uri + '\n');
+    }
+    return next(hyper, req);
+};


### PR DESCRIPTION
Created a script that would scrub meaningful URIs we use for testing. The script scrubs only GET uris, and excludes uris examining endpoints which we make accessible only for testing. Also, those depending on nock are excluded. 

We don't include POST endpoints, as it's better to just look at the spec for them. 

The RB code total coverage achieved by requesting each of the produced URIs is about 55%. The problem is that many of the code paths are executed only if the content is not in the storage, which wouldn't be true for the fuzzer.

Bug: https://phabricator.wikimedia.org/T129926

cc @wikimedia/services