### PR TITLE
Redirect filter

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -43,6 +43,7 @@ default_project: &default_project
           purge:
             host: 127.0.0.1
             port: 4321
+        purged_cache_control: test_purged_cache_control
 
 labs_project: &labs_project
   x-modules:

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -7,6 +7,7 @@ var P = require('bluebird');
 var gunzip = P.promisify(require('zlib').gunzip);
 var Title = require('mediawiki-title').Title;
 var HyperSwitch = require('hyperswitch');
+var querystring = require('querystring');
 var HTTPError = HyperSwitch.HTTPError;
 var URI = HyperSwitch.URI;
 
@@ -229,6 +230,33 @@ mwUtil.getSiteInfo = function(hyper, req) {
         });
     }
     return siteInfoCache[rp.domain];
+};
+
+mwUtil.getQueryString = function(req) {
+    if (Object.keys(req.query).length) {
+        return '?' + querystring.stringify(req.query);
+    }
+    return '';
+};
+
+mwUtil.createRelativeTitleRedirect = function(path, req, newReqParams, titleParamName) {
+    titleParamName = titleParamName || 'title';
+    newReqParams = newReqParams || req.params;
+    var pathBeforeTitle = path.substring(0, path.indexOf('{' + titleParamName + '}'));
+    pathBeforeTitle = new URI(pathBeforeTitle, req.params, true).toString();
+    // Omit the domain prefix as it could be wrong for node shared between domains
+    pathBeforeTitle = pathBeforeTitle.replace(/^\/[^\/]+\//, '');
+    var pathSuffix = req.uri.toString()
+            .replace(/^\/[^\/]+\//, '')
+            .replace(pathBeforeTitle, '');
+    var pathSuffixCount = (pathSuffix.match(/\//g) || []).length;
+    var backString = Array.apply(null, { length: pathSuffixCount }).map(function() {
+        return '../';
+    }).join('');
+    var pathPatternAfterTitle = path.substring(path.indexOf('{title}') - 1);
+    return backString
+        + new URI(pathPatternAfterTitle, newReqParams, true).toString().substr(1)
+        + mwUtil.getQueryString(req);
 };
 
 module.exports = mwUtil;

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -10,7 +10,6 @@ var HyperSwitch = require('hyperswitch');
 var querystring = require('querystring');
 var HTTPError = HyperSwitch.HTTPError;
 var URI = HyperSwitch.URI;
-
 var mwUtil = {};
 
 /**

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -4,7 +4,6 @@ var HyperSwitch = require('hyperswitch');
 var mwUtil = require('./mwUtil');
 var URI = HyperSwitch.URI;
 var P = require('bluebird');
-var querystring = require('querystring');
 
 function getQueryString(req) {
     if (Object.keys(req.query).length) {
@@ -62,28 +61,10 @@ module.exports = function(hyper, req, next, options, specInfo) {
                     return res;
                 });
             } else {
-                var pathBeforeTitle = specInfo.path
-                    .substring(0, specInfo.path.indexOf('{title}'));
-                pathBeforeTitle = new URI(pathBeforeTitle, rp, true).toString();
-                // Omit the domain prefix as it could be wrong for node shared between domains
-                pathBeforeTitle = pathBeforeTitle.replace(/^\/[^\/]+\//, '');
-                var pathSuffix = req.uri.toString()
-                    .replace(/^\/[^\/]+\//, '')
-                    .replace(pathBeforeTitle, '');
-                var pathSuffixCount = (pathSuffix.match(/\//g) || []).length;
-                var backString = Array.apply(null, { length: pathSuffixCount }).map(function() {
-                    return '../';
-                }).join('');
-                var pathPatternAfterTitle = specInfo.path
-                    .substring(specInfo.path.indexOf('{title}') - 1);
-                var contentLocation = backString
-                    + new URI(pathPatternAfterTitle, rp, true).toString().substr(1)
-                    + getQueryString(req);
-
                 return P.resolve({
                     status: 301,
                     headers: {
-                        location: contentLocation,
+                        location: mwUtil.createRelativeTitleRedirect(specInfo.path, req),
                         'cache-control': options.redirect_cache_control || 'no-cache'
                     }
                 });
@@ -94,7 +75,8 @@ module.exports = function(hyper, req, next, options, specInfo) {
                 // until https://phabricator.wikimedia.org/T130757 (VE
                 // redirect support) is resolved.
                 // TODO: Remove.
-                && /^WikipediaApp\//.test(req.headers['user-agent'])) {
+                && /^WikipediaApp\//.test(req.headers['user-agent'])
+                && req.query.redirect !== 'no') {
             return next(hyper, req).catch({ status: 404 }, function(e) {
                 return mwUtil.getSiteInfo(hyper, req)
                 .then(function(siteInfo) {
@@ -104,7 +86,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
                         var redirectPath = req.uri + '';
                         redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
                         redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1'
-                        + redirectPath + getQueryString(req);
+                        + redirectPath + mwUtil.getQueryString(req);
                         return {
                             status: 302,
                             headers: {

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -67,7 +67,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
                 // redirect support) is resolved.
                 // TODO: Remove.
                 && /^WikipediaApp\//.test(req.headers['user-agent'])
-                && req.query.redirect !== 'no') {
+                && req.query.redirect !== false) {
             return next(hyper, req).catch({ status: 404 }, function(e) {
                 return mwUtil.getSiteInfo(hyper, req)
                 .then(function(siteInfo) {
@@ -77,7 +77,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
                         var redirectPath = req.uri + '';
                         redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
                         redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1'
-                        + redirectPath + mwUtil.getQueryString(req);
+                            + redirectPath + mwUtil.getQueryString(req);
                         return {
                             status: 302,
                             headers: {

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -61,13 +61,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
                 });
             }
         }
-        if (normalizeResult.getNamespace().isFile()
-                // Temporarily limit file descripiton redirects to the app,
-                // until https://phabricator.wikimedia.org/T130757 (VE
-                // redirect support) is resolved.
-                // TODO: Remove.
-                && /^WikipediaApp\//.test(req.headers['user-agent'])
-                && req.query.redirect !== false) {
+        if (normalizeResult.getNamespace().isFile() && req.query.redirect !== false) {
             return next(hyper, req).catch({ status: 404 }, function(e) {
                 return mwUtil.getSiteInfo(hyper, req)
                 .then(function(siteInfo) {

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -1,16 +1,7 @@
 "use strict";
 
-var HyperSwitch = require('hyperswitch');
 var mwUtil = require('./mwUtil');
-var URI = HyperSwitch.URI;
 var P = require('bluebird');
-
-function getQueryString(req) {
-    if (Object.keys(req.query).length) {
-        return '?' + querystring.stringify(req.query);
-    }
-    return '';
-}
 
 module.exports = function(hyper, req, next, options, specInfo) {
     var rp = req.params;

--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -6,6 +6,7 @@
 var URI = require('hyperswitch').URI;
 var mwUtil = require('./mwUtil');
 var entities = require('entities');
+var P = require('bluebird');
 
 var redirectRegEx = /<link rel="mw:PageProp\/redirect" href="\.\/([^"#]+)(?:#[^"]*)?"/;
 
@@ -26,25 +27,26 @@ module.exports = function(hyper, req, next, options, specInfo) {
             if (rp.revision) {
                 htmlPath.push('' + rp.revision);
             }
-            return hyper.get({ uri: new URI(htmlPath) })
-            .then(function(res) {
-                var html = res.body;
+            return P.props({
+                content: next(hyper, req),
+                html: hyper.get({ uri: new URI(htmlPath) })
+            })
+            .then(function(responses) {
+                var html = responses.html.body;
                 var redirectMatch = redirectRegEx.exec(html);
                 if (redirectMatch) {
                     var newParams = Object.assign({}, rp);
                     newParams[titleName] = decodeURIComponent(entities.decodeXML(redirectMatch[1]));
-                    var location = mwUtil.createRelativeTitleRedirect(specInfo.path, req,
-                        newParams, titleName);
-                    return next(hyper, req).then(function(res) {
-                        return {
-                            status: 302,
-                            headers: Object.assign(res.headers, {
-                                location: location,
-                                'cache-control': options.redirect_cache_control || 'no-cache'
-                            }),
-                            body: res.body
-                        };
-                    });
+                    var location = mwUtil.createRelativeTitleRedirect(specInfo.path,
+                            req, newParams, titleName);
+                    return {
+                        status: 302,
+                        headers: Object.assign(responses.content.headers, {
+                            location: location,
+                            'cache-control': options.redirect_cache_control || 'no-cache'
+                        }),
+                        body: responses.content.body
+                    };
                 } else {
                     return next(hyper, req);
                 }

--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -7,7 +7,7 @@ var URI = require('hyperswitch').URI;
 var mwUtil = require('./mwUtil');
 var entities = require('entities');
 
-var redirectRegEx = /<link rel="mw:PageProp\/redirect" href="\.\/([^"#]+)"/;
+var redirectRegEx = /<link rel="mw:PageProp\/redirect" href="\.\/([^"#]+)(?:#[^"]*)?"/;
 
 module.exports = function(hyper, req, next, options, specInfo) {
     var rp = req.params;

--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -1,0 +1,55 @@
+"use strict";
+
+// TODO: This is a temp solution that will
+// be eventually replaced by the restrictions table.
+
+var URI = require('hyperswitch').URI;
+var mwUtil = require('./mwUtil');
+var entities = require('entities');
+
+var redirectRegEx = /<link rel="mw:PageProp\/redirect" href="\.\/([^"]+)"/;
+
+module.exports = function(hyper, req, next, options, specInfo) {
+    var rp = req.params;
+    var titleName = options.title ? options.title : 'title';
+    var checkURIParts = [rp.domain, 'sys', 'page_revisions', 'page', rp[titleName]];
+    if (rp.revision) {
+        checkURIParts.push('' + rp.revision);
+    }
+
+    return hyper.get({ uri: new URI(checkURIParts) })
+    .then(function(res) {
+        var revision = res.body.items[0];
+
+        if (revision.redirect && req.query.redirect !== 'no') {
+            var htmlPath = [rp.domain, 'sys', 'parsoid', 'html', rp[titleName]];
+            if (rp.revision) {
+                htmlPath.push('' + rp.revision);
+            }
+            return hyper.get({ uri: new URI(htmlPath) })
+            .then(function(res) {
+                var html = res.body;
+                var redirectMatch = redirectRegEx.exec(html);
+                if (redirectMatch) {
+                    var newParams = Object.assign({}, rp);
+                    newParams[titleName] = entities.decodeXML(decodeURIComponent(redirectMatch[1]));
+                    var location = mwUtil.createRelativeTitleRedirect(specInfo.path, req,
+                        newParams, titleName);
+                    return next(hyper, req).then(function(res) {
+                        return {
+                            status: 302,
+                            headers: Object.assign(res.headers, {
+                                location: location,
+                                'cache-control': options.redirect_cache_control || 'no-cache'
+                            }),
+                            body: res.body
+                        };
+                    });
+                } else {
+                    return next(hyper, req);
+                }
+            });
+        }
+        return next(hyper, req);
+    });
+};

--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -7,7 +7,7 @@ var URI = require('hyperswitch').URI;
 var mwUtil = require('./mwUtil');
 var entities = require('entities');
 
-var redirectRegEx = /<link rel="mw:PageProp\/redirect" href="\.\/([^"]+)"/;
+var redirectRegEx = /<link rel="mw:PageProp\/redirect" href="\.\/([^"#]+)"/;
 
 module.exports = function(hyper, req, next, options, specInfo) {
     var rp = req.params;
@@ -21,7 +21,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
     .then(function(res) {
         var revision = res.body.items[0];
 
-        if (revision.redirect && req.query.redirect !== 'no') {
+        if (revision.redirect && req.query.redirect !== false) {
             var htmlPath = [rp.domain, 'sys', 'parsoid', 'html', rp[titleName]];
             if (rp.revision) {
                 htmlPath.push('' + rp.revision);
@@ -32,7 +32,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
                 var redirectMatch = redirectRegEx.exec(html);
                 if (redirectMatch) {
                     var newParams = Object.assign({}, rp);
-                    newParams[titleName] = entities.decodeXML(decodeURIComponent(redirectMatch[1]));
+                    newParams[titleName] = decodeURIComponent(entities.decodeXML(redirectMatch[1]));
                     var location = mwUtil.createRelativeTitleRedirect(specInfo.path, req,
                         newParams, titleName);
                     return next(hyper, req).then(function(res) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "content-type": "git+https://github.com/wikimedia/content-type#master",
     "hyperswitch": "^0.4.1",
     "jsonwebtoken": "^5.5.4",
-    "mediawiki-title": "^0.4.0"
+    "mediawiki-title": "^0.4.0",
+    "entities": "^1.1.1"
   },
   "devDependencies": {
     "js-yaml": "^3.5.2",

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -34,6 +34,8 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
             /transform:
               x-modules:
                 - path: v1/transform.yaml

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -35,7 +35,7 @@ paths:
               x-modules:
                 - path: v1/content.yaml
                   options:
-                    response_cache_control: '{{options.purged_cache_control}}'
+                    purged_cache_control: '{{options.purged_cache_control}}'
             /transform:
               x-modules:
                 - path: v1/transform.yaml

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -37,6 +37,8 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},
                                 options.mobileapps)}}'

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -38,7 +38,7 @@ paths:
               x-modules:
                 - path: v1/content.yaml
                   options:
-                    response_cache_control: '{{options.purged_cache_control}}'
+                    purged_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},
                                 options.mobileapps)}}'

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -38,6 +38,8 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},
                                     options.mobileapps)}}'

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -39,7 +39,7 @@ paths:
               x-modules:
                 - path: v1/content.yaml
                   options:
-                    response_cache_control: '{{options.purged_cache_control}}'
+                    purged_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},
                                     options.mobileapps)}}'

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -305,6 +305,7 @@ PRS.prototype.fetchAndStoreMWRevision = function(hyper, req) {
                 var storedRev = res.body.items[0];
                 // The redirect in MW API is based on the latest revision,
                 // so for older revisions it must never be updated.
+                // TODO: redirects for old revision might be incorrect
                 revision.redirect = storedRev.redirect;
                 if (!self._checkSameRev(revision, res.body.items[0])) {
                     throw new HTTPError({ status: 404 });

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -301,11 +301,14 @@ PRS.prototype.fetchAndStoreMWRevision = function(hyper, req) {
             }
         })
         .then(function(res) {
-            var sameRev = res && res.body.items
-                    && res.body.items.length > 0
-                    && self._checkSameRev(revision, res.body.items[0]);
-            if (!sameRev) {
-                throw new HTTPError({ status: 404 });
+            if (res && res.body.items && res.body.items.length > 0) {
+                var storedRev = res.body.items[0];
+                // The redirect in MW API is based on the latest revision,
+                // so for older revisions it must never be updated.
+                revision.redirect = storedRev.redirect;
+                if (!self._checkSameRev(revision, res.body.items[0])) {
+                    throw new HTTPError({ status: 404 });
+                }
             }
         })
         .catch({ status: 404 }, function() {

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -159,24 +159,6 @@ PSP._dependenciesUpdate = function(hyper, req) {
     });
 };
 
-/**
- * Wraps a request for getting content (the promise) into a
- * P.all() call, bundling it with a request for revision
- * info, so that a 403 error gets raised overall if access to
- * the revision should be denied
- * @param {HyperSwitch} hyper the HyperSwitch router object
- * @param {Object} req the user request
- * @param {Object} promise the promise object to wrap
- * @private
- */
-PSP._wrapInAccessCheck = function(hyper, req, promise) {
-    return P.props({
-        content: promise,
-        revisionInfo: this.getRevisionInfo(hyper, req)
-    })
-    .then(function(responses) { return responses.content; });
-};
-
 PSP.getBucketURI = function(rp, format, tid, useKeyRevValue) {
     var bucket = useKeyRevValue ? 'key_rev_value' : this.options.bucket_type;
     var path = [rp.domain, 'sys', bucket, 'parsoid.' + format, rp.title];
@@ -457,10 +439,7 @@ PSP.getFormat = function(format, hyper, req) {
             generateContent);
     } else {
         // Only (possibly) generate content if there was an error
-        contentReq = contentReq.catch(generateContent)
-        .then(function(res) {
-            return self._wrapInAccessCheck(hyper, req, P.resolve(res));
-        });
+        contentReq = contentReq.catch(generateContent);
     }
     return contentReq
     .then(function(res) {

--- a/test/features/pagecontent/access_checks.js
+++ b/test/features/pagecontent/access_checks.js
@@ -78,17 +78,25 @@ describe('Access checks', function() {
             api = setUpNockResponse(api, deletedPageTitle, deletedPageOlderRevision);
             api = setUpNockResponse(api, deletedPageTitle, deletedPageRevision);
 
+            // Need to supply no-cache header to make the summary update synchronous
+            // to avoid races on mocks. Can remove when switched to change propagation
             return preq.get({
                 uri: server.config.bucketURL + '/html/'
                         + encodeURIComponent(deletedPageTitle)
-                        + '/' + deletedPageOlderRevision
+                        + '/' + deletedPageOlderRevision,
+                headers: {
+                    'cache-control': 'no-cache'
+                }
             })
             .then(function(res) {
                 assert.deepEqual(res.status, 200);
                 return preq.get({
                     uri: server.config.bucketURL + '/html/'
                             + encodeURIComponent(deletedPageTitle)
-                            + '/' + deletedPageRevision
+                            + '/' + deletedPageRevision,
+                    headers: {
+                        'cache-control': 'no-cache'
+                    }
                 });
             })
             .then(function (res) {

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -313,10 +313,7 @@ describe('item requests', function() {
 
     it('should redirect to commons for missing file pages', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg',
-            headers: {
-                'user-agent': 'WikipediaApp/2.1.141-beta-2016-02-10 (Android 5.0.2; Phone) Google Play Beta Channel'
-            }
+            uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -72,6 +72,17 @@ describe('Redirects', function() {
         });
     });
 
+    it('should return 302 for redirect pages html, hash', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fRedirect_Test_Hash',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 302);
+            assert.deepEqual(res.headers.location, 'Main_Page');
+        });
+    });
+
     it('should return 200 for redirect pages html with redirect=no', function() {
         return preq.get({
             uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fRedirect_Test?redirect=no',

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -56,6 +56,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(/Redirect Target/.test(res.body.toString()), false);
         });
     });
@@ -68,6 +69,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%26');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(/Redirect Target/.test(res.body.toString()), false);
         });
     });
@@ -80,6 +82,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers.location, 'Main_Page');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
         });
     });
 
