### PR TITLE
Migrate to new mediawiki-title API

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -192,8 +192,11 @@ mwUtil.getSiteInfo = function(hyper, req) {
         })
         .then(function(res) {
             return {
-                lang: res.body.query.general.lang,
-                legaltitlechars: res.body.query.general.legaltitlechars,
+                general: {
+                    lang: res.body.query.general.lang,
+                    legaltitlechars: res.body.query.general.legaltitlechars,
+                    case: res.body.query.general.case
+                },
                 namespaces: res.body.query.namespaces,
                 namespacealiases: res.body.query.namespacealiases,
                 sharedRepoRootURI: findSharedRepoDomain(res)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "content-type": "git+https://github.com/wikimedia/content-type#master",
     "hyperswitch": "^0.4.0",
     "jsonwebtoken": "^5.5.4",
-    "mediawiki-title": "^0.3.3"
+    "mediawiki-title": "^0.4.0"
   },
   "devDependencies": {
     "js-yaml": "^3.5.2",


### PR DESCRIPTION
After discussion with @subbuss we've decided to update `mediawiki-title` API so that it takes siteInfo in the same format as returned by the PHP API. This PR migrates RESTBase to this new format, and also fixes a bug when we didn't provide one on the parameters to the normaliser.

cc @wikimedia/services @subbuss 