### PR TITLE
Refactored sections handling and made it no-cache

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -91,9 +91,22 @@ mwUtil.coerceTid = function(tidString, bucket) {
  */
 mwUtil.normalizeContentType = function(res) {
     if (res && res.headers && res.headers['content-type']) {
-        res.headers['content-type'] =
-        contentType.format(contentType.parse(res.headers['content-type']));
+        var cType = res.headers['content-type'];
+        if (/^text\/html\b/.test(cType) && !/charset=/.test(cType)) {
+            // Make sure a charset is set
+            res.headers['content-type'] = cType + ';charset=utf-8';
+        }
+        res.headers['content-type'] = contentType.format(contentType.parse(cType));
     }
+};
+
+/**
+ * Checks whether the request is a 'no-cache' request
+ *
+ * @param {Object} req
+ */
+mwUtil.isNoCacheRequest = function(req) {
+    return req.headers && /no-cache/i.test(req.headers['cache-control']);
 };
 
 mwUtil.parseRevision = function(rev, bucketName) {

--- a/sys/key_value.js
+++ b/sys/key_value.js
@@ -101,10 +101,8 @@ function returnRevision(req) {
 }
 
 KVBucket.prototype.getRevision = function(hyper, req) {
-    if (req.headers && /no-cache/i.test(req.headers['cache-control'])) {
-        throw new HTTPError({
-            status: 404
-        });
+    if (mwUtil.isNoCacheRequest(req)) {
+        throw new HTTPError({ status: 404 });
     }
 
     var rp = req.params;

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -362,7 +362,7 @@ PRS.prototype.getTitleRevision = function(hyper, req) {
             return self.fetchAndStoreMWRevision(hyper, req);
         });
     } else if (!rp.revision) {
-        if (req.headers && /no-cache/.test(req.headers['cache-control'])) {
+        if (mwUtil.isNoCacheRequest(req)) {
             revisionRequest = self.fetchAndStoreMWRevision(hyper, req)
             .catch({ status: 404 }, function(e) {
                 return getLatestTitleRevision()
@@ -506,7 +506,7 @@ PRS.prototype.getRevision = function(hyper, req) {
             }
         });
     }
-    if (req.headers && /no-cache/.test(req.headers['cache-control'])) {
+    if (mwUtil.isNoCacheRequest(req)) {
         // Ask the MW API directly and
         // store and return its result
         return this.fetchAndStoreMWRevision(hyper, req);

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -103,6 +103,7 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'application/json');
+            assert.deepEqual(res.headers['cache-control'], 'no-cache');
             var body = res.body;
             if (!body['mp-sister'] || typeof body['mp-sister'] !== 'string'
                     || !body['mp-lang']) {
@@ -118,6 +119,7 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'application/json');
+            assert.deepEqual(res.headers['cache-control'], 'no-cache');
             var body = res.body;
             if (!body['mp-sister'] || typeof body['mp-sister'] !== 'string') {
                 throw new Error('Missing section content!');
@@ -138,6 +140,7 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'application/json');
+            assert.deepEqual(res.headers['cache-control'], 'no-cache');
             var body = res.body;
             if (!body['mp-sister'] || typeof body['mp-sister'] !== 'string'
             || !body['mp-lang']) {

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -266,6 +266,7 @@ describe('on-demand generation of html and data-parsoid', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['cache-control'], 'no-cache');
             assert.deepEqual(/Second Revision/.test(res.body.mwAQ), true);
         })
     });


### PR DESCRIPTION
We shouldn't cache responses of the requests with ?sections, because we can't purge them.

Also, refactored the sections handling by moving it to a separate method. 

cc @wikimedia/services 