### PR TITLE
Do not emit an event if it will cause a loop

### DIFF
--- a/sys/events.js
+++ b/sys/events.js
@@ -86,10 +86,10 @@ EventService.prototype._emit = function(hyper, req) {
             })
             .filter(function(event) { return !!event; });
 
-            // Change-propagation will set up the x-rerender-reason header, indicating
+            // Change-propagation will set up the x-triggered-by header, indicating
             // the event which caused the rerender. In case RESTBase is about to emit
             // the same event, it will cause a rerender loop. So, log an error and skip
-            // an event.
+            // the event.
             var triggeredBy = req.headers && req.headers['x-triggered-by']
                 || hyper._rootReq && hyper._rootReq['x-triggered-by'];
             if (triggeredBy) {

--- a/sys/events.js
+++ b/sys/events.js
@@ -90,11 +90,13 @@ EventService.prototype._emit = function(hyper, req) {
             // the event which caused the rerender. In case RESTBase is about to emit
             // the same event, it will cause a rerender loop. So, log an error and skip
             // an event.
-            var reRenderReason = req.headers && req.headers['x-rerender-reason']
-                || hyper._rootReq && hyper._rootReq['x-rerender-reason'];
-            if (reRenderReason) {
+            var triggeredBy = req.headers && req.headers['x-triggered-by']
+                || hyper._rootReq && hyper._rootReq['x-triggered-by'];
+            if (triggeredBy) {
+                triggeredBy = triggeredBy.replace(/https?:/g, '');
                 events = events.filter(function(event) {
-                    if (reRenderReason.replace(/^https?:/, '') === event.meta.uri.replace(/^https?:/, '')) {
+                    var eventId = event.meta.topic + ':' + event.meta.uri.replace(/^https?:/, '');
+                    if (triggeredBy.indexOf(eventId) !== -1) {
                         hyper.log('error/events/rerender_loop', {
                             message: 'Rerender loop detected',
                             event: event

--- a/test/features/events/events.js
+++ b/test/features/events/events.js
@@ -105,54 +105,51 @@ describe('Change event emitting', function() {
         });
     });
 
-    it('should send correct events to the service', function(done) {
-        var eventLogging = null;
-
-        function really_done(e) {
-            if (eventLogging) {
-                eventLogging.close();
+    function createEventLogging(done) {
+        var eventLogging = http.createServer(function(request) {
+            try {
+                assert.deepEqual(request.method, 'POST');
+                var postData;
+                request.on('data', function(data) {
+                    postData = postData ? Buffer.concat(postData, data) : data;
+                });
+                request.on('end', function() {
+                    try {
+                        var events = JSON.parse(postData.toString());
+                        assert.deepEqual(events.length, 1);
+                        var event = events[0];
+                        assert.deepEqual(event.meta.domain, 'en.wikipedia.org');
+                        assert.deepEqual(!!new Date(event.meta.dt), true);
+                        assert.deepEqual(uuid.test(event.meta.id), true);
+                        assert.deepEqual(!!event.meta.request_id, true);
+                        assert.deepEqual(event.meta.topic, 'resource_change');
+                        assert.deepEqual(event.meta.uri, 'http://en.wikipedia.org/wiki/User:Pchelolo');
+                        assert.deepEqual(event.tags, ['test', 'restbase']);
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                });
+            } catch (e) {
                 done(e);
             }
-            eventLogging = null;
+        });
+        eventLogging.on('error', done);
+        eventLogging.listen(8085);
+        return eventLogging;
+    }
+    
+   
+
+    it('should send correct events to the service', function(done) {
+        var eventLogging;
+
+        function really_done(e) {
+            if (eventLogging) eventLogging.close();
+            done(e)
         }
 
-        try {
-            eventLogging = http.createServer(function(request, response) {
-                try {
-                    assert.deepEqual(request.method, 'POST');
-                    var postData;
-                    request.on('data', function(data) {
-                        postData = postData ? Buffer.concat(postData, data) : data;
-                    });
-                    request.on('end', function() {
-                        try {
-                            var events = JSON.parse(postData.toString());
-                            assert.deepEqual(events.length, 1);
-                            var event = events[0];
-                            assert.deepEqual(event.meta.domain, 'en.wikipedia.org');
-                            assert.deepEqual(!!new Date(event.meta.dt), true);
-                            assert.deepEqual(uuid.test(event.meta.id), true);
-                            assert.deepEqual(!!event.meta.request_id, true);
-                            assert.deepEqual(event.meta.topic, 'resource_change');
-                            assert.deepEqual(event.meta.uri, 'http://en.wikipedia.org/wiki/User:Pchelolo');
-                            assert.deepEqual(event.tags, ['test', 'restbase']);
-                            really_done();
-                            response.writeHead(200);
-                            response.end();
-                        } catch (e) {
-                            really_done(e);
-                        }
-                    });
-                } catch (e) {
-                    really_done(e);
-                }
-            });
-            eventLogging.on('error', done);
-            eventLogging.listen(8085);
-        } catch (e) {
-            really_done(e);
-        }
-
+        eventLogging = createEventLogging(really_done);
         return preq.post({
             uri: server.config.baseURL + '/events_emit/',
             headers: {
@@ -175,4 +172,41 @@ describe('Change event emitting', function() {
             really_done(new Error('HTTP event server timeout!'));
         });
     });
+
+    it('Should skip event if it will cause a loop', function(done) {
+        var eventLogging;
+
+        function really_done(e) {
+            if (eventLogging) eventLogging.close();
+            done(e)
+        }
+
+        eventLogging = createEventLogging(really_done);
+
+        return preq.post({
+            uri: server.config.baseURL + '/events_emit/',
+            headers: {
+                'content-type': 'application/json',
+                'x-rerender-reason': '//en.wikipedia.org/wiki/Prohibited'
+            },
+            body: [
+                {
+                    meta: {
+                        uri: '//en.wikipedia.org/wiki/Prohibited'
+                    },
+                    tags: ['test']
+                },
+                {
+                    meta: {
+                        uri: '//en.wikipedia.org/wiki/User:Pchelolo'
+                    },
+                    tags: ['test']
+                }
+            ]
+        })
+        .delay(10000)
+        .finally(function() {
+            really_done(new Error('HTTP event server timeout!'));
+        });
+    })
 });

--- a/test/features/events/events.js
+++ b/test/features/events/events.js
@@ -187,7 +187,7 @@ describe('Change event emitting', function() {
             uri: server.config.baseURL + '/events_emit/',
             headers: {
                 'content-type': 'application/json',
-                'x-rerender-reason': '//en.wikipedia.org/wiki/Prohibited'
+                'x-triggered-by': 'resource_change:https://en.wikipedia.org/wiki/Prohibited'
             },
             body: [
                 {


### PR DESCRIPTION
After [an outage](https://phabricator.wikimedia.org/T134537) we've discovered, that when change-prop is introduced, some bugs playing together might cause rerender loops in RESTBase, when change-prop serenaders some content, and it creates the same event that caused a rerender to happen. 

This PR adds some protection against it - change-prop will add the `x-rerender-reason` header (name subject to a bike shed) to a RESTBase request, containing an original event URI (it's enough as RB only emits `resource_change` events). If we are about to emit the same event causing a cycle - log an error and drop the event.

Questions:
1. What to use as an event hash. I think URI is enough, but suggestions are welcome
2. This doesn't prevent multiple-step loops (event1 causes rerender1 causes event2 causes rerender2 causes event1). Do we want to support cases like that? As a generic way of preventing multi-step loops, we've had an idea to add something like an XFF header to the event meta to indicate the whole sequence of events that caused some event to fire. This could be useful for debugging as well as to prevent multi-step loops

PS: need to add this header in change-propagation.

cc @wikimedia/services 