### PR TITLE
Update metrics endpoints documentation for project

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -47,7 +47,7 @@ paths:
       parameters:
         - name: project
           in: path
-          description: The name of any Wikimedia project formatted like {language code}.{project name}, for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped off.  For projects like commons without language codes, use commons.wikimedia
+          description: If you want to filter by project, use the name of any Wikimedia project formatted like {language code}.{project name}, for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped off. For projects like commons without language codes, use commons.wikimedia. For projects like www.mediawiki.org, you can use that full string, or just use mediawiki or mediawiki.org. If you are interested in all pageviews regardless of project, use all-projects.
           type: string
           required: true
         - name: access
@@ -111,7 +111,7 @@ paths:
       parameters:
         - name: project
           in: path
-          description: If you want to filter by project, use the name of any Wikimedia project formatted like {language code}.{project name}, for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped off. For projects like commons without language codes, use commons.wikimedia. If you are interested in all pageviews regardless of project, use all-projects
+          description: If you want to filter by project, use the name of any Wikimedia project formatted like {language code}.{project name}, for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped off. For projects like commons without language codes, use commons.wikimedia. For projects like www.mediawiki.org, you can use that full string, or just use mediawiki or mediawiki.org. If you are interested in all pageviews regardless of project, use all-projects.
           type: string
           required: true
         - name: access
@@ -193,7 +193,7 @@ paths:
       parameters:
         - name: project
           in: path
-          description: The name of any Wikimedia project formatted like {language code}.{project name}, for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped off.  For projects like commons without language codes, use commons.wikimedia
+          description: If you want to filter by project, use the name of any Wikimedia project formatted like {language code}.{project name}, for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped off. For projects like commons without language codes, use commons.wikimedia. For projects like www.mediawiki.org, you can use that full string, or just use mediawiki or mediawiki.org. If you are interested in all pageviews regardless of project, use all-projects.
           type: string
           required: true
         - name: access
@@ -245,7 +245,7 @@ paths:
       parameters:
         - name: project
           in: path
-          description: The name of any Wikimedia project formatted like {language code}.{project name}, for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped off. For projects like commons without language codes, use commons.wikimedia
+          description: If you want to filter by project, use the name of any Wikimedia project formatted like {language code}.{project name}, for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped off. For projects like commons without language codes, use commons.wikimedia. For projects like www.mediawiki.org, you can use that full string, or just use mediawiki or mediawiki.org. If you are interested in all pageviews regardless of project, use all-projects.
           type: string
           required: true
         - name: access-site


### PR DESCRIPTION
AQS now strips trailing www. and ending .org from project names, this patch
updates the documentation accordingly.