### PR TITLE
Refetch siteInfo in case it failed

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -227,7 +227,7 @@ mwUtil.getSiteInfo = function(hyper, req) {
                 sharedRepoRootURI: findSharedRepoDomain(res)
             };
         })
-        .catch((e) => {
+        .catch(function(e) {
             hyper.log('error/site_info', e);
             delete siteInfoCache[rp.domain];
             throw e;

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -226,6 +226,11 @@ mwUtil.getSiteInfo = function(hyper, req) {
                 namespacealiases: res.body.query.namespacealiases,
                 sharedRepoRootURI: findSharedRepoDomain(res)
             };
+        })
+        .catch((e) => {
+            hyper.log('error/site_info', e);
+            delete siteInfoCache[rp.domain];
+            throw e;
         });
     }
     return siteInfoCache[rp.domain];

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "content-type": "git+https://github.com/wikimedia/content-type#master",
     "hyperswitch": "^0.5.2",
     "jsonwebtoken": "^6.2.0",
-    "mediawiki-title": "^0.5.2",
+    "mediawiki-title": "^0.5.4",
     "entities": "^1.1.1"
   },
   "devDependencies": {

--- a/test/features/errors/invalid_request.js
+++ b/test/features/errors/invalid_request.js
@@ -3,14 +3,79 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, it, before, beforeEach, after, afterEach */
 
-var assert = require('../../utils/assert.js');
-var preq   = require('preq');
-var server = require('../../utils/server.js');
+var assert  = require('../../utils/assert.js');
+var preq    = require('preq');
+var server  = require('../../utils/server.js');
+var nock    = require('nock');
+var mwUtils =
 
 describe('400 handling', function() {
     this.timeout(20000);
 
-    before(function () { return server.start(); });
+    var siteInfo;
+    var revisionInfo;
+    before(function () {
+        return server.start()
+        .then(function() {
+            // Fetch real siteInfo to return from a mock
+            return preq.post({
+                uri: server.config.apiURL,
+                body: {
+                    action: 'query',
+                    meta: 'siteinfo|filerepoinfo',
+                    siprop: 'general|namespaces|namespacealiases',
+                    format: 'json',
+                    formatversion: 2
+                }
+            });
+        })
+        .then(function(res) {
+            siteInfo = res.body;
+            // Fetch real revision info for Main_Page
+            return preq.post({
+                uri: server.config.apiURL,
+                body: {
+                    action: 'query',
+                    prop: 'info|revisions',
+                    continue: '',
+                    rvprop: 'ids|timestamp|user|userid|size|sha1|contentmodel|comment|tags',
+                    format: 'json',
+                    formatversion: 2,
+                    titles: 'Main_Page'
+                }
+            });
+        })
+        .then(function(res) {
+            revisionInfo = res.body;
+        })
+    });
+
+    it('should refetch siteInfo on error', function() {
+        // Set up nock:
+        // 1. Throw an error on siteInfo fetch
+        // 2. Return correct siteInfo
+        // 3. Return revision data
+        var mwApi = nock(server.config.apiURL, {allowUnmocked: true})
+        .post('').reply(400)
+        .post('').reply(200, siteInfo)
+        .post('').reply(200, revisionInfo);
+
+        return preq.get({
+            uri: server.config.bucketURL + '/title/Main_Page'
+        })
+        .catch(function (e) {
+            assert.deepEqual(e.status, 400);
+            return preq.get({
+                uri: server.config.bucketURL + '/title/Main_Page'
+            });
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.items[0].title, 'Main_Page');
+            mwApi.done();
+        })
+        .finally(function () { nock.cleanAll(); })
+    });
 
     it('should return a proper 400 for an empty POST', function() {
         return preq.post({


### PR DESCRIPTION
We're fetching the `siteInfo` of the first request to the domain and then caching the resolved promise to reuse it later. If the fetch was failed for any reason - delete the cache entry so that the next request would retry fetching the information.

cc @wikimedia/services 