### PR TITLE
Add /page to random redirect title path

### DIFF
--- a/v1/random.yaml
+++ b/v1/random.yaml
@@ -37,7 +37,7 @@ paths:
               status: 303
               headers:
                 cache_control: '{{options.random_cache_control}}'
-                location: '../../{request.params.format}/{title_from_mobileapps.body.items[0].title}'
+                location: '../{request.params.format}/{title_from_mobileapps.body.items[0].title}'
       x-monitor: true
       x-amples:
         - title: Random title redirect
@@ -48,5 +48,5 @@ paths:
             status: 303
             headers:
               cache-control: /.+/
-              location: /^..\/..\/title\/[^\/]+$/
+              location: /^..\/title\/[^\/]+$/
         


### PR DESCRIPTION
Currently the random title and redirect URLs are missing the /page segment
from their path and therefore they aren't working.