### PR TITLE
Do access checks sequentially

### DIFF
--- a/lib/mediawiki_auth_filter.js
+++ b/lib/mediawiki_auth_filter.js
@@ -65,16 +65,8 @@ module.exports = function(hyper, req, next, options) {
         return next(hyper, req);
     }
 
-    if (req.method === 'get' || req.method === 'head') {
-        return P.all([
-            next(hyper, req),
-            checkPermissions(hyper, req, options.permissions)
-        ])
-        .spread(function(res) { return res; });
-    } else {
-        return checkPermissions(hyper, req, options.permissions)
-        .then(function() {
-            return next(hyper, req);
-        });
-    }
+    return checkPermissions(hyper, req, options.permissions)
+    .then(function() {
+        return next(hyper, req);
+    });
 };

--- a/lib/mediawiki_auth_filter.js
+++ b/lib/mediawiki_auth_filter.js
@@ -68,5 +68,11 @@ module.exports = function(hyper, req, next, options) {
     return checkPermissions(hyper, req, options.permissions)
     .then(function() {
         return next(hyper, req);
+    })
+    .then(function(res) {
+        if (res.headers) {
+            res.headers['cache-control'] = 'no-cache';
+        }
+        return res;
     });
 };

--- a/test/features/security/security.js
+++ b/test/features/security/security.js
@@ -169,35 +169,6 @@ describe('router - security', function() {
                     'rights': ['som right', 'some other right']
                 }
             }
-        })
-        .post('')
-        .reply(200, {
-            'batchcomplete': '',
-            'query': {
-                'pages': {
-                    '11089416': {
-                        'pageid': 11089416,
-                        'ns': 0,
-                        'title': title,
-                        'contentmodel': 'wikitext',
-                        'pagelanguage': 'en',
-                        'touched': '2015-05-22T08:49:39Z',
-                        'lastrevid': 653508365,
-                        'length': 2941,
-                        'revisions': [{
-                            'revid': revision,
-                            'user': 'Chuck Norris',
-                            'userid': 3606755,
-                            'timestamp': '2015-03-25T20:29:50Z',
-                            'size': 2941,
-                            'sha1': 'c47571122e00f28402d2a1b75cff77a22e7bfecd',
-                            'contentmodel': 'wikitext',
-                            'comment': 'Test',
-                            'tags': []
-                        }]
-                    }
-                }
-            }
         });
         return preq.get({
             uri: server.config.secureBucketURL + '/title/' + title,


### PR DESCRIPTION
When we do content request in parallel with an access check, it's obviously good for performance, but it's too risky. API returns very different results for our queries if the access is not granted, and non of our code is ready for that. So, we will very likely hit a ton of 500 errors, may corrupt the storage, or get some completely unpredictable consequences. 

Making all the code in RESTBase behave correctly if access is not granted is a big task, and right now I'm not sure we want to follow that path. Access check is fairly quick, so we're not winning a lot in latency.
If we ever decide we want to speed up private wikis, we can reconsider, but now I don't think it worths the effort.

cc @wikimedia/services 