### PR TITLE
Re-export hyperswitch as the main package entry point; release v0.15.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+
+module.exports = require('hyperswitch');
+

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "restbase",
-  "version": "0.14.4",
+  "version": "0.15.0",
   "description": "REST storage and service dispatcher",
-  "main": "lib/server.js",
+  "main": "index.js",
   "scripts": {
     "postpublish": "git tag -a \"v${npm_package_version}\" -m \"${npm_package_name}@${npm_package_version} release\" && git push upstream \"v${npm_package_version}\"",
     "start": "service-runner",


### PR DESCRIPTION
We usually use RESTBase as a service, not a dependency for other projects. However, when it is used as dependency it can't be loaded as `lib/server.js` doesn't exist any more. Hence, re-export hyperswitch as the module's main entry point.