### PR TITLE
Added postpublish hook that would tag the repo in git

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {
-    "postpublish": "git tag -a \"v${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version} release\" && git push upstream --tags",
+    "postpublish": "git tag -a \"v${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version} release\" && git push upstream \"v${npm_package_version}\"",
     "start": "service-runner",
     "test": "sh test/utils/run_tests.sh test",
     "coverage": "sh test/utils/run_tests.sh coverage",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {
-    "prepublish": "git tag \"v${npm_package_version}\" && git push upstream --tags",
+    "mpostpublish": "git tag -a \"v${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version} release\" && git push upstream --tags",
     "start": "service-runner",
     "test": "sh test/utils/run_tests.sh test",
     "coverage": "sh test/utils/run_tests.sh coverage",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {
+    "prepublish": "git tag \"v${npm_package_version}\" && git push upstream --tags",
     "start": "service-runner",
     "test": "sh test/utils/run_tests.sh test",
     "coverage": "sh test/utils/run_tests.sh coverage",
@@ -31,7 +32,7 @@
     "url": "https://phabricator.wikimedia.org/tag/restbase/"
   },
   "homepage": "https://github.com/wikimedia/restbase",
-	"readme": "README.md",
+  "readme": "README.md",
   "dependencies": {
     "bluebird": "^3.4.1",
     "cassandra-uuid": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "REST storage and service dispatcher",
   "main": "lib/server.js",
   "scripts": {
-    "mpostpublish": "git tag -a \"v${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version} release\" && git push upstream --tags",
+    "postpublish": "git tag -a \"v${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version} release\" && git push upstream --tags",
     "start": "service-runner",
     "test": "sh test/utils/run_tests.sh test",
     "coverage": "sh test/utils/run_tests.sh coverage",


### PR DESCRIPTION
We forget to tag the release in git sometimes, so let's do it generically in the prepublish script.

It assumes that your upstream is called `upstream` which, I assume, is true for all of us..

cc @wikimedia/services 