### PR TITLE
Made revision parameter an integer

### DIFF
--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -452,7 +452,7 @@ paths:
         - name: revision
           in: path
           description: The revision
-          type: string
+          type: integer
           required: true
         - name: tid
           in: path


### PR DESCRIPTION
For some reason `revision` parameter was documented as `string`, making validation incorrect for this endpoint.

cc @wikimedia/services 