### PR TITLE
By default, preserve all parameters in relative redirects

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -244,10 +244,10 @@ mwUtil.getQueryString = function(req) {
  * @param {string} path, the path pattern from specInfo.
  * @param {hyper.request} req, the request
  * @param {object} options, with possible parameters:
- *    - {object} newReqParams, use these parameters instead of the original
- *    request parameters.
- *    - {string} titleParamName, the name of the title parameter.
- *    - {boolean} dropPathAfterTitle, indicating that the redirect should drop
+ * @param {object} options.newReqParams, use these parameters instead of the
+ * original request parameters.
+ * @param {string} options.titleParamName, the name of the title parameter.
+ * @param {boolean} options.dropPathAfterTitle, indicating that the redirect should drop
  *    the path after the title parameter. Typically used for redirects to
  *    another title, where revision & tid would no longer match.
  * @return {string} Location header value containing a relative redirect path.

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -238,9 +238,24 @@ mwUtil.getQueryString = function(req) {
     return '';
 };
 
-mwUtil.createRelativeTitleRedirect = function(path, req, newReqParams, titleParamName) {
-    titleParamName = titleParamName || 'title';
-    newReqParams = newReqParams || req.params;
+/**
+ * Create a `location` header value for a relative redirect.
+ *
+ * @param {string} path, the path pattern from specInfo.
+ * @param {hyper.request} req, the request
+ * @param {object} options, with possible parameters:
+ *    - {object} newReqParams, use these parameters instead of the original
+ *    request parameters.
+ *    - {string} titleParamName, the name of the title parameter.
+ *    - {boolean} dropPathAfterTitle, indicating that the redirect should drop
+ *    the path after the title parameter. Typically used for redirects to
+ *    another title, where revision & tid would no longer match.
+ * @return {string} Location header value containing a relative redirect path.
+ */
+mwUtil.createRelativeTitleRedirect = function(path, req, options) {
+    options = options || {};
+    var titleParamName = options.titleParamName || 'title';
+    var newReqParams = options.newReqParams || req.params;
     var pathBeforeTitle = path.substring(0, path.indexOf('{' + titleParamName + '}'));
     pathBeforeTitle = new URI(pathBeforeTitle, req.params, true).toString();
     // Omit the domain prefix as it could be wrong for node shared between domains
@@ -252,7 +267,14 @@ mwUtil.createRelativeTitleRedirect = function(path, req, newReqParams, titlePara
     var backString = Array.apply(null, { length: pathSuffixCount }).map(function() {
         return '../';
     }).join('');
-    return backString + encodeURIComponent(newReqParams.title) + mwUtil.getQueryString(req);
+    if (!options.dropPathAfterTitle) {
+        var pathPatternAfterTitle = path.substring(path.indexOf('{title}') - 1);
+        return backString
+            + new URI(pathPatternAfterTitle, newReqParams, true).toString().substr(1)
+            + mwUtil.getQueryString(req);
+    } else {
+        return backString + encodeURIComponent(newReqParams.title) + mwUtil.getQueryString(req);
+    }
 };
 
 module.exports = mwUtil;

--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -40,8 +40,11 @@ module.exports = function(hyper, req, next, options, specInfo) {
                 if (redirectMatch) {
                     var newParams = Object.assign({}, rp);
                     newParams[titleName] = decodeURIComponent(entities.decodeXML(redirectMatch[1]));
-                    var location = mwUtil.createRelativeTitleRedirect(specInfo.path,
-                        req, newParams, titleName);
+                    var location = mwUtil.createRelativeTitleRedirect(specInfo.path, req, {
+                        newReqParams: newParams,
+                        titleParamName: titleName,
+                        dropPathAfterTitle: true,
+                    });
 
                     var contentPromise;
                     if (options.attach_body_to_redirect) {

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -23,6 +23,28 @@ describe('Redirects', function() {
         });
     });
 
+    it('should preserve parameters while redirecting to a normalized version of a title', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/html/Main%20Page/1234?test=mwAQ',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 301);
+            assert.deepEqual(res.headers['location'], '../Main_Page/1234?test=mwAQ');
+        });
+    });
+
+    it('should preserve parameters while redirecting to a normalized version of a title, #2', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/html/Main%20Page/',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 301);
+            assert.deepEqual(res.headers['location'], '../Main_Page/');
+        });
+    });
+
     it('should not redirect to a normalized version of a title, no-cache', function() {
         return preq.get({
             uri: server.config.bucketURL + '/html/Main%20Page?test=mwAQ',


### PR DESCRIPTION
Relative redirects are used for different use cases, some of which
require the preservation of all parameters (ex: title normalization), and
others do not. Before eec5180, we defaulted to full preservation, and have
since switched to no preservation. As a result, normalized redirects for
anything but wikitext redirects are currently not fully preserving all
parameters.

This patch makes the path stripping optional with a boolean option. To
generally reduce the number of parameters, an `options` object is introduced.