@@ -103,6 +106,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers.location, '../User%3APchelolo%2FRedirect_Target_%25/331630');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(/Redirect Target/.test(res.body.toString()), false);
         });
     });
@@ -127,6 +131,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.body, {
                 title: 'User:Pchelolo/Redirect Test',
                 extract: '',

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -1,0 +1,162 @@
+'use strict';
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var assert = require('../../utils/assert.js');
+var preq   = require('preq');
+var server = require('../../utils/server.js');
+var P      = require('bluebird');
+
+describe('Redirects', function() {
+    before(function() { return server.start(); });
+
+    it('should redirect to commons for missing file pages', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg',
+            headers: {
+                'user-agent': 'WikipediaApp/2.1.141-beta-2016-02-10 (Android 5.0.2; Phone) Google Play Beta Channel'
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-location'],
+            'https://commons.wikimedia.org/api/rest_v1/page/html/File%3AThinkingMan_Rodin.jpg');
+        });
+    });
+
+    it('should not redirect if file is missing on commons', function() {
+        return preq.get({
+            uri: server.config.hostPort +
+            '/commons.wikimedia.org/v1/html/File:Some_File_That_Does_Not_Exist.jpg'
+        })
+        .then(function() {
+            throw new Error('Error should be thrown');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+        });
+    });
+
+    it('should result in 404 if + is normalized by MW API', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2FOnDemand+Test'
+        })
+        .then(function() {
+            throw new Error('Error should be thrown');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
+        });
+    });
+
+    it('should return 302 for redirect pages html', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fRedirect_Test',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 302);
+            assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
+            assert.deepEqual(/Redirect Target/.test(res.body.toString()), false);
+        });
+    });
+
+    it('should return 302 for redirect pages html, entities', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fRedirect_Test_Amp',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 302);
+            assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%26');
+            assert.deepEqual(/Redirect Target/.test(res.body.toString()), false);
+        });
+    });
+
+    it('should return 200 for redirect pages html with redirect=no', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fRedirect_Test?redirect=no',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers.location, undefined);
+            assert.deepEqual(/Redirect Target/.test(res.body.toString()), false);
+        });
+    });
+
+    it('should return 302 for redirect pages html with revision', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fRedirect_Test/331630',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 302);
+            assert.deepEqual(res.headers.location, '../User%3APchelolo%2FRedirect_Target_%25/331630');
+            assert.deepEqual(/Redirect Target/.test(res.body.toString()), false);
+        });
+    });
+
+    it('should return 200 for redirect pages html with revision, redirect=no', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2fRedirect_Test/331630?redirect=no',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers.location, undefined);
+            assert.deepEqual(/Redirect Target/.test(res.body.toString()), false);
+        });
+    });
+
+    it('should return 302 for redirect pages summary', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/summary/User:Pchelolo%2fRedirect_Test',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 302);
+            assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
+            assert.deepEqual(res.body, {
+                title: 'User:Pchelolo/Redirect Test',
+                extract: '',
+                lang: 'en',
+                dir: 'ltr'
+            });
+        });
+    });
+
+    /* TODO disabled until mobileapps fix their on entities decoding.
+    it('should return 302 for redirect pages mobile-sections', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/mobile-sections/User:Pchelolo%2fRedirect_Test',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 302);
+            assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
+        });
+    });
+
+    it('should return 302 for redirect pages mobile-sections-lead', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/mobile-sections-lead/User:Pchelolo%2fRedirect_Test',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 302);
+            assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
+        });
+    });
+
+    it('should return 302 for redirect pages mobile-sections-remaining', function() {
+        return preq.get({
+            uri: server.config.labsBucketURL + '/mobile-sections-remaining/User:Pchelolo%2fRedirect_Test',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 302);
+            assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
+        });
+    });
+    */
+});

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -13,15 +13,23 @@ describe('Redirects', function() {
 
     it('should redirect to commons for missing file pages', function() {
         return preq.get({
-            uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg',
-            headers: {
-                'user-agent': 'WikipediaApp/2.1.141-beta-2016-02-10 (Android 5.0.2; Phone) Google Play Beta Channel'
-            }
+            uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg'
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers['content-location'],
-            'https://commons.wikimedia.org/api/rest_v1/page/html/File%3AThinkingMan_Rodin.jpg');
+                'https://commons.wikimedia.org/api/rest_v1/page/html/File%3AThinkingMan_Rodin.jpg');
+        });
+    });
+
+    it('should not redirect to commons for missing file pages, redirect=false', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg?redirect=false'
+        })
+        .then(function() {
+            throw new Error('Error should be thrown');
+        }, function(e) {
+            assert.deepEqual(e.status, 404);
         });
     });
 

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -179,6 +179,8 @@ paths:
       x-monitor: false
 
   /html/{title}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
     get:
       tags:
         - Page content
