### PR TITLE
Start testing rate limiting on transform end points

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -118,3 +118,10 @@ metrics:
   host: localhost
   port: 8125
   batch: true
+
+ratelimiter:
+  type: kademlia
+  # Cluster nodes
+  seeds:
+    # Port 3050 used by default
+    - 127.0.0.1

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -88,6 +88,7 @@ paths:
             limits:
               internal: 10
               external: 5
+            log_only: true
 
       x-request-handler:
         - get_from_backend:
@@ -174,6 +175,7 @@ paths:
             limits:
               internal: 10
               external: 5
+            log_only: true
 
       x-request-handler:
         - get_from_backend:
@@ -345,6 +347,7 @@ paths:
             limits:
               internal: 10
               external: 5
+            log_only: true
 
       x-request-handler:
         - get_from_backend:

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -80,6 +80,15 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 10
+              external: 5
+
       x-request-handler:
         - get_from_backend:
             request:
@@ -157,6 +166,15 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 10
+              external: 5
+
       x-request-handler:
         - get_from_backend:
             request:
@@ -319,6 +337,15 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 10
+              external: 5
+
       x-request-handler:
         - get_from_backend:
             request:


### PR DESCRIPTION
Since March, we have a basic rate limit filter in the hyperswitch repository.
This is currently only logging when rates are exceeded, so that we can start
by verifying the basic operation without a risk of aborting requests
unnecessarily.

This patch enables this filter with conservative limits on the un-cached
`transform` end points. By deploying this change (and a puppet change to
configure the rate limiter), we can move forward by testing rate limiting in
staging & production.