### PR TITLE
Removed summary and definition updates

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -105,34 +105,6 @@ PSP._dependenciesUpdate = function(hyper, req) {
     .then(function(siteInfo) {
         var rp = req.params;
         var updates = [];
-        var summaryPromise = P.resolve();
-        if (rp.domain.indexOf('wiktionary') === -1) {
-            // non-wiktionary, update summary
-            summaryPromise = hyper.get({
-                uri: new URI([rp.domain, 'v1', 'page', 'summary', rp.title]),
-                headers: {
-                    'cache-control': 'no-cache'
-                }
-            });
-        } else if (/en.wiktionary/.test(rp.domain)) {
-            if (Title.newFromText(rp.title, siteInfo).getNamespace().isMain()) {
-                // wiktionary update, we are interested only in en.wiktionary
-                // and only in Main namespaces
-                summaryPromise = hyper.get({
-                    uri: new URI([rp.domain, 'v1', 'page', 'definition', rp.title]),
-                    headers: {
-                        'cache-control': 'no-cache'
-                    }
-                });
-            }
-        }
-        summaryPromise = summaryPromise.catch(function(e) {
-            if (e.status !== 501 && e.status !== 404) {
-                hyper.log('error/' + rp.domain.indexOf('wiktionary') < 0 ?
-                        'summary' : 'definition', e);
-            }
-        });
-        updates.push(summaryPromise);
 
         // Emit resource change events
         var publicBaseURI = '//' + rp.domain + '/api/rest_v1/page';

--- a/test/features/pagecontent/access_checks.js
+++ b/test/features/pagecontent/access_checks.js
@@ -44,18 +44,6 @@ describe('Access checks', function() {
                     }
                 }
             }
-        })
-        // TEMP: summary also needs update		
-        .post('').reply(200, {
-            'batchcomplete': '',
-            'query': {
-                'pages': {
-                    '11089416': {
-                        'title': title,
-                        'extract': 'test'
-                    }
-                }
-            }
         });
     }
 


### PR DESCRIPTION
We're going to test whether `summary` and `definition` updates from change-prop are reaching RESTBase. In order to do so - delete the built-in updates.

cc @wikimedia/services 