### PR TITLE
Remove dependency updates and release v0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {

--- a/test/features/pagecontent/access_checks.js
+++ b/test/features/pagecontent/access_checks.js
@@ -44,18 +44,6 @@ describe('Access checks', function() {
                     }
                 }
             }
-        })
-        // TEMP: summary also needs update		
-        .post('').reply(200, {
-            'batchcomplete': '',
-            'query': {
-                'pages': {
-                    '11089416': {
-                        'title': title,
-                        'extract': 'test'
-                    }
-                }
-            }
         });
     }
 
@@ -83,20 +71,14 @@ describe('Access checks', function() {
             return preq.get({
                 uri: server.config.bucketURL + '/html/'
                         + encodeURIComponent(deletedPageTitle)
-                        + '/' + deletedPageOlderRevision,
-                headers: {
-                    'cache-control': 'no-cache'
-                }
+                        + '/' + deletedPageOlderRevision
             })
             .then(function(res) {
                 assert.deepEqual(res.status, 200);
                 return preq.get({
                     uri: server.config.bucketURL + '/html/'
                             + encodeURIComponent(deletedPageTitle)
-                            + '/' + deletedPageRevision,
-                    headers: {
-                        'cache-control': 'no-cache'
-                    }
+                            + '/' + deletedPageRevision
                 });
             })
             .then(function (res) {


### PR DESCRIPTION
We will be relying on the change-propagation service from now on.

Note: depends on change-prop clearing the backlog and https://gerrit.wikimedia.org/r/#/c/286847/

cc @wikimedia/services 