### PR TITLE
Add feed and random public endpoints; release v0.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -49,6 +49,14 @@ paths:
                     response_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/related.js
                   options: '{{options.related}}'
+                - path: v1/random.yaml
+                  options: '{{merge({"random_cache_control": "s-maxage=2, max-age=1"},
+                                options.mobileapps)}}'
+            /feed:
+              x-modules:
+                - path: v1/feed.yaml
+                  options: '{{merge({"feed_cache_control": "s-maxage=60, max-age=30"},
+                                options.mobileapps)}}'
             /transform:
               x-modules:
                 - path: v1/transform.yaml

--- a/test/test_module.yaml
+++ b/test/test_module.yaml
@@ -66,6 +66,7 @@ paths:
                   - title: Retreives parallel content with simple service
                     request:
                       params:
+                        domain: en.wikipedia.org
                         key1: User:GWicke/Date
                         key2: User:GWicke/Date
                     response:

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -81,7 +81,8 @@ paths:
                     pageid: /.+/
                     normalizedtitle: /.+/
               random:
-                title: /.+/
+                items:
+                  - title: /.+/
               news:
                 - story: /.+/
                   links:

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -1,0 +1,105 @@
+# Feed endpoints powered by the MCS
+
+swagger: 2.0
+paths:
+  /featured/{yyyy}/{mm}/{dd}:
+    get:
+      tags:
+        - Feed
+      summary: Aggregated featured content
+      description: |
+        Provides the aggregated feed content for the given date. The endpoint returns
+        the featured article of the day, most read articles for the previous day, news
+        content, a random article, and the featured image and video of the day.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json
+      parameters:
+        - name: yyyy
+          in: path
+          description: 'Year the aggregated content is requested for'
+          type: string
+          required: true
+        - name: mm
+          in: path
+          description: 'Month the aggregated content is requested for'
+          type: string
+          required: true
+        - name: dd
+          in: path
+          description: 'Day of the month the aggregated content is requested for'
+          type: string
+          required: true
+      responses:
+        '200':
+          description: JSON containing all of the featured content
+          schema:
+            type: object
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - from_mobileapps:
+            request:
+              method: get
+              uri: '{{options.host}}/{domain}/v1/feed/featured/{yyyy}/{mm}/{dd}'
+            return: 
+              status: '{{from_mobileapps.status}}'
+              headers: '{{ merge({"cache-control": options.feed_cache_control},
+                            from_mobileapps.headers) }}'
+              body: '{{from_mobileapps.body}}'
+      x-monitor: true
+      x-amples:
+        - title: Retrieve aggregated feed content for April 29, 2016
+          request:
+            params:
+              domain: en.wikipedia.org
+              yyyy: '2016'
+              mm: '04'
+              dd: '29'
+          response:
+            status: 200
+            headers:
+              content-type: /application\/json/
+            body:
+              tfa:
+                title: /.+/
+                description: /.+/
+                extract: /.+/
+                thumbnail:
+                  source: /.+/
+                  width: /.+/
+                  height: /.+/
+              mostread:
+                date: /.+/
+                articles:
+                  - views: /.+/
+                    rank: /.+/
+                    title: /.+/
+                    pageid: /.+/
+                    normalizedtitle: /.+/
+              random:
+                title: /.+/
+              news:
+                - story: /.+/
+                  links:
+                    - pageid: /.+/
+                      ns: /.+/
+                      normalizedtitle: /.+/
+                      title: /.+/
+              image:
+                title: /.+/
+                description:
+                  text: /.+/
+                  lang: /.+/
+                image:
+                  source: /.+/
+                  width: /.+/
+                  height: /.+/
+                thumbnail:
+                  source: /.+/
+                  width: /.+/
+                  height: /.+/
+

--- a/v1/random.yaml
+++ b/v1/random.yaml
@@ -37,7 +37,7 @@ paths:
               status: 303
               headers:
                 cache_control: '{{options.random_cache_control}}'
-                location: '../../{request.params.format}/{title_from_mobileapps.body.title}'
+                location: '../../{request.params.format}/{title_from_mobileapps.body.items[0].title}'
       x-monitor: true
       x-amples:
         - title: Random title redirect

--- a/v1/random.yaml
+++ b/v1/random.yaml
@@ -1,0 +1,52 @@
+swagger: '2.0'
+paths:
+  /random/{format}:
+    get:
+      tags:
+        - Page content
+      summary: Get content for a random page
+      description: |
+        Redirects the client to the URI for the desired format for a random page title.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      parameters:
+        - name: format
+          in: path
+          description: The desired return format
+          type: string
+          enum:
+            - title
+            - html
+            - summary
+            - related
+            - mobile-sections
+            - mobile-sections-lead
+          required: true
+      responses:
+        '303':
+          description: The redirect to the desired format URI for a random page
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - title_from_mobileapps:
+            request:
+              uri: '{{options.host}}/{domain}/v1/page/random/title'
+            return:
+              status: 303
+              headers:
+                cache_control: '{{options.random_cache_control}}'
+                location: '../../{request.params.format}/{title_from_mobileapps.body.title}'
+      x-monitor: true
+      x-amples:
+        - title: Random title redirect
+          request:
+            params:
+              format: title
+          response:
+            status: 303
+            headers:
+              cache-control: /.+/
+              location: /^..\/..\/title\/[^\/]+$/
+        


### PR DESCRIPTION
`/feed/featured` is the aggregate endpoint used by the next version of the native Adroid app. The endpoint forwards the request to the Mobile Content Service and returns its response. There is no storage for it at the moment; it should be added in a second iteration (once the endpoint's output format stabilises) and it should be modelled after mobile-sections since it returns the aggregate response for multiple smaller endpoints (they will be added once we start storing this endpoint's response). Varnish is instructed to cache the response for one minute.

`/page/random/{format}` gets a radnom page title from MCS' `page/random/title` endpoint and returns a redirect to the client based on the chosen format. Valid formats are title, html, summary, related, mobile-sections and mobile-sections lead. Since different random titles should be returned as often as possible, the redirect is cached for only 2 seconds.

This PR also makes a couple of improvements to the specification monitoring test utilities. Namely:

- if the example request does not specify the domain, assume it's the domain we are currently testing for
- don't set a field value to '' if it is false-y, but only if it's null or undefined
- if the example's response contains an array with only one element, assume we want to check each item of the returned array against it

Bug: [T136960](https://phabricator.wikimedia.org/T136960)