### PR TITLE
Allow providing both sectionId and html

### DIFF
--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -320,17 +320,13 @@ paths:
                   '^mw\w+$':
                     type: array
                     items:
-                      oneOf:
-                        - type: object
-                          properties:
-                            id:
-                              type: string
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            html:
-                              type: string
-                          additionalProperties: false
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        html:
+                          type: string
+                      additionalProperties: false
                 example:
                   mwAg:
                     - html: '<h2>Prepended section</h2>'


### PR DESCRIPTION
Actually providing both id and HTML might be useful, support that.

cc @wikimedia/services 