### PR TITLE
Promote mobile-sections* endpoints' stability to unstable

### DIFF
--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -15,7 +15,7 @@ paths:
         Retrieve the latest HTML for a page title optimised for viewing with
         native mobile applications. Note that the output is split by sections.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
       parameters:
@@ -92,7 +92,7 @@ paths:
         Retrieve the lead section of the latest HTML for a page title optimised
         for viewing with native mobile applications.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
       parameters:
@@ -155,7 +155,7 @@ paths:
         a page title optimised for viewing with native mobile applications,
         provided as a JSON object containing the sections.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental). Don't rely on this.
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
       parameters:


### PR DESCRIPTION
The `mobile-sections*` endpoints are now being used by the Android
native mobile app, so promote their stability from experimental to
unstable since they will be kept around, but their output format may
still slightly change. Once the output format becomes final, the
stability should be promoted to stable.