### PR TITLE
Tests: Add accept header to swagger-ui retrieval test

### DIFF
--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -189,7 +189,8 @@ describe('item requests', function() {
 
     it('should retrieve the swagger-ui main page', function() {
         return preq.get({
-            uri: server.config.baseURL + '/?doc'
+            uri: server.config.baseURL + '/',
+            headers: { accept: 'text/html' }
         })
         .then(function(res) {
             assert.deepEqual(res.status, 200);


### PR DESCRIPTION
Note: this will keep failing until [T142366](https://phabricator.wikimedia.org/T142366) is fixed.