### PR TITLE
Temporarily limit commons page redirects to app clients

### DIFF
--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -8,10 +8,9 @@ var Title = require('mediawiki-title').Title;
 var P = require('bluebird');
 
 function normalizeTitle(title, siteInfo) {
-    return P.try(function() {
+    try {
         return Title.newFromText(title, siteInfo);
-    })
-    .catch(function(e) {
+    } catch (e) {
         throw new HTTPError({
             status: 400,
             body: {
@@ -19,7 +18,7 @@ function normalizeTitle(title, siteInfo) {
                 detail: e.message
             }
         });
-    });
+    }
 }
 
 module.exports = function(hyper, req, next, options, specInfo) {
@@ -56,67 +55,71 @@ module.exports = function(hyper, req, next, options, specInfo) {
 
     return mwUtil.getSiteInfo(hyper, req)
     .then(function(siteInfo) {
-        return normalizeTitle(rp.title, siteInfo)
-        .then(function(result) {
-            var resultText = result.getPrefixedDBKey();
-            if (resultText !== rp.title) {
-                rp.title = resultText;
-                if (req.method === 'post' // Don't redirect POSTs as it's not cached anyway
-                        || result.getNamespace().isUser()
-                        || result.getNamespace().isUserTalk()) {
-                    // Due to gender variations of User and User_Talk namespaces in some langs
-                    // use canonical name for storage, but don't redirect. Don't cache either
-                    return next(hyper, req)
-                    .then(function(res) {
-                        if (res) {
-                            res.headers = res.headers || {};
-                            res.headers['cache-control'] = 'no-cache';
-                        }
-                        return res;
-                    });
-                } else {
-                    var pathBeforeTitle = specInfo.path
-                        .substring(0, specInfo.path.indexOf('{title}'));
-                    pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
-                    // Omit the domain prefix as it could be wrong for node shared between domains
-                    pathBeforeTitle = pathBeforeTitle.replace(/^\/[^\/]+\//, '');
-                    var pathSuffix = req.uri.toString()
-                        .replace(/^\/[^\/]+\//, '')
-                        .replace(pathBeforeTitle, '');
-                    var pathSuffixCount = (pathSuffix.match(/\//g) || []).length;
-                    var backString = Array.apply(null, { length: pathSuffixCount }).map(function() {
-                        return '../';
-                    }).join('');
-                    var pathPatternAfterTitle = specInfo.path
-                        .substring(specInfo.path.indexOf('{title}') - 1);
-                    var contentLocation = backString
-                        + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
-                    return P.resolve({
-                        status: 301,
-                        headers: {
-                            location: contentLocation,
-                            'cache-control': options.redirect_cache_control || 'no-cache'
-                        }
-                    });
-                }
-            }
-            if (result.getNamespace().isFile() && siteInfo.sharedRepoRootURI) {
-                return next(hyper, req).catch({ status: 404 }, function() {
-                    // It's a file page and it might be in the shared repo.
-                    // Redirect.
-                    var redirectPath = req.uri + '';
-                    redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
-                    redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1' + redirectPath;
-                    return {
-                        status: 302,
-                        headers: {
-                            location: redirectPath,
-                            'cache-control': options.redirect_cache_control || 'no-cache'
-                        }
-                    };
+        var normalizeResult = normalizeTitle(rp.title, siteInfo);
+        var resultText = normalizeResult.getPrefixedDBKey();
+        if (resultText !== rp.title) {
+            rp.title = resultText;
+            if (req.method === 'post' // Don't redirect POSTs as it's not cached anyway
+                    || normalizeResult.getNamespace().isUser()
+                    || normalizeResult.getNamespace().isUserTalk()) {
+                // Due to gender variations of User and User_Talk namespaces in some langs
+                // use canonical name for storage, but don't redirect. Don't cache either
+                return next(hyper, req)
+                .then(function(res) {
+                    if (res) {
+                        res.headers = res.headers || {};
+                        res.headers['cache-control'] = 'no-cache';
+                    }
+                    return res;
+                });
+            } else {
+                var pathBeforeTitle = specInfo.path
+                    .substring(0, specInfo.path.indexOf('{title}'));
+                pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
+                // Omit the domain prefix as it could be wrong for node shared between domains
+                pathBeforeTitle = pathBeforeTitle.replace(/^\/[^\/]+\//, '');
+                var pathSuffix = req.uri.toString()
+                    .replace(/^\/[^\/]+\//, '')
+                    .replace(pathBeforeTitle, '');
+                var pathSuffixCount = (pathSuffix.match(/\//g) || []).length;
+                var backString = Array.apply(null, { length: pathSuffixCount }).map(function() {
+                    return '../';
+                }).join('');
+                var pathPatternAfterTitle = specInfo.path
+                    .substring(specInfo.path.indexOf('{title}') - 1);
+                var contentLocation = backString
+                    + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
+                return P.resolve({
+                    status: 301,
+                    headers: {
+                        location: contentLocation,
+                        'cache-control': options.redirect_cache_control || 'no-cache'
+                    }
                 });
             }
-            return next(hyper, req);
-        });
+        }
+        if (normalizeResult.getNamespace().isFile()
+                && siteInfo.sharedRepoRootURI
+                // Temporarily limit file descripiton redirects to the app,
+                // until https://phabricator.wikimedia.org/T130757 (VE
+                // redirect support) is resolved.
+                // TODO: Remove.
+                && /^WikipediaApp\//.test(req.headers['user-agent'])) {
+            return next(hyper, req).catch({ status: 404 }, function() {
+                // It's a file page and it might be in the shared repo.
+                // Redirect.
+                var redirectPath = req.uri + '';
+                redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
+                redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1' + redirectPath;
+                return {
+                    status: 302,
+                    headers: {
+                        location: redirectPath,
+                        'cache-control': options.redirect_cache_control || 'no-cache'
+                    }
+                };
+            });
+        }
+        return next(hyper, req);
     });
 };

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -310,7 +310,10 @@ describe('item requests', function() {
 
     it('should redirect to commons for missing file pages', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg'
+            uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg',
+            headers: {
+                'user-agent': 'WikipediaApp/2.1.141-beta-2016-02-10 (Android 5.0.2; Phone) Google Play Beta Channel'
+            }
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);


### PR DESCRIPTION
Until https://phabricator.wikimedia.org/T130757 is resolved, VisualEditor
cannot handle redirect responses for file description pages hosted on Commons.
To let us move forward with those redirects for the app, this patch
temporarily restricts commons redirects to app clients, identified by user
agent string.

Additionally, the normalizeTitle function is made synchronous, avoiding the
creation of another Promise instance.