### PR TITLE
Summary: Fix timestamp extraction logic

### DIFF
--- a/v1/summary.js
+++ b/v1/summary.js
@@ -16,8 +16,11 @@ module.exports = function(options, templates) {
                 }
                 return thumb;
             },
-            getTimestamp: function(items) {
-                return items && items[0] && items[0].timestamp
+            getRevision: function(revItems) {
+                if (Array.isArray(revItems) && revItems.length) {
+                    return revItems[0];
+                }
+                return {};
             }
         }
     };

--- a/v1/summary.js
+++ b/v1/summary.js
@@ -15,6 +15,9 @@ module.exports = function(options, templates) {
                     thumb.source = thumb.source.replace(/^http:/, 'https:');
                 }
                 return thumb;
+            },
+            getTimestamp: function(items) {
+                return items && items[0] && items[0].timestamp
             }
         }
     };

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -114,7 +114,7 @@ paths:
                 thumbnail: '{{httpsSource(extract.body.items[0].thumbnail)}}'
                 lang: '{{extract.body.items[0].pagelanguagehtmlcode}}'
                 dir: '{{extract.body.items[0].pagelanguagedir}}'
-                timestamp: '{{getTimestamp(extract.body.items[0].revisions)}}'
+                timestamp: '{{getRevision(extract.body.items[0].revisions).timestamp}}'
 
         - emit_change_event:
             request:

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -114,7 +114,7 @@ paths:
                 thumbnail: '{{httpsSource(extract.body.items[0].thumbnail)}}'
                 lang: '{{extract.body.items[0].pagelanguagehtmlcode}}'
                 dir: '{{extract.body.items[0].pagelanguagedir}}'
-                timestamp: '{{extract.body.items[0].revisions[0].timestamp}}'
+                timestamp: '{{getTimestamp(extract.body.items[0].revisions)}}'
 
         - emit_change_event:
             request:


### PR DESCRIPTION
Under certain circumstances the revision timestamp logic might result in a 500 error. If the page was quickly deleted, but that info wasn't propagated to RESTBase yet, the access check filter allows access to the summary. The MW API call results in an object with a `missing` property, and absent `revisions` property, so template execution fails with 500.

cc @wikimedia/services 