### PR TITLE
Add timestamp to the summary endpoint format

### DIFF
--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -113,9 +113,7 @@ paths:
                 thumbnail: '{{httpsSource(extract.body.items[0].thumbnail)}}'
                 lang: '{{extract.body.items[0].pagelanguagehtmlcode}}'
                 dir: '{{extract.body.items[0].pagelanguagedir}}'
-                # Need to figure out the format of this before we can add it.
-                # See https://phabricator.wikimedia.org/T117082#1787617.
-                #timestamp: '{{request.params.timestamp}}'
+                timestamp: '{{extract.body.items[0].touched}}'
 
         - emit_change_event:
             request:
@@ -207,4 +205,8 @@ definitions:
         type: string
         description: The page language direction code
         example: ltr
+      timestamp:
+        type: string
+        description: The time when the page was last editted in the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format
+        example: '1970-01-01T00:00:00.000Z'
     required: ['title', 'extract', 'lang', 'dir']

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -97,11 +97,12 @@ paths:
               method: post
               uri: /{domain}/sys/action/query
               body:
-                prop: 'info|extracts|pageimages'
+                prop: 'info|extracts|pageimages|revisions'
                 exsentences: 5
                 explaintext: true
                 piprop: 'thumbnail'
                 pithumbsize: 320
+                rvprop: 'timestamp'
                 titles: '{{request.params.title}}'
             response:
               # Define the response to save & return.
@@ -113,7 +114,7 @@ paths:
                 thumbnail: '{{httpsSource(extract.body.items[0].thumbnail)}}'
                 lang: '{{extract.body.items[0].pagelanguagehtmlcode}}'
                 dir: '{{extract.body.items[0].pagelanguagedir}}'
-                timestamp: '{{extract.body.items[0].touched}}'
+                timestamp: '{{extract.body.items[0].revisions[0].timestamp}}'
 
         - emit_change_event:
             request:


### PR DESCRIPTION
On the meeting with the mobile team it's been decided to add a timestamp to the summary output.

cc @wikimedia/services @wikimedia/mobile 