### PR TITLE
Feeds: Split the aggregated feed request and cache it

### DIFF
--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -54,8 +54,8 @@ paths:
                                 options.mobileapps)}}'
             /feed:
               x-modules:
-                - path: v1/feed.yaml
-                  options: '{{merge({"feed_cache_control": "s-maxage=60, max-age=30"},
+                - path: v1/feed.js
+                  options: '{{merge({"feed_cache_control": "s-maxage=30, max-age=15", "ttl": 600},
                                 options.mobileapps)}}'
             /transform:
               x-modules:

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -1,0 +1,167 @@
+'use strict';
+
+
+var P = require('bluebird');
+var HyperSwitch = require('hyperswitch');
+var uuid = require('cassandra-uuid').TimeUuid;
+
+var URI = HyperSwitch.URI;
+var HTTPError = HyperSwitch.HTTPError;
+
+var spec = HyperSwitch.utils.loadSpec(__dirname + '/feed.yaml');
+
+
+var DEFAULT_TTL = 3600;
+
+var FEED_URIS = {
+    tfa: { uri: ['v1', 'page', 'featured'], date: true },
+    mostread: { uri: ['v1', 'page', 'most-read'], date: true },
+    random: { uri: ['v1', 'page', 'random', 'title'], date: false },
+    image: { uri: ['v1', 'media', 'image', 'featured'], date: true },
+    news: { uri: ['v1', 'page', 'news'], date: false }
+};
+
+
+function Feed(options) {
+
+    this.options = options;
+
+}
+
+
+Feed.prototype._makeFeedRequests = function(parts, hyper, rp, dateArr) {
+
+    var self = this;
+    var props = {};
+
+    parts.forEach(function(part) {
+        var def = FEED_URIS[part];
+        var uriArray = [self.options.host, rp.domain].concat(def.uri);
+        if (def.date) {
+            Array.prototype.push.apply(uriArray, dateArr);
+        }
+        props[part] = hyper.get({
+            uri: uriArray.join('/'),
+            query: { aggregated: true }
+        });
+    });
+
+    return P.props(props);
+
+};
+
+
+Feed.prototype.aggregated = function(hyper, req) {
+
+    var self = this;
+    var rp = req.params;
+    var date;
+    var dateArr;
+
+    // key the records on the date in the format YYYY-MM-DD
+    try {
+        date = new Date(Date.UTC(rp.yyyy, rp.mm - 1, rp.dd));
+        date = date.toISOString().split('T').shift();
+        dateArr = date.split('-');
+    } catch (err) {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'bad_request',
+                description: 'wrong date format specified'
+            }
+        });
+    }
+
+    // check if we have a record in Cassandra already
+    return hyper.get({
+        uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated', date])
+    }).then(function(res) {
+        // we've got a cache hit, so we just need to request
+        // the random component and return the bundle
+        if (!res.body) {
+            throw new HTTPError({
+                status: 500,
+                body: {
+                    type: '#internal_error',
+                    detail: 'No data received for aggregated feed date ' + date,
+                    feed_date: date
+                }
+            });
+        }
+        return self._makeFeedRequests(['random'], hyper, rp).then(function(rndRes) {
+            res.body.random = rndRes.random.body;
+            // make a new ETag since we are changing a part of the body
+            res.headers.etag = dateArr.join('') + '/' + uuid.now().toString();
+            return res;
+        }).catch(function(e) {
+            // something went wrong while retrieving the random part of
+            // the response from MCS, so just return the stored content
+            // as there is no need to error out for this edge case
+            return res;
+        });
+    }).catch({ status: 404 }, function(err) {
+        // it's a cache miss, so we need to request all
+        // of the components and store them
+        return self._makeFeedRequests(Object.keys(FEED_URIS), hyper, rp, dateArr)
+        .then(function(result) {
+            // assemble the final response to be returned
+            var finalResult = {
+                status: 200,
+                headers: {
+                    'cache-control': self.options.feed_cache_control,
+                    // mimic MCS' ETag value
+                    etag: dateArr.join('') + '/' + uuid.now().toString(),
+                    // TODO: need a way to dynamically derive this
+                    'content-type': 'application/json; charset=utf-8; ' +
+                        'profile="https://www.mediawiki.org/wiki/Specs/aggregated-feed/0.5.0"'
+                },
+                body: {}
+            };
+            // populate its body
+            Object.keys(result).forEach(function(key) {
+                finalResult.body[key] = result[key].body;
+            });
+            // store it
+            return hyper.put({
+                uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated', date]),
+                headers: finalResult.headers,
+                body: finalResult.body
+            }).then(function() {
+                return finalResult;
+            });
+        });
+    });
+
+};
+
+
+module.exports = function(options) {
+
+    options.ttl = options.ttl || DEFAULT_TTL;
+    options.feed_cache_control = options.feed_cache_control || 's-maxage=30, max-age=15';
+    if (!options.host) {
+        throw new Error('feed module: host option missing');
+    }
+
+    var feed = new Feed(options);
+
+    return {
+        spec: spec,
+        operations: {
+            aggregatedFeed: feed.aggregated.bind(feed)
+        },
+        resources: [{
+            uri: '/{domain}/sys/key_value/feed.aggregated',
+            body: {
+                valueType: 'json',
+                retention_policy: {
+                    type: 'ttl',
+                    ttl: options.ttl
+                }
+            }
+        }]
+    };
+
+};
+

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -42,16 +42,7 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
-      x-request-handler:
-        - from_mobileapps:
-            request:
-              method: get
-              uri: '{{options.host}}/{domain}/v1/feed/featured/{yyyy}/{mm}/{dd}'
-            return: 
-              status: '{{from_mobileapps.status}}'
-              headers: '{{ merge({"cache-control": options.feed_cache_control},
-                            from_mobileapps.headers) }}'
-              body: '{{from_mobileapps.body}}'
+      operationId: aggregatedFeed
       x-monitor: true
       x-amples:
         - title: Retrieve aggregated feed content for April 29, 2016


### PR DESCRIPTION
Instead of requesting the whole response of the aggregated feed endpoint
in MCS, it is much faster to request its individual pieces and then
assemble them in RESTBase. The process happens in parallel, so different
MCS workers get to work on a part of the response.

Moreover, in order to decrease the amount of requests to MCS, store the
response using the `ttl` revision retention policy. Currently, we begin
with the conservative ttl of 10 minutes, but it is likely we can
increase it in the future. The random component needs to change more
frequently than that, so whenever we have a cache hit, we re-request a
random title from MCS and incorporate it in the new response. We also
tell Varnish to cache the response for 30 seconds. This means that the
number of requests will be:
- 1 request for the random title every 30 seconds
- 5 requests for the various response components every 10 minutes

Note: depends on the deployment of [Gerrit 308589](https://gerrit.wikimedia.org/r/#/c/308589/)

Bug: [T143912](https://phabricator.wikimedia.org/T143912)