### PR TITLE
Block User:Pentjuuu!.!/sandbox updates

### DIFF
--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -125,6 +125,7 @@ paths:
                         User:Cyberbot_I/Run/Datefixer: true
                         User:Cyberbot_I/adminrights-admins.js: true
                         User:Cyberpower678/Tally: true
+                        User:Pentjuuu!.!/sandbox: true
                       ur.wikipedia.org:
                         نام_مقامات_ایل: true
                         نام_مقامات_ڈی: true


### PR DESCRIPTION
The page is huge and has a ton of null edits which time-out on updates,
so skip it.