### PR TITLE
Drop custom title normalizations and rely on the filter

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -12,15 +12,6 @@ var URI = HyperSwitch.URI;
 var mwUtil = {};
 
 /**
- * Store titles as MediaWiki db keys
- * @param {string} title a title to normalize
- * @returns {string} normalized title
- */
-mwUtil.normalizeTitle = function(title) {
-    return title.replace(/ /g, '_');
-};
-
-/**
  * Create an etag value of the form
  * "<revision>/<tid>/<optional_suffix>"
  * @param {Integer} rev page revision number

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -5,6 +5,7 @@ var contentType = require('content-type');
 var jwt = require('jsonwebtoken');
 var P = require('bluebird');
 var gunzip = P.promisify(require('zlib').gunzip);
+var Title = require('mediawiki-title').Title;
 var HyperSwitch = require('hyperswitch');
 var HTTPError = HyperSwitch.HTTPError;
 var URI = HyperSwitch.URI;
@@ -26,6 +27,26 @@ mwUtil.makeETag = function(rev, tid, suffix) {
     }
     return etag + '"';
 };
+
+/**
+ * Normalizes the request.params.title and returns it back
+ */
+mwUtil.normalizeTitle = function(hyper, req, title) {
+    return mwUtil.getSiteInfo(hyper, req)
+    .then(function(siteInfo) {
+        return Title.newFromText(title, siteInfo);
+    })
+    .catch(function(e) {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'bad_request',
+                detail: e.message
+            }
+        });
+    });
+};
+
 
 /**
  * Parse an etag value of the form

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -112,8 +112,9 @@ module.exports = function(hyper, req, next, options, specInfo) {
                                 'cache-control': options.redirect_cache_control || 'no-cache'
                             }
                         };
+                    } else {
+                        throw e;
                     }
-                    throw e;
                 });
             });
         }

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -2,25 +2,9 @@
 
 var HyperSwitch = require('hyperswitch');
 var mwUtil = require('./mwUtil');
-var HTTPError = HyperSwitch.HTTPError;
 var URI = HyperSwitch.URI;
-var Title = require('mediawiki-title').Title;
 var P = require('bluebird');
 var querystring = require('querystring');
-
-function normalizeTitle(title, siteInfo) {
-    try {
-        return Title.newFromText(title, siteInfo);
-    } catch (e) {
-        throw new HTTPError({
-            status: 400,
-            body: {
-                type: 'bad_request',
-                detail: e.message
-            }
-        });
-    }
-}
 
 function getQueryString(req) {
     if (Object.keys(req.query).length) {
@@ -59,9 +43,8 @@ module.exports = function(hyper, req, next, options, specInfo) {
         return next(hyper, req);
     }
 
-    return mwUtil.getSiteInfo(hyper, req)
-    .then(function(siteInfo) {
-        var normalizeResult = normalizeTitle(rp.title, siteInfo);
+    return mwUtil.normalizeTitle(hyper, req, rp.title)
+    .then(function(normalizeResult) {
         var resultText = normalizeResult.getPrefixedDBKey();
         if (resultText !== rp.title) {
             rp.title = resultText;
@@ -107,26 +90,31 @@ module.exports = function(hyper, req, next, options, specInfo) {
             }
         }
         if (normalizeResult.getNamespace().isFile()
-                && siteInfo.sharedRepoRootURI
                 // Temporarily limit file descripiton redirects to the app,
                 // until https://phabricator.wikimedia.org/T130757 (VE
                 // redirect support) is resolved.
                 // TODO: Remove.
                 && /^WikipediaApp\//.test(req.headers['user-agent'])) {
-            return next(hyper, req).catch({ status: 404 }, function() {
-                // It's a file page and it might be in the shared repo.
-                // Redirect.
-                var redirectPath = req.uri + '';
-                redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
-                redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1'
-                    + redirectPath + getQueryString(req);
-                return {
-                    status: 302,
-                    headers: {
-                        location: redirectPath,
-                        'cache-control': options.redirect_cache_control || 'no-cache'
+            return next(hyper, req).catch({ status: 404 }, function(e) {
+                return mwUtil.getSiteInfo(hyper, req)
+                .then(function(siteInfo) {
+                    if (siteInfo.sharedRepoRootURI) {
+                        // It's a file page and it might be in the shared repo.
+                        // Redirect.
+                        var redirectPath = req.uri + '';
+                        redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
+                        redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1'
+                        + redirectPath + getQueryString(req);
+                        return {
+                            status: 302,
+                            headers: {
+                                location: redirectPath,
+                                'cache-control': options.redirect_cache_control || 'no-cache'
+                            }
+                        };
                     }
-                };
+                    throw e;
+                });
             });
         }
         return next(hyper, req);

--- a/sys/action.js
+++ b/sys/action.js
@@ -155,7 +155,6 @@ function buildQueryResponse(apiReq, res) {
             return pages[key];
         });
 
-        console.log(newBody);
         // XXX: Clean this up!
         res.body = {
             items: newBody,

--- a/sys/action.js
+++ b/sys/action.js
@@ -154,6 +154,8 @@ function buildQueryResponse(apiReq, res) {
         var newBody = Object.keys(pages).map(function(key) {
             return pages[key];
         });
+
+        console.log(newBody);
         // XXX: Clean this up!
         res.body = {
             items: newBody,

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -247,13 +247,15 @@ PRS.prototype.fetchAndStoreMWRevision = function(hyper, req) {
             return /hidden$/.test(key);
         });
 
+        // MW API returns title in text format with spaces,
+        // while we store them in DBKey format with underscore
+        dataResp.title = dataResp.title.replace(/ /g, '_');
         // Get the redirect property, it's inclusion means true
+        // FIXME: Figure out redirect strategy: https://phabricator.wikimedia.org/T87393
         var redirect = dataResp.redirect !== undefined;
+
         var revision = {
-            // FIXME: if a title has been given, check it
-            // matches the one returned by the MW API
-            // cf. https://phabricator.wikimedia.org/T87393
-            title: mwUtil.normalizeTitle(dataResp.title),
+            title: dataResp.title,
             page_id: parseInt(dataResp.pageid),
             rev: parseInt(apiRev.revid),
             tid: uuid.now().toString(),
@@ -273,7 +275,7 @@ PRS.prototype.fetchAndStoreMWRevision = function(hyper, req) {
             body: {
                 table: self.tableName,
                 attributes: {
-                    title: mwUtil.normalizeTitle(dataResp.title),
+                    title: dataResp.title,
                     rev: parseInt(apiRev.revid)
                 }
             }
@@ -316,7 +318,7 @@ PRS.prototype.getTitleRevision = function(hyper, req) {
             body: {
                 table: self.tableName,
                 attributes: {
-                    title: mwUtil.normalizeTitle(rp.title)
+                    title: rp.title
                 },
                 limit: 1
             }
@@ -330,7 +332,7 @@ PRS.prototype.getTitleRevision = function(hyper, req) {
             body: {
                 table: this.tableName,
                 attributes: {
-                    title: mwUtil.normalizeTitle(rp.title),
+                    title: rp.title,
                     rev: parseInt(rp.revision)
                 },
                 limit: 1
@@ -391,7 +393,7 @@ PRS.prototype.listTitleRevisions = function(hyper, req) {
     var revisionRequest = {
         table: this.tableName,
         attributes: {
-            title: mwUtil.normalizeTitle(rp.title)
+            title: rp.title
         },
         proj: ['rev'],
         limit: hyper.config.default_page_size

--- a/sys/page_save.js
+++ b/sys/page_save.js
@@ -77,8 +77,7 @@ PageSave.prototype._getBaseRevision = function(req) {
 
 PageSave.prototype._getRevInfo = function(hyper, req, revision) {
     var rp = req.params;
-    var path = [rp.domain, 'sys', 'page_revisions', 'page',
-                    mwUtil.normalizeTitle(rp.title)];
+    var path = [rp.domain, 'sys', 'page_revisions', 'page', rp.title];
     if (!/^(?:[0-9]+)$/.test(revision)) {
         throw new HTTPError({
             status: 400,
@@ -99,7 +98,7 @@ PageSave.prototype._getRevInfo = function(hyper, req, revision) {
         // We are dealing with a restricted revision
         // however, let MW deal with it as the user
         // might have sufficient permissions to do an edit
-        return { title: mwUtil.normalizeTitle(rp.title) };
+        return { title: rp.title };
     });
 };
 
@@ -121,7 +120,6 @@ PageSave.prototype._checkParams = function(params) {
 PageSave.prototype.saveWikitext = function(hyper, req) {
     var self = this;
     var rp = req.params;
-    var title = mwUtil.normalizeTitle(rp.title);
     var promise = P.resolve({});
     this._checkParams(req.body);
     var baseRevision = this._getBaseRevision(req);
@@ -130,7 +128,7 @@ PageSave.prototype.saveWikitext = function(hyper, req) {
     }
     return promise.then(function(revInfo) {
         var body = {
-            title: title,
+            title: rp.title,
             text: req.body.wikitext,
             summary: req.body.comment || req.body.wikitext.substr(0, 100),
             minor: !!req.body.is_minor,
@@ -162,10 +160,9 @@ PageSave.prototype.saveWikitext = function(hyper, req) {
 PageSave.prototype.saveHtml = function(hyper, req) {
     var self = this;
     var rp = req.params;
-    var title = mwUtil.normalizeTitle(rp.title);
     this._checkParams(req.body);
     // First transform the HTML to wikitext via the parsoid module
-    var path = [rp.domain, 'sys', 'parsoid', 'transform', 'html', 'to', 'wikitext', title];
+    var path = [rp.domain, 'sys', 'parsoid', 'transform', 'html', 'to', 'wikitext', rp.title];
     var baseRevision = this._getBaseRevision(req);
     if (baseRevision) {
         path.push(baseRevision);

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -333,11 +333,22 @@ describe('item requests', function() {
             assert.deepEqual(e.status, 404);
         });
     });
+
+    it('should result in 404 if + is normalized by MW API', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2FOnDemand+Test'
+        })
+        .then(function() {
+            throw new Error('Error should be thrown');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+        });
+    });
 });
 
 describe('page content access', function() {
 
-    var deniedTitle = 'User%20talk:DivineAlpha';
+    var deniedTitle = 'User talk:DivineAlpha%2FQ1 2015 discussions';
     var deniedRev = '645504917';
 
     this.timeout(30000);

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -416,7 +416,7 @@ describe('page save api', function() {
                 edit: {
                     result: "Success",
                     pageid: 46950417,
-                    title: "User:Mobrovac-WMF/RB Save Api Test",
+                    title: "Save_Test",
                     contentmodel: "wikitext",
                     oldrevid: 680525605,
                     newrevid: 680525800,


### PR DESCRIPTION
After mediawiki-title was integrated all the titles incoming to any of the endpoint request are guaranteed to be in normalised form. The only source of non-normalised titles left is MW API. It returns the title in the text form with spaces, not the DBKey format with underscores, so we need to apply title normalisation to the result as well. This also ensures that we're storing gender-neutral version for gendered namespaces.

If the result title doesn't match the originally requested one - some non-needed normalisation happened, so we need to throw 404 as per https://phabricator.wikimedia.org/T131726

Also, some of our tests started to fail after this fix, but that's good, it exposed bugs in tests

cc @wikimedia/services 