@@ -415,6 +417,8 @@ paths:
       x-monitor: false
 
   /html/{title}/{revision}{/tid}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
     get:
       tags:
         - Page content
@@ -504,6 +508,8 @@ paths:
       x-monitor: false
 
   /data-parsoid/{title}/{revision}/{tid}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
     get:
       tags:
         - Page content

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -202,11 +202,10 @@ paths:
         - name: redirect
           in: query
           description: >
-            By default for redirect pages HTTP status 302 is returned with a location header,
-            pointing to the redirect target. The response body contains html for a redirect
-            page. In case the client cannot disable following redirects automatically, supply
-            `false` or `no` to the redirect parameter, and normal 200 response with redirect
-            page html will be returned.
+            Requests for [redirect pages](https://www.mediawiki.org/wiki/Help:Redirects)
+            return HTTP 302 with a redirect target in `Location` header and content in the body.
+
+            To get a 200 response instead, supply `false` to the `redirect` parameter.
           type: boolean
           required: false
       produces:
@@ -464,11 +463,10 @@ paths:
         - name: redirect
           in: query
           description: >
-            By default for redirect pages HTTP status 302 is returned with a location header,
-            pointing to the redirect target. The response body contains html for a redirect
-            page. In case the client cannot disable following redirects automatically, supply
-            `false` or `no` to the redirect parameter, and normal 200 response with redirect
-            page html will be returned.
+            Requests for [redirect pages](https://www.mediawiki.org/wiki/Help:Redirects)
+            return HTTP 302 with a redirect target in `Location` header and content in the body.
+
+            To get a 200 response instead, supply `false` to the `redirect` parameter.
           type: boolean
           required: false
       responses:
@@ -573,11 +571,10 @@ paths:
         - name: redirect
           in: query
           description: >
-            By default for redirect pages HTTP status 302 is returned with a location header,
-            pointing to the redirect target. The response body contains html for a redirect
-            page. In case the client cannot disable following redirects automatically, supply
-            `false` or `no` to the redirect parameter, and normal 200 response with redirect
-            page html will be returned.
+            Requests for [redirect pages](https://www.mediawiki.org/wiki/Help:Redirects)
+            return HTTP 302 with a redirect target in `Location` header and content in the body.
+
+            To get a 200 response instead, supply `false` to the `redirect` parameter.
           type: boolean
           required: false
       responses:

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -182,7 +182,7 @@ paths:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
         options:
-          redirect_cache_control: '{{options.response_cache_control}}'
+          redirect_cache_control: '{{options.purged_cache_control}}'
     get:
       tags:
         - Page content
@@ -431,7 +431,7 @@ paths:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
         options:
-          redirect_cache_control: '{{options.response_cache_control}}'
+          redirect_cache_control: '{{options.purged_cache_control}}'
     get:
       tags:
         - Page content
@@ -533,7 +533,7 @@ paths:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
         options:
-          redirect_cache_control: '{{options.response_cache_control}}'
+          redirect_cache_control: '{{options.purged_cache_control}}'
     get:
       tags:
         - Page content

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -181,6 +181,8 @@ paths:
   /html/{title}:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
+        options:
+          redirect_cache_control: '{{options.response_cache_control}}'
     get:
       tags:
         - Page content
@@ -429,6 +431,8 @@ paths:
   /html/{title}/{revision}{/tid}:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
+        options:
+          redirect_cache_control: '{{options.response_cache_control}}'
     get:
       tags:
         - Page content
@@ -530,6 +534,8 @@ paths:
   /data-parsoid/{title}/{revision}/{tid}:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
+        options:
+          redirect_cache_control: '{{options.response_cache_control}}'
     get:
       tags:
         - Page content

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -197,6 +197,16 @@ paths:
           in: query
           description: Comma-separated list of section IDs.
           type: string
+        - name: redirect
+          in: query
+          description: >
+            By default for redirect pages HTTP status 302 is returned with a location header,
+            pointing to the redirect target. The response body contains html for a redirect
+            page. In case the client cannot disable following redirects automatically, supply
+            `false` or `no` to the redirect parameter, and normal 200 response with redirect
+            page html will be returned.
+          type: boolean
+          required: false
       produces:
         - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.2.1"
       responses:
@@ -447,6 +457,16 @@ paths:
           in: query
           description: Comma-separated list of section IDs
           type: string
+        - name: redirect
+          in: query
+          description: >
+            By default for redirect pages HTTP status 302 is returned with a location header,
+            pointing to the redirect target. The response body contains html for a redirect
+            page. In case the client cannot disable following redirects automatically, supply
+            `false` or `no` to the redirect parameter, and normal 200 response with redirect
+            page html will be returned.
+          type: boolean
+          required: false
       responses:
         '200':
           description: |
@@ -544,6 +564,16 @@ paths:
           description: The revision's time ID
           type: string
           required: true
+        - name: redirect
+          in: query
+          description: >
+            By default for redirect pages HTTP status 302 is returned with a location header,
+            pointing to the redirect target. The response body contains html for a redirect
+            page. In case the client cannot disable following redirects automatically, supply
+            `false` or `no` to the redirect parameter, and normal 200 response with redirect
+            page html will be returned.
+          type: boolean
+          required: false
       responses:
         '200':
           description: The latest Parsoid data for the given page

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -17,6 +17,7 @@ paths:
       - path: ./lib/revision_table_access_check_filter.js
         options:
           title: term
+          redirect_cache_control: '{{options.response_cache_control}}'
     get:
       tags:
         - Page content

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -37,6 +37,16 @@ paths:
           description: The term to define
           type: string
           required: true
+        - name: redirect
+          in: query
+          description: >
+            By default for redirect pages HTTP status 302 is returned with a location header,
+            pointing to the redirect target. The response body contains html for a redirect
+            page. In case the client cannot disable following redirects automatically, supply
+            `false` or `no` to the redirect parameter, and normal 200 response with redirect
+            page html will be returned.
+          type: boolean
+          required: false
       responses:
         '200':
           description: The definition for the given term

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -13,6 +13,10 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /definition/{term}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
+        options:
+          title: term
     get:
       tags:
         - Page content
@@ -60,17 +64,7 @@ paths:
               valueType: 'json'
 
       x-request-handler:
-        # Get the revision metadata for access control (will return an error
-        # if there's no access), and so that we can use the normalized title &
-        # other info in case we have a storage miss.
-        - rev_info:
-            request:
-              method: get
-              uri: /{domain}/sys/page_revisions/page/{term}
-            response:
-              body: '{{rev_info.body.items[0]}}'
-
-          storage:
+        - storage:
             request:
               method: get
               headers:

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -41,11 +41,10 @@ paths:
         - name: redirect
           in: query
           description: >
-            By default for redirect pages HTTP status 302 is returned with a location header,
-            pointing to the redirect target. The response body contains html for a redirect
-            page. In case the client cannot disable following redirects automatically, supply
-            `false` or `no` to the redirect parameter, and normal 200 response with redirect
-            page html will be returned.
+            Requests for [redirect pages](https://www.mediawiki.org/wiki/Help:Redirects)
+            return HTTP 302 with a redirect target in `Location` header and content in the body.
+
+            To get a 200 response instead, supply `false` to the `redirect` parameter.
           type: boolean
           required: false
       responses:

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -27,11 +27,10 @@ paths:
         - name: redirect
           in: query
           description: >
-            By default for redirect pages HTTP status 302 is returned with a location header,
-            pointing to the redirect target. The response body contains html for a redirect
-            page. In case the client cannot disable following redirects automatically, supply
-            `false` or `no` to the redirect parameter, and normal 200 response with redirect
-            page html will be returned.
+            Requests for [redirect pages](https://www.mediawiki.org/wiki/Help:Redirects)
+            return HTTP 302 with a redirect target in `Location` header and content in the body.
+
+            To get a 200 response instead, supply `false` to the `redirect` parameter.
           type: boolean
           required: false
       responses:
@@ -105,11 +104,10 @@ paths:
         - name: redirect
           in: query
           description: >
-            By default for redirect pages HTTP status 302 is returned with a location header,
-            pointing to the redirect target. The response body contains html for a redirect
-            page. In case the client cannot disable following redirects automatically, supply
-            `false` or `no` to the redirect parameter, and normal 200 response with redirect
-            page html will be returned.
+            Requests for [redirect pages](https://www.mediawiki.org/wiki/Help:Redirects)
+            return HTTP 302 with a redirect target in `Location` header and content in the body.
+
+            To get a 200 response instead, supply `false` to the `redirect` parameter.
           type: boolean
           required: false
       responses:
@@ -169,11 +167,10 @@ paths:
         - name: redirect
           in: query
           description: >
-            By default for redirect pages HTTP status 302 is returned with a location header,
-            pointing to the redirect target. The response body contains html for a redirect
-            page. In case the client cannot disable following redirects automatically, supply
-            `false` or `no` to the redirect parameter, and normal 200 response with redirect
-            page html will be returned.
+            Requests for [redirect pages](https://www.mediawiki.org/wiki/Help:Redirects)
+            return HTTP 302 with a redirect target in `Location` header and content in the body.
+
+            To get a 200 response instead, supply `false` to the `redirect` parameter.
           type: boolean
           required: false
       responses:

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -3,6 +3,8 @@
 swagger: 2.0
 paths:
   /mobile-sections/{title}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
     get:
       tags:
         - Mobile
@@ -40,11 +42,7 @@ paths:
           schema:
             $ref: '#/definitions/problem'
       x-request-handler:
-        - access_check:
-            request:
-              method: get
-              uri: /{domain}/sys/page_revisions/page/{title}
-          from_backend:
+        - from_backend:
             request:
               method: get
               uri: /{domain}/sys/mobileapps/mobile-sections/{title}
@@ -71,6 +69,8 @@ paths:
               remaining: /.+/
 
   /mobile-sections-lead/{title}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
     get:
       tags:
         - Mobile
@@ -108,11 +108,7 @@ paths:
           schema:
             $ref: '#/definitions/problem'
       x-request-handler:
-        - access_check:
-            request:
-              method: get
-              uri: /{domain}/sys/page_revisions/page/{title}
-          from_backend:
+        - from_backend:
             request:
               method: get
               uri: /{domain}/sys/mobileapps/mobile-sections-lead/{title}
@@ -124,6 +120,8 @@ paths:
       x-monitor: false
 
   /mobile-sections-remaining/{title}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
     get:
       tags:
         - Mobile
@@ -162,11 +160,7 @@ paths:
           schema:
             $ref: '#/definitions/problem'
       x-request-handler:
-        - access_check:
-            request:
-              method: get
-              uri: /{domain}/sys/page_revisions/page/{title}
-          from_backend:
+        - from_backend:
             request:
               method: get
               uri: /{domain}/sys/mobileapps/mobile-sections-remaining/{title}

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -22,6 +22,16 @@ paths:
           description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
+        - name: redirect
+          in: query
+          description: >
+            By default for redirect pages HTTP status 302 is returned with a location header,
+            pointing to the redirect target. The response body contains html for a redirect
+            page. In case the client cannot disable following redirects automatically, supply
+            `false` or `no` to the redirect parameter, and normal 200 response with redirect
+            page html will be returned.
+          type: boolean
+          required: false
       responses:
         '200':
           description: JSON containing HTML sections and metadata for the given page title.
@@ -88,6 +98,16 @@ paths:
           description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
+        - name: redirect
+          in: query
+          description: >
+            By default for redirect pages HTTP status 302 is returned with a location header,
+            pointing to the redirect target. The response body contains html for a redirect
+            page. In case the client cannot disable following redirects automatically, supply
+            `false` or `no` to the redirect parameter, and normal 200 response with redirect
+            page html will be returned.
+          type: boolean
+          required: false
       responses:
         '200':
           description: The HTML for the given page title.
@@ -140,6 +160,16 @@ paths:
           description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
+        - name: redirect
+          in: query
+          description: >
+            By default for redirect pages HTTP status 302 is returned with a location header,
+            pointing to the redirect target. The response body contains html for a redirect
+            page. In case the client cannot disable following redirects automatically, supply
+            `false` or `no` to the redirect parameter, and normal 200 response with redirect
+            page html will be returned.
+          type: boolean
+          required: false
       responses:
         '200':
           description: JSON wrapping HTML sections for the given page title.

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -5,6 +5,8 @@ paths:
   /mobile-sections/{title}:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
+        options:
+          redirect_cache_control: '{{options.purged_cache_control}}'
     get:
       tags:
         - Mobile
@@ -81,6 +83,8 @@ paths:
   /mobile-sections-lead/{title}:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
+        options:
+          redirect_cache_control: '{{options.purged_cache_control}}'
     get:
       tags:
         - Mobile
@@ -142,6 +146,8 @@ paths:
   /mobile-sections-remaining/{title}:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
+        options:
+          redirect_cache_control: '{{options.purged_cache_control}}'
     get:
       tags:
         - Mobile

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -38,11 +38,10 @@ paths:
         - name: redirect
           in: query
           description: >
-            By default for redirect pages HTTP status 302 is returned with a location header,
-            pointing to the redirect target. The response body contains html for a redirect
-            page. In case the client cannot disable following redirects automatically, supply
-            `false` or `no` to the redirect parameter, and normal 200 response with redirect
-            page html will be returned.
+            Requests for [redirect pages](https://www.mediawiki.org/wiki/Help:Redirects)
+            return HTTP 302 with a redirect target in `Location` header and content in the body.
+
+            To get a 200 response instead, supply `false` to the `redirect` parameter.
           type: boolean
           required: false
       responses:

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -13,6 +13,8 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /summary/{title}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
     get:
       tags:
         - Page content
@@ -59,18 +61,7 @@ paths:
               valueType: 'json'
 
       x-request-handler:
-
-        # Get the revision metadata for access control (will return an error
-        # if there's no access), and so that we can use the normalized title &
-        # other info in case we have a storage miss.
-        - rev_info:
-            request:
-              method: get
-              uri: /{domain}/sys/page_revisions/page/{title}
-            response:
-              body: '{{rev_info.body.items[0]}}'
-
-          storage:
+        - storage:
             request:
               method: get
               headers:
@@ -96,12 +87,11 @@ paths:
               uri: /{domain}/sys/action/query
               body:
                 prop: 'info|extracts|pageimages'
-                redirects: true
                 exsentences: 5
                 explaintext: true
                 piprop: 'thumbnail'
                 pithumbsize: 320
-                titles: '{{rev_info.body.title}}'
+                titles: '{{request.params.title}}'
             response:
               # Define the response to save & return.
               headers:

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -15,6 +15,8 @@ paths:
   /summary/{title}:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
+        options:
+          redirect_cache_control: '{{options.response_cache_control}}'
     get:
       tags:
         - Page content

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -33,6 +33,16 @@ paths:
           description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
+        - name: redirect
+          in: query
+          description: >
+            By default for redirect pages HTTP status 302 is returned with a location header,
+            pointing to the redirect target. The response body contains html for a redirect
+            page. In case the client cannot disable following redirects automatically, supply
+            `false` or `no` to the redirect parameter, and normal 200 response with redirect
+            page html will be returned.
+          type: boolean
+          required: false
       responses:
         '200':
           description: The summary for the given page


### PR DESCRIPTION
First iteration of the redirect support in RESTBase.

Note: before merging this we need to temporarily disable caching for redirect=no requests, ask mobile apps and VE to supply redirect=no query param. After that is merged we can implement a varnish optimisation so that VE shared the cache. Also we will be able to remove the redirect handling from mobile service and make them rely on RESTBase.

Further performance optimisations will be achieved with restrictions table.

Bug: https://phabricator.wikimedia.org/T131570