### PR TITLE
Limit the maximum rate of requests per IP

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -92,10 +92,22 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 100
+              external: 100
+            log_only: true
       x-request-handler:
         - get_from_backend:
             request:
               uri: '{{options.host}}/pageviews/per-article/{project}/{access}/{agent}/{article}/{granularity}/{start}/{end}'
+              headers:
+                cache-control: '{{cache-control}}'
+                if-unmodified-since: '{{if-unmodified-since}}'
+                x-client-ip: '{{x-client-ip}}'
       x-monitor: false
 
   /pageviews/aggregate/{project}/{access}/{agent}/{granularity}/{start}/{end}:
@@ -151,10 +163,22 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 100
+              external: 100
+            log_only: true
       x-request-handler:
         - get_from_backend:
             request:
               uri: '{{options.host}}/pageviews/aggregate/{project}/{access}/{agent}/{granularity}/{start}/{end}'
+              headers:
+                cache-control: '{{cache-control}}'
+                if-unmodified-since: '{{if-unmodified-since}}'
+                x-client-ip: '{{x-client-ip}}'
       x-monitor: true
       x-amples:
         - title: Get aggregate page views
@@ -226,10 +250,22 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 100
+              external: 100
+            log_only: true
       x-request-handler:
         - get_from_backend:
             request:
               uri: '{{options.host}}/pageviews/top/{project}/{access}/{year}/{month}/{day}'
+              headers:
+                cache-control: '{{cache-control}}'
+                if-unmodified-since: '{{if-unmodified-since}}'
+                x-client-ip: '{{x-client-ip}}'
       x-monitor: false
 
   /unique-devices/{project}/{access-site}/{granularity}/{start}/{end}:
@@ -279,10 +315,22 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 100
+              external: 100
+            log_only: true
       x-request-handler:
         - get_from_backend:
             request:
               uri: '{{options.host}}/unique-devices/{project}/{access-site}/{granularity}/{start}/{end}'
+              headers:
+                cache-control: '{{cache-control}}'
+                if-unmodified-since: '{{if-unmodified-since}}'
+                x-client-ip: '{{x-client-ip}}'
       x-monitor: false
 
 definitions:

--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -105,8 +105,6 @@ paths:
             request:
               uri: '{{options.host}}/pageviews/per-article/{project}/{access}/{agent}/{article}/{granularity}/{start}/{end}'
               headers:
-                cache-control: '{{cache-control}}'
-                if-unmodified-since: '{{if-unmodified-since}}'
                 x-client-ip: '{{x-client-ip}}'
       x-monitor: false
 
@@ -176,8 +174,6 @@ paths:
             request:
               uri: '{{options.host}}/pageviews/aggregate/{project}/{access}/{agent}/{granularity}/{start}/{end}'
               headers:
-                cache-control: '{{cache-control}}'
-                if-unmodified-since: '{{if-unmodified-since}}'
                 x-client-ip: '{{x-client-ip}}'
       x-monitor: true
       x-amples:
@@ -263,8 +259,6 @@ paths:
             request:
               uri: '{{options.host}}/pageviews/top/{project}/{access}/{year}/{month}/{day}'
               headers:
-                cache-control: '{{cache-control}}'
-                if-unmodified-since: '{{if-unmodified-since}}'
                 x-client-ip: '{{x-client-ip}}'
       x-monitor: false
 
@@ -328,8 +322,6 @@ paths:
             request:
               uri: '{{options.host}}/unique-devices/{project}/{access-site}/{granularity}/{start}/{end}'
               headers:
-                cache-control: '{{cache-control}}'
-                if-unmodified-since: '{{if-unmodified-since}}'
                 x-client-ip: '{{x-client-ip}}'
       x-monitor: false
 


### PR DESCRIPTION
Configure the metrics endpoints to filter out requests that happen more
than X times per second from the same IP to the same endpoint.  The
exact number is not decided yet but I'm tentatively setting it at 100.

Right now, the filter is just logging if the limit is exceeded so we can
get a feel for how often this happens.  We may decide to make it a real
filter as part of this PR or later.

https://phabricator.wikimedia.org/T135240
Bug: T135240