### PR TITLE
Lowering throttling limits to 10 req/sec

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -97,8 +97,8 @@ paths:
           name: ratelimit_route
           options:
             limits:
-              internal: 100
-              external: 100
+              internal: 10
+              external: 10
             log_only: true
       x-request-handler:
         - get_from_backend:


### PR DESCRIPTION
At this time we want to limit requests per IP when load exceeds
30 requests per sec. This limit is enforced per node for the whole aqs
cluster which has three machines, thus setting to 10.