### PR TITLE
Update Parsoid content-type to 1.2.1

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -67,8 +67,8 @@ wiktionary_project: &wiktionary_project
 # Hacky way to parametrize RESTBase tests. TODO: Move to config?
 test:
   content_types:
-    html: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.2.0"
-    data-parsoid: application/json; charset=utf-8; profile="mediawiki.org/specs/data-parsoid/0.0.2"
+    html: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.2.1"
+    data-parsoid: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/0.0.2"
     wikitext: text/plain; charset=utf-8; profile="mediawiki.org/specs/wikitext/1.0.0"
 
 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -69,7 +69,7 @@ test:
   content_types:
     html: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.2.1"
     data-parsoid: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/0.0.2"
-    wikitext: text/plain; charset=utf-8; profile="mediawiki.org/specs/wikitext/1.0.0"
+    wikitext: text/plain; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/wikitext/1.0.0"
 
 
 # The root of the spec tree. Domains tend to share specs by referencing them

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -368,7 +368,7 @@ describe('storage-backed transform api', function() {
             headers: { 'content-type': 'application/json' },
             body: {
                 headers: {
-                  'content-type': 'text/html;profile="mediawiki.org/specs/html/1.0.0"'
+                  'content-type': 'text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.2.1"'
                 },
                 body: '<html>The modified HTML</html>'
             }
@@ -378,7 +378,7 @@ describe('storage-backed transform api', function() {
             assert.deepEqual(res.body, {
                 wikitext: {
                     headers: {
-                        'content-type': 'text/plain;profile="mediawiki.org/specs/wikitext/1.0.0"'
+                        'content-type': 'text/plain; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/wikitext/1.0.0"'
                     },
                     body: 'The modified HTML'
                 }

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -96,7 +96,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.2.0"
+              content-type: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.2.1"
 
   /{domain}/v1/page/html/{title}/{revision}:
     get:
@@ -147,7 +147,7 @@ paths:
           response:
             status: 200
             headers:
-                content-type: text/html; charset=utf-8; profile="mediawiki.org/specs/html/1.2.0"
+              content-type: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.2.1"
 
 definitions:
   defaultError:

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -196,7 +196,7 @@ paths:
           description: Comma-separated list of section IDs.
           type: string
       produces:
-        - text/html; profile="mediawiki.org/specs/html/1.1.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.2.1"
       responses:
         '200':
           description: |
@@ -423,7 +423,7 @@ paths:
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       operationId: getFormatRevision
       produces:
-        - text/html; profile="mediawiki.org/specs/html/1.1.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.2.1"
       parameters:
         - name: title
           in: path

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -25,7 +25,7 @@ paths:
       consumes:
         - multipart/form-data
       produces:
-        - text/plain; profile="mediawiki.org/specs/wikitext/1.0.0"
+        - text/plain; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/wikitext/1.0.0"
       parameters:
         - name: title
           in: path
@@ -104,7 +104,7 @@ paths:
       consumes:
         - multipart/form-data
       produces:
-        - text/html; profile="mediawiki.org/specs/html/1.1.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/html/1.2.1"
       parameters:
         - name: title
           in: path
@@ -194,7 +194,7 @@ paths:
 #      consumes:
 #        - multipart/form-data
 #      produces:
-#        - text/html; profile="mediawiki.org/specs/html/1.1.0"
+#        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.2.1"
 #      parameters:
 #        - name: title
 #          in: path
@@ -267,7 +267,7 @@ paths:
         - application/json
         - multipart/form-data
       produces:
-        - text/html; profile="mediawiki.org/specs/html/1.1.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.2.1"
       parameters:
         - name: title
           in: path


### PR DESCRIPTION
Also:

- Include charset parameter, as in the response.
- Link to the mediawiki.org documentation page.