### PR TITLE
Only wrapContentReq after saving the Parsoid result

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -372,10 +372,10 @@ PSP.generateAndSave = function(hyper, req, format, currentContentRes) {
                 body: res.body[format].body
             };
             resp.headers.etag = mwUtil.makeETag(rp.revision, tid);
-            var responsePromise = self.wrapContentReq(hyper, req,
-                    P.resolve(resp), format, tid);
             return self.saveParsoidResult(hyper, req, format, tid, res)
             .then(function() {
+                var responsePromise = self.wrapContentReq(hyper, req,
+                        P.resolve(resp), format, tid);
                 var dependencyUpdate = self._dependenciesUpdate(hyper, req);
                 if (req.headers && /no-cache/i.test(req.headers['cache-control'])) {
                     // Finish background updates before returning


### PR DESCRIPTION
One no-cache test with sections showed a failure after merging content-type
fixes. This patch fixes those failures.