### PR TITLE
Sections scrub_wikitext and if-match

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -565,13 +565,10 @@ PSP.transformRevision = function(hyper, req, from, to) {
     var rp = req.params;
 
     var etag = req.headers && mwUtil.parseETag(req.headers['if-match']);
-    var tid;
-    if (from === 'html') {
-        if (etag) {
-            // Prefer the If-Match header
-            tid = etag.tid;
-        }
+    // Prefer the If-Match header
+    var tid = etag && etag.tid;
 
+    if (from === 'html') {
         if (req.body && req.body.html) {
             // Fall back to an inline meta tag in the HTML
             var htmlTid = extractTidMeta(req.body.html);

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -187,6 +187,29 @@ describe('transform api', function() {
         });
     });
 
+    it('sections2wt, replace, scrub_wikitext', function() {
+        var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
+        var pageWithSectionsRev = 275834;
+        return preq.post({
+            uri: server.config.labsURL
+            + '/transform/sections/to/wikitext/'
+            + pageWithSectionsTitle
+            + '/' + pageWithSectionsRev,
+            body: {
+                sections: '{"mwAg":"<h2></h2>","mwAw":"<h2>Second Section replaced</h2>"}',
+                scrub_wikitext: true
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.contentType(res, contentTypes.wikitext);
+            assert.deepEqual(/== First Section ==/.test(res.body), false);
+            assert.deepEqual(/== Second Section ==/.test(res.body), false);
+            assert.deepEqual(/== ?<nowiki\/> ?==/.test(res.body), false);
+            assert.deepEqual(/== Second Section replaced ==/.test(res.body), true);
+        });
+    });
+
     it('sections2wt, append', function() {
         var pageWithSectionsTitle = 'User:Pchelolo%2Fsections_test';
         var pageWithSectionsRev = 275834;

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -309,8 +309,18 @@ paths:
             properties:
               sections:
                 example: '{"mwAg":"<h2>First Section replaced</h2><h2>Appended Section</h2>"}'
+              scrub_wikitext:
+                type: boolean
+                description: Normalise the DOM to yield cleaner wikitext?
             required:
               - sections
+        - name: if-match
+          in: header
+          description: |
+            The `ETag` header of the original render indicating it's revision and timeuuid.
+            Required if both `title` and `revision` parameters are present.
+          type: string
+          required: false
       responses:
         '200':
           description: Wikitext of the full page.
@@ -355,6 +365,7 @@ paths:
               uri: /{domain}/sys/parsoid/transform/sections/to/wikitext/{title}/{revision}
               body:
                 sections: '{{sections}}'
+                scrub_wikitext: '{{scrub_wikitext}}'
       x-monitor: false
 
 definitions:

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -310,7 +310,6 @@ paths:
               sections:
                 example: '{"mwAg":"<h2>First Section replaced</h2><h2>Appended Section</h2>"}'
               scrub_wikitext:
-                type: boolean
                 description: Normalise the DOM to yield cleaner wikitext?
             required:
               - sections
@@ -363,6 +362,8 @@ paths:
         - get_from_backend:
             request:
               uri: /{domain}/sys/parsoid/transform/sections/to/wikitext/{title}/{revision}
+              headers:
+                if-match: '{{if-match}}'
               body:
                 sections: '{{sections}}'
                 scrub_wikitext: '{{scrub_wikitext}}'


### PR DESCRIPTION
As it's correctly indicated in the phab bug, we accept the 'scrub_wikitext' parameter in requests for sections transforms - no reason not to. It's not documented that it's a boolean because type coercion in the validator dosn't work for JSON object schemas - and that's done so because the sections/to/wikitext endpoint supports both `form-data` and `application/json` (which we wanna change in https://phabricator.wikimedia.org/T116336

Another thing - an `if-match` header. Not requiring it was an oversight in the first place - sections-to-wikitext transform is essentially html-to-wikitext, so it's critically important to get the same version of data-parsoid. More then that, section IDs might not be stable across rerenders, so getting an if-match header is even more important. For now I've left it optional, but we might wanna make it required. It's a breaking change though.

cc @wikimedia/services 
Bug: https://phabricator.wikimedia.org/T142518