### PR TITLE
Mathoid: Add purging and the /math/formula/{hash} endpoint

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -100,20 +100,15 @@ var PSP = ParsoidService.prototype;
 // HTML resource_change event emission
 PSP._dependenciesUpdate = function(hyper, req) {
     var rp = req.params;
-    var updates = [];
+    var publicURI = '//' + rp.domain + '/api/rest_v1/page/html/' + encodeURIComponent(rp.title);
 
-    var publicBaseURI = '//' + rp.domain + '/api/rest_v1/page';
-    updates.push(hyper.post({
+    return hyper.post({
         uri: new URI([rp.domain, 'sys', 'events', '']),
         body: [
-            { meta: { uri: publicBaseURI + '/html/' + encodeURIComponent(rp.title) } },
-            { meta: { uri: publicBaseURI + '/html/' + encodeURIComponent(rp.title)
-                + '/' + rp.revision } }
+            { meta: { uri: publicURI } },
+            { meta: { uri: publicURI + '/' + rp.revision } }
         ]
-    }));
-
-    return P.all(updates)
-    .catch(function(e) {
+    }).catch(function(e) {
         hyper.log('warn/bg-updates', e);
     });
 };

--- a/test/features/mathoid.js
+++ b/test/features/mathoid.js
@@ -79,6 +79,16 @@ describe('Mathoid', function() {
         });
     });
 
+    it('gets the formula from storage', function() {
+        return preq.get({
+            uri: uri + '/formula/' + hash
+        }).then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.checkString(res.headers['x-resource-location'], hash);
+            assert.ok(res.body);
+        });
+    });
+
     for (var i = 0; i < formats.length; i++) {
         var format = formats[i];
         it('gets the render in ' + format, function() {

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -71,6 +71,42 @@ paths:
               headers: '{{ request.headers }}'
               body: '{{ request.body }}'
 
+  /math/formula/{hash}:
+    get:
+      tags: ['Math']
+      summary: Get a previously-stored formula
+      description: |
+        Returns the previously-stored formula via `/media/math/check/{type}` for
+        the given hash.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
+      produces:
+        - application/json
+      parameters:
+        - name: hash
+          in: path
+          description: The hash string of the previous POST data
+          type: string
+          required: true
+      responses:
+        '200':
+          description: Information about the checked formula
+        '404':
+          description: Data for the given hash cannot be found
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-monitor: false
+      x-request-handler:
+        - get_from_sys:
+            request:
+              method: get
+              uri: /wikimedia.org/sys/mathoid/formula/{hash}
+              headers: '{{ request.headers }}'
+
   /math/render/{format}/{hash}:
     get:
       tags: ['Math']
@@ -147,7 +183,7 @@ paths:
               body: '{{ check_storage.body }}'
         - postdata:
             request:
-              uri: /wikimedia.org/sys/post_data/mathoid.input/{$.request.params.hash}
+              uri: /wikimedia.org/sys/mathoid/formula/{request.params.hash}
         - mathoid:
             request:
               method: post


### PR DESCRIPTION
This commit adds a new endpoint - /media/math/formula/{hash} - which is
useful for retrieving input formulae when users report problems with
specific renders.

More importantly, `resource_change` events are now being emitted for
changed or new content (for both formulae and their renders), which will
be picked up by Change Propagation and purged from Varnish.

Bug: [T136205](https://phabricator.wikimedia.org/T136205)