### PR TITLE
Don't forward request headers in redirect check

### DIFF
--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -34,13 +34,6 @@ module.exports = function(hyper, req, next, options, specInfo) {
             }
             return hyper.get({
                 uri: new URI(htmlPath),
-                /* TODO FIXME TEMP
-                 * This removes the cache-control header when requesting the HTML
-                 * for redirect inspection. However, this is a temporary hack in
-                 * order to avoid re-renders for no-cache requests. We need to
-                 * implement a proper header inspection routine.
-                 */
-                headers: Object.assign({}, req.headers, { 'cache-control': undefined })
             })
             .then(function(html) {
                 var redirectMatch = redirectRegEx.exec(html.body);


### PR DESCRIPTION
Request headers are not needed for this request. Follow-up from #604.