### PR TITLE
Don't include revisions and tids to a redirect target

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -252,10 +252,7 @@ mwUtil.createRelativeTitleRedirect = function(path, req, newReqParams, titlePara
     var backString = Array.apply(null, { length: pathSuffixCount }).map(function() {
         return '../';
     }).join('');
-    var pathPatternAfterTitle = path.substring(path.indexOf('{title}') - 1);
-    return backString
-        + new URI(pathPatternAfterTitle, newReqParams, true).toString().substr(1)
-        + mwUtil.getQueryString(req);
+    return backString + encodeURIComponent(newReqParams.title) + mwUtil.getQueryString(req);
 };
 
 module.exports = mwUtil;

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -83,8 +83,7 @@ describe('Redirects', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 302);
-            assert.deepEqual(res.headers.location, '../../User%3APchelolo%2FRedirect_Target_%25/'
-                + renderInfo.rev + '/' + renderInfo.tid);
+            assert.deepEqual(res.headers.location, '../../User%3APchelolo%2FRedirect_Target_%25');
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-type'], server.config.conf.test.content_types['data-parsoid']);
             assert.deepEqual(Object.keys(res.body).length > 0, true);
@@ -138,7 +137,7 @@ describe('Redirects', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 302);
-            assert.deepEqual(res.headers.location, '../User%3APchelolo%2FRedirect_Target_%25/331630');
+            assert.deepEqual(res.headers.location, '../User%3APchelolo%2FRedirect_Target_%25');
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.body.length > 0, true);
             assert.deepEqual(/Redirect Target/.test(res.body.toString()), false);


### PR DESCRIPTION
Bug: when constructing redirect targets we take into account the revision number and tid etc. But the redirect target page doesn't have that revision, so redirected requests with a revision number always result in 404.

cc @wikimedia/services 