### PR TITLE
Optimize html fetching for redirect check, enable mobile service tests

### DIFF
--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -26,27 +26,46 @@ module.exports = function(hyper, req, next, options, specInfo) {
             var htmlPath = [rp.domain, 'sys', 'parsoid', 'html', rp[titleName]];
             if (rp.revision) {
                 htmlPath.push('' + rp.revision);
+                if (rp.tid) {
+                    htmlPath.push('' + rp.tid);
+                }
             }
-            return P.props({
-                content: next(hyper, req),
-                html: hyper.get({ uri: new URI(htmlPath) })
+            return hyper.get({
+                uri: new URI(htmlPath),
+                headers: req.headers
             })
-            .then(function(responses) {
-                var html = responses.html.body;
-                var redirectMatch = redirectRegEx.exec(html);
+            .then(function(html) {
+                var redirectMatch = redirectRegEx.exec(html.body);
                 if (redirectMatch) {
                     var newParams = Object.assign({}, rp);
                     newParams[titleName] = decodeURIComponent(entities.decodeXML(redirectMatch[1]));
                     var location = mwUtil.createRelativeTitleRedirect(specInfo.path,
-                            req, newParams, titleName);
-                    return {
-                        status: 302,
-                        headers: Object.assign(responses.content.headers, {
-                            location: location,
-                            'cache-control': options.redirect_cache_control || 'no-cache'
-                        }),
-                        body: responses.content.body
-                    };
+                        req, newParams, titleName);
+
+                    var contentPromise;
+                    if (options.attach_body_to_redirect) {
+                        if (specInfo.path.indexOf('html') !== -1) {
+                            contentPromise = P.resolve(html);
+                        } else {
+                            contentPromise = next(hyper, req);
+                        }
+                    } else {
+                        contentPromise = P.resolve({
+                            headers: {
+                                etag: html.headers.etag
+                            }
+                        });
+                    }
+                    return contentPromise.then(function(content) {
+                        return {
+                            status: 302,
+                            headers: Object.assign(content.headers, {
+                                location: location,
+                                'cache-control': options.redirect_cache_control || 'no-cache'
+                            }),
+                            body: content.body
+                        };
+                    });
                 } else {
                     return next(hyper, req);
                 }

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -183,6 +183,7 @@ paths:
       - path: ./lib/revision_table_access_check_filter.js
         options:
           redirect_cache_control: '{{options.purged_cache_control}}'
+          attach_body_to_redirect: true
     get:
       tags:
         - Page content
@@ -432,6 +433,7 @@ paths:
       - path: ./lib/revision_table_access_check_filter.js
         options:
           redirect_cache_control: '{{options.purged_cache_control}}'
+          attach_body_to_redirect: true
     get:
       tags:
         - Page content
@@ -534,6 +536,7 @@ paths:
       - path: ./lib/revision_table_access_check_filter.js
         options:
           redirect_cache_control: '{{options.purged_cache_control}}'
+          attach_body_to_redirect: true
     get:
       tags:
         - Page content


### PR DESCRIPTION
1. We only need to attach body to redirects where it makes sense - for HTML and data-parsoid.
2. Enable some mobile-related tests
3. Optimise content fetch in a filter - don't fetch html twice

cc @wikimedia/services 