### PR TITLE
Use the canonical file namespace whe redirecting to commons

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -95,6 +95,7 @@ spec_root: &spec_root
     # The order is important for tests.
     # Redirect tests require en.wiki being not the first wiki in the list.
     /{domain:en.wikipedia.org}: *default_project
+    /{domain:de.wikipedia.org}: *default_project
     /{domain:test2.wikipedia.org}: *default_project
     /{domain:commons.wikimedia.org}: *default_project
 

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -75,7 +75,8 @@ module.exports = function(hyper, req, next, options, specInfo) {
                             + ':' + normalizeResult.getKey();
                         var redirectPath = req.uri + '';
                         redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2)
-                            .replace(encodeURIComponent(rp.title), encodeURIComponent(commonsTitle));
+                            .replace(encodeURIComponent(rp.title),
+                                encodeURIComponent(commonsTitle));
                         redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1'
                             + redirectPath + mwUtil.getQueryString(req);
                         return {

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -71,8 +71,11 @@ module.exports = function(hyper, req, next, options, specInfo) {
                     if (siteInfo.sharedRepoRootURI && !mwUtil.isNoCacheRequest(req)) {
                         // It's a file page and it might be in the shared repo.
                         // Redirect.
+                        var commonsTitle = normalizeResult.getNamespace().getCanonicalText()
+                            + ':' + normalizeResult.getKey();
                         var redirectPath = req.uri + '';
-                        redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2);
+                        redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2)
+                            .replace(encodeURIComponent(rp.title), encodeURIComponent(commonsTitle));
                         redirectPath = siteInfo.sharedRepoRootURI + '/api/rest_v1'
                             + redirectPath + mwUtil.getQueryString(req);
                         return {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "content-type": "git+https://github.com/wikimedia/content-type#master",
     "hyperswitch": "^0.5.2",
     "jsonwebtoken": "^6.2.0",
-    "mediawiki-title": "^0.4.2",
+    "mediawiki-title": "^0.5.2",
     "entities": "^1.1.1"
   },
   "devDependencies": {

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -68,6 +68,17 @@ describe('Redirects', function() {
         });
     });
 
+    it('should redirect to commons for missing file pages, dewiki', function() {
+        return preq.get({
+            uri: server.config.hostPort + '/de.wikipedia.org/v1/page/html/Datei:Name.jpg'
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-location'],
+                'https://commons.wikimedia.org/api/rest_v1/page/html/File%3AName.jpg');
+        });
+    });
+
     it('should not redirect to commons for missing file pages, redirect=false', function() {
         return preq.get({
             uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg?redirect=false'


### PR DESCRIPTION
Commons doesn't understand localised File namespace names, so replace it with a canonical name.

Bug: https://phabricator.wikimedia.org/T138081
cc @wikimedia/services 