### PR TITLE
Add query string to redirects

### DIFF
--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -6,6 +6,7 @@ var HTTPError = HyperSwitch.HTTPError;
 var URI = HyperSwitch.URI;
 var Title = require('mediawiki-title').Title;
 var P = require('bluebird');
+var querystring = require('querystring');
 
 function normalizeTitle(title, siteInfo) {
     try {
@@ -23,10 +24,7 @@ function normalizeTitle(title, siteInfo) {
 
 function getQueryString(req) {
     if (Object.keys(req.query).length) {
-        return '?' + Object.keys(req.query).map(function(queryParamName) {
-            return queryParamName + '=' + encodeURIComponent(req.query[queryParamName]);
-        })
-        .join('&');
+        return '?' + querystring.stringify(req.query);
     }
     return '';
 }

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -21,6 +21,16 @@ function normalizeTitle(title, siteInfo) {
     }
 }
 
+function getQueryString(req) {
+    if (Object.keys(req.query).length) {
+        return '?' + Object.keys(req.query).map(function(queryParamName) {
+            return queryParamName + '=' + encodeURIComponent(req.query[queryParamName]);
+        })
+        .join('&');
+    }
+    return '';
+}
+
 module.exports = function(hyper, req, next, options, specInfo) {
     var rp = req.params;
     /**
@@ -47,8 +57,6 @@ module.exports = function(hyper, req, next, options, specInfo) {
             });
         };
     }
-
-    var nextRequest;
     if (!rp.title) {
         return next(hyper, req);
     }
@@ -88,7 +96,9 @@ module.exports = function(hyper, req, next, options, specInfo) {
                 var pathPatternAfterTitle = specInfo.path
                     .substring(specInfo.path.indexOf('{title}') - 1);
                 var contentLocation = backString
-                    + new URI(pathPatternAfterTitle, rp, true).toString().substr(1);
+                    + new URI(pathPatternAfterTitle, rp, true).toString().substr(1)
+                    + getQueryString(req);
+
                 return P.resolve({
                     status: 301,
                     headers: {
@@ -110,7 +120,8 @@ module.exports = function(hyper, req, next, options, specInfo) {
                 // Redirect.
                 var redirectPath = req.uri + '';
                 redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
-                redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1' + redirectPath;
+                redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1'
+                    + redirectPath + getQueryString(req);
                 return {
                     status: 302,
                     headers: {

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -393,11 +393,12 @@ describe('page content access', function() {
 
     it('Should redirect to a normalized version of a title', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/Main Page'
+            uri: server.config.bucketURL + '/html/Main%20Page?test=mwAQ'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['content-location'], server.config.bucketURL + '/html/Main_Page');
+            assert.deepEqual(res.headers['content-location'], server.config.bucketURL
+                + '/html/Main_Page?test=mwAQ');
         });
     });
 });


### PR DESCRIPTION
We need to preserve the query string on redirects to avoid losing `sections` part.

cc @wikimedia/services 