### PR TITLE
Simple content-type enforcement filter

### DIFF
--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -26,51 +26,55 @@ function checkContentType(hyper, req, next, expectedContentType, responsePromise
     .then(function(res) {
         // Do not check or re-render if the response was only rendered within
         // the last two minutes.
-      //  if (res.headers.etag
-      //      && Date.now() - mwUtil.extractDateFromEtag(res.headers.etag) < 120000) {
-      //      return res;
-      //  }
+        if (res.headers && res.headers.etag
+            && Date.now() - mwUtil.extractDateFromEtag(res.headers.etag) < 120000) {
+            return res;
+        }
+
+        function updateSpecWarning() {
+            // Returned content type version is higher than what the
+            // spec promises. Log a warning about the need to update the spec.
+            hyper.log('warn/content-type/spec_outdated', {
+                msg: 'Spec needs update to reflect latest content type.',
+                expected: expectedContentType,
+                actual: res.headers['content-type']
+            });
+            // Don't fail the request.
+            return res;
+        }
 
         if (res.headers && res.headers['content-type'] !== expectedContentType) {
             // Parse the expected & response content type, and compare profiles.
             var expectedProfile = cType.parse(expectedContentType).parameters.profile;
             var actualProfile = cType.parse(res.headers['content-type']).parameters.profile;
 
-            if (actualProfile && expectedProfile && actualProfile !== expectedProfile) {
+            if (actualProfile && actualProfile !== expectedProfile) {
+                if (!expectedProfile) {
+                    return updateSpecWarning();
+                }
                 // Check if actual content type is newer than the spec
                 var actualProfileParts = splitProfile(actualProfile);
                 var expectedProfileParts = splitProfile(expectedProfile);
                 if (actualProfileParts.path === expectedProfileParts.path
                         && actualProfileParts.version > expectedProfileParts.version) {
-                    // Returned content type version is higher than what the
-                    // spec promises. Log a warning about the need to update the spec.
-                    hyper.log('warn/content-type/spec_outdated', {
-                        msg: 'Spec needs update to reflect latest content type.',
-                        expected: expectedContentType,
-                        actual: res.headers['content-type']
-                    });
-                    // Don't fail the request.
-                    return res;
+                    return updateSpecWarning();
                 }
             }
 
-            // The old content might not have any profile at all
-            if (expectedProfile && actualProfile !== expectedProfile) {
-                // Re-try request with no-cache header
-                if (!mwUtil.isNoCacheRequest(req)) {
-                    req.headers['cache-control'] = 'no-cache';
-                    return checkContentType(hyper, req, next,
-                        expectedContentType, next(hyper, req));
-                } else {
-                    // Log issue
-                    hyper.log('warn/content-type/upgrade_failed', {
-                        msg: 'Could not update the content-type',
-                        expected: expectedContentType,
-                        actual: res.headers['content-type']
-                    });
-                    // Limit response caching to a few seconds
-                    res.headers['cache-control'] = 'max-age=10, s-maxage=10';
-                }
+            // Re-try request with no-cache header
+            if (!mwUtil.isNoCacheRequest(req)) {
+                req.headers['cache-control'] = 'no-cache';
+                return checkContentType(hyper, req, next,
+                    expectedContentType, next(hyper, req));
+            } else {
+                // Log issue
+                hyper.log('warn/content-type/upgrade_failed', {
+                    msg: 'Could not update the content-type',
+                    expected: expectedContentType,
+                    actual: res.headers['content-type']
+                });
+                // Limit response caching to a few seconds
+                res.headers['cache-control'] = 'max-age=10, s-maxage=10';
             }
         }
 

--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -24,11 +24,18 @@ function splitProfile(profile) {
 function checkContentType(hyper, req, next, expectedContentType, responsePromise) {
     return responsePromise
     .then(function(res) {
+        // Do not check or re-render if the response was only rendered within
+        // the last two minutes.
+      //  if (res.headers.etag
+      //      && Date.now() - mwUtil.extractDateFromEtag(res.headers.etag) < 120000) {
+      //      return res;
+      //  }
+
         if (res.headers && res.headers['content-type'] !== expectedContentType) {
-            // Parse the expected & response content type, and compare
-            // profiles.
+            // Parse the expected & response content type, and compare profiles.
             var expectedProfile = cType.parse(expectedContentType).parameters.profile;
             var actualProfile = cType.parse(res.headers['content-type']).parameters.profile;
+
             if (actualProfile && expectedProfile && actualProfile !== expectedProfile) {
                 // Check if actual content type is newer than the spec
                 var actualProfileParts = splitProfile(actualProfile);
@@ -45,19 +52,15 @@ function checkContentType(hyper, req, next, expectedContentType, responsePromise
                     // Don't fail the request.
                     return res;
                 }
+            }
 
-                // Do not re-render if the response was only rendered within
-                // the last two minutes.
-                if (res.headers.etag
-                        && Date.now() - mwUtil.extractDateFromEtag(res.headers.etag) < 120000) {
-                    return res;
-                }
-
+            // The old content might not have any profile at all
+            if (expectedProfile && actualProfile !== expectedProfile) {
                 // Re-try request with no-cache header
                 if (!mwUtil.isNoCacheRequest(req)) {
                     req.headers['cache-control'] = 'no-cache';
                     return checkContentType(hyper, req, next,
-                            expectedContentType, next(hyper, req));
+                        expectedContentType, next(hyper, req));
                 } else {
                     // Log issue
                     hyper.log('warn/content-type/upgrade_failed', {

--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var cType = require('content-type');
+var mwUtil = require('./mwUtil');
+
+// Utility function to split path & version suffix from a profile parameter.
+function splitProfile(profile) {
+    var match = /^(.*)\/([0-9\.]+)$/.exec(profile);
+    return {
+        path: match[1],
+        version: match[2],
+    };
+}
+
+
+/**
+ * Simple content type enforcement
+ *
+ * - Assumes that the first `produces` array entry is the latest.
+ * - Repeats request with `no-cache` header set if the content-type does not
+ *   match the latest version.
+ */
+
+function checkContentType(hyper, req, next, expectedContentType, responsePromise) {
+    return responsePromise
+    .then(function(res) {
+        if (res.headers && res.headers['content-type'] !== expectedContentType) {
+            // Parse the expected & response content type, and compare
+            // profiles.
+            var expectedProfile = cType.parse(expectedContentType).parameters.profile;
+            var actualProfile = cType.parse(res.headers['content-type']).parameters.profile;
+            if (actualProfile && expectedProfile && actualProfile !== expectedProfile) {
+                // Check if actual content type is newer than the spec
+                var actualProfileParts = splitProfile(actualProfile);
+                var expectedProfileParts = splitProfile(expectedProfile);
+                if (actualProfileParts.path === expectedProfileParts.path
+                        && actualProfileParts.version > expectedProfileParts.version) {
+                    // Returned content type version is higher than what the
+                    // spec promises. Log a warning about the need to update the spec.
+                    hyper.log('warn/content-type/spec_outdated', {
+                        msg: 'Spec needs update to reflect latest content type.',
+                        expected: expectedContentType,
+                        actual: res.headers['content-type']
+                    });
+                    // Don't fail the request.
+                    return res;
+                }
+
+                // Do not re-render if the response was only rendered within
+                // the last two minutes.
+                if (res.headers.etag
+                        && Date.now() - mwUtil.extractDateFromEtag(res.headers.etag) < 120000) {
+                    return res;
+                }
+
+                // Re-try request with no-cache header
+                if (!mwUtil.isNoCacheRequest(req)) {
+                    req.headers['cache-control'] = 'no-cache';
+                    return checkContentType(hyper, req, next,
+                            expectedContentType, next(hyper, req));
+                } else {
+                    // Log issue
+                    hyper.log('warn/content-type/upgrade_failed', {
+                        msg: 'Could not update the content-type',
+                        expected: expectedContentType,
+                        actual: res.headers['content-type']
+                    });
+                    // Limit response caching to a few seconds
+                    res.headers['cache-control'] = 'max-age=10, s-maxage=10';
+                }
+            }
+        }
+
+        // Default: Just return.
+        return res;
+    });
+}
+
+
+module.exports = function(hyper, req, next, options, specInfo) {
+    var rp = req.params;
+    var produces = specInfo.spec.produces;
+    var expectedContentType = Array.isArray(produces) && produces[0];
+    var responsePromise = next(hyper, req);
+    if (expectedContentType) {
+        // Found a content type. Ensure that we return the latest profile.
+        return checkContentType(hyper, req, next, expectedContentType, responsePromise);
+    } else {
+        return responsePromise;
+    }
+};

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -29,6 +29,25 @@ mwUtil.makeETag = function(rev, tid, suffix) {
 };
 
 /**
+ * Normalizes the request.params.title and returns it back
+ */
+mwUtil.normalizeTitle = function(hyper, req, title) {
+    return mwUtil.getSiteInfo(hyper, req)
+    .then(function(siteInfo) {
+        return Title.newFromText(title, siteInfo);
+    })
+    .catch(function(e) {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'bad_request',
+                detail: e.message
+            }
+        });
+    });
+};
+
+/**
  * Parse an etag value of the form
  * "<revision>/<tid>/<suffix>"
  * @param {string} etag
@@ -56,30 +75,10 @@ mwUtil.parseETag = function(etag) {
 mwUtil.extractDateFromEtag = function(etag) {
     var bits = mwUtil.parseETag(etag);
     if (bits) {
-        uuid = uuid.fromString(bits.tid);
-        return uuid.getDate();
+        return uuid.fromString(bits.tid).getDate();
     } else {
         return null;
     }
-};
-
-/**
- * Normalizes the request.params.title and returns it back
- */
-mwUtil.normalizeTitle = function(hyper, req, title) {
-    return mwUtil.getSiteInfo(hyper, req)
-    .then(function(siteInfo) {
-        return Title.newFromText(title, siteInfo);
-    })
-    .catch(function(e) {
-        throw new HTTPError({
-            status: 400,
-            body: {
-                type: 'bad_request',
-                detail: e.message
-            }
-        });
-    });
 };
 
 mwUtil.coerceTid = function(tidString, bucket) {

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -29,26 +29,6 @@ mwUtil.makeETag = function(rev, tid, suffix) {
 };
 
 /**
- * Normalizes the request.params.title and returns it back
- */
-mwUtil.normalizeTitle = function(hyper, req, title) {
-    return mwUtil.getSiteInfo(hyper, req)
-    .then(function(siteInfo) {
-        return Title.newFromText(title, siteInfo);
-    })
-    .catch(function(e) {
-        throw new HTTPError({
-            status: 400,
-            body: {
-                type: 'bad_request',
-                detail: e.message
-            }
-        });
-    });
-};
-
-
-/**
  * Parse an etag value of the form
  * "<revision>/<tid>/<suffix>"
  * @param {string} etag
@@ -65,6 +45,41 @@ mwUtil.parseETag = function(etag) {
     } else {
         return null;
     }
+};
+
+/**
+ * Extract the date from an `etag` header of the form
+ * "<revision>/<tid>/<suffix>"
+ * @param {string} etag
+ * @returns {Date|null}
+ */
+mwUtil.extractDateFromEtag = function(etag) {
+    var bits = mwUtil.parseETag(etag);
+    if (bits) {
+        uuid = uuid.fromString(bits.tid);
+        return uuid.getDate();
+    } else {
+        return null;
+    }
+};
+
+/**
+ * Normalizes the request.params.title and returns it back
+ */
+mwUtil.normalizeTitle = function(hyper, req, title) {
+    return mwUtil.getSiteInfo(hyper, req)
+    .then(function(siteInfo) {
+        return Title.newFromText(title, siteInfo);
+    })
+    .catch(function(e) {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'bad_request',
+                detail: e.message
+            }
+        });
+    });
 };
 
 mwUtil.coerceTid = function(tidString, bucket) {


### PR DESCRIPTION
This patch adds a simple content-type check & enforcement filter, which

1) compares the returned content-type with the first entry of the `produces`
   array in the route spec, and
2) repeats the request with `no-cache` header set if the content-type
   mis-matches.