### PR TITLE
Document rate limits for pageview API end points

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -20,7 +20,8 @@ paths:
       description: |
         This is the root of all pageview data endpoints.  The list of paths that this returns includes ways to query by article, project, top articles, etc.  If browsing the interactive documentation, see the specifics for each endpoint below.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+        - Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+        - Rate limit: 10 req/s
       produces:
         - application/json
       responses:
@@ -40,8 +41,10 @@ paths:
         - Pageviews data
       summary: Get pageview counts for a page.
       description: |
-        Given a Mediawiki article and a date range, returns a daily timeseries of its pageview counts. You can also filter by access method and/or agent type
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Given a Mediawiki article and a date range, returns a daily timeseries of its pageview counts. You can also filter by access method and/or agent type.
+
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 10 req/s
       produces:
         - application/json
       parameters:
@@ -114,8 +117,10 @@ paths:
         - Pageviews data
       summary: Get pageview counts for a project.
       description: |
-        Given a date range, returns a timeseries of pageview counts. You can filter by project, access method and/or agent type. You can choose between daily and hourly granularity as well
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Given a date range, returns a timeseries of pageview counts. You can filter by project, access method and/or agent type. You can choose between daily and hourly granularity as well.
+        
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 10 req/s
       produces:
         - application/json
       parameters:
@@ -206,8 +211,10 @@ paths:
         - Pageviews data
       summary: Get the most viewed articles for a project.
       description: |
-        Lists the 1000 most viewed articles for a given project and timespan (month or day). You can filter by access method
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Lists the 1000 most viewed articles for a given project and timespan (month or day). You can filter by access method.
+
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 10 req/s
       produces:
         - application/json
       parameters:
@@ -268,8 +275,10 @@ paths:
         - Unique devices data
       summary: Get unique devices count per project
       description: |
-        Given a project and a date range, returns a timeseries of unique devices counts. You need to specify a project, and can filter by accessed site (mobile or desktop). You can choose between daily and hourly granularity as well
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Given a project and a date range, returns a timeseries of unique devices counts. You need to specify a project, and can filter by accessed site (mobile or desktop). You can choose between daily and hourly granularity as well.
+        
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 10 req/s
       produces:
         - application/json
       parameters:


### PR DESCRIPTION
Add a bullet point clearly documenting the per-entrypoint limits before
enforcing them.