### PR TITLE
Removed events for data-parsoid

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -150,9 +150,6 @@ PSP._dependenciesUpdate = function(hyper, req) {
             body: [
                 { meta: { uri: publicBaseURI + '/html/' + encodeURIComponent(rp.title) } },
                 { meta: { uri: publicBaseURI + '/html/' + encodeURIComponent(rp.title)
-                    + '/' + rp.revision } },
-                { meta: { uri: publicBaseURI + '/data-parsoid/' + encodeURIComponent(rp.title) } },
-                { meta: { uri: publicBaseURI + '/data-parsoid/' + encodeURIComponent(rp.title)
                     + '/' + rp.revision } }
             ]
         }));


### PR DESCRIPTION
The data-parsoid without revision or tid endpoints were removed, but we still emit events to them. Fixing.

cc @wikimedia/services 