### PR TITLE
Switch to Node v4.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
-    - "4.3"
     - "4"
     - "5"
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "swagger-test": "0.3.0"
   },
   "deploy": {
-    "node": "4.3.0",
+    "node": "4.4.6",
     "target": "debian",
     "dependencies": {
       "_all": []


### PR DESCRIPTION
We now have the new LTS version in the repo so it's time to switch to
it.

Bug: [T138561](https://phabricator.wikimedia.org/T138561)