### PR TITLE
Remove the name of the body parameter

### DIFF
--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -308,8 +308,7 @@ paths:
           description: The page revision
           type: integer
           required: true
-        - name: section-changes
-          in: body
+        - in: body
           description: Section changes to transform
           required: true
           schema:


### PR DESCRIPTION
This name doesn't make any sense since this parameter represents the whole body, so remove it.

cc @wikimedia/services 