### PR TITLE
Don't redirect for update requests

### DIFF
--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -41,9 +41,11 @@ module.exports = function(hyper, req, next, options, specInfo) {
             rp.title = resultText;
             if (req.method === 'post' // Don't redirect POSTs as it's not cached anyway
                     || normalizeResult.getNamespace().isUser()
-                    || normalizeResult.getNamespace().isUserTalk()) {
+                    || normalizeResult.getNamespace().isUserTalk()
+                    || mwUtil.isNoCacheRequest(req)) {
                 // Due to gender variations of User and User_Talk namespaces in some langs
                 // use canonical name for storage, but don't redirect. Don't cache either
+                // For no-cache update requests we don't want to redirect in general
                 return next(hyper, req)
                 .then(function(res) {
                     if (res) {
@@ -66,7 +68,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
             return next(hyper, req).catch({ status: 404 }, function(e) {
                 return mwUtil.getSiteInfo(hyper, req)
                 .then(function(siteInfo) {
-                    if (siteInfo.sharedRepoRootURI) {
+                    if (siteInfo.sharedRepoRootURI && !mwUtil.isNoCacheRequest(req)) {
                         // It's a file page and it might be in the shared repo.
                         // Redirect.
                         var redirectPath = req.uri + '';

--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -22,7 +22,9 @@ module.exports = function(hyper, req, next, options, specInfo) {
     .then(function(res) {
         var revision = res.body.items[0];
 
-        if (revision.redirect && req.query.redirect !== false) {
+        if (revision.redirect
+                && req.query.redirect !== false
+                && !mwUtil.isNoCacheRequest(req)) {
             var htmlPath = [rp.domain, 'sys', 'parsoid', 'html', rp[titleName]];
             if (rp.revision) {
                 htmlPath.push('' + rp.revision);

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -310,40 +310,6 @@ describe('item requests', function() {
     //        assert.deepEqual(res.status, 200);
     //    });
     //});
-
-    it('should redirect to commons for missing file pages', function() {
-        return preq.get({
-            uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg'
-        })
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['content-location'],
-                'https://commons.wikimedia.org/api/rest_v1/page/html/File%3AThinkingMan_Rodin.jpg');
-        });
-    });
-
-    it('should not redirect if file is missing on commons', function() {
-        return preq.get({
-            uri: server.config.hostPort +
-                '/commons.wikimedia.org/v1/html/File:Some_File_That_Does_Not_Exist.jpg'
-        })
-        .then(function() {
-            throw new Error('Error should be thrown');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-        });
-    });
-
-    it('should result in 404 if + is normalized by MW API', function() {
-        return preq.get({
-            uri: server.config.labsBucketURL + '/html/User:Pchelolo%2FOnDemand+Test'
-        })
-        .then(function() {
-            throw new Error('Error should be thrown');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-        });
-    });
 });
 
 describe('page content access', function() {
@@ -399,17 +365,6 @@ describe('page content access', function() {
         }, function(e) {
             assert.deepEqual(e.status, 400);
             assert.deepEqual(e.body.detail, 'title-invalid-characters');
-        });
-    });
-
-    it('Should redirect to a normalized version of a title', function() {
-        return preq.get({
-            uri: server.config.bucketURL + '/html/Main%20Page?test=mwAQ'
-        })
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['content-location'], server.config.bucketURL
-                + '/html/Main_Page?test=mwAQ');
         });
     });
 });


### PR DESCRIPTION
We generically don't want to redirect for no-cache requests to avoid change prop following those redirects and updating what it actually should not. Also moved redirect tests around to make them all end up in one group. Removed duplicated tests.

cc @wikimedia/services 