### PR TITLE
Added spec for the feed endpoint

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -97,6 +97,7 @@ spec_root: &spec_root
     # The order is important for tests.
     # Redirect tests require en.wiki being not the first wiki in the list.
     /{domain:en.wikipedia.org}: *default_project
+    /{domain:ru.wikipedia.org}: *default_project
     /{domain:de.wikipedia.org}: *default_project
     /{domain:test2.wikipedia.org}: *default_project
     /{domain:commons.wikimedia.org}: *default_project

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "mocha-lcov-reporter": "^1.2.0",
     "nock": "^8.0.0",
     "restbase-mod-table-sqlite": "^0.1.18",
-    "swagger-test": "0.3.0"
+    "swagger-test": "0.3.0",
+    "ajv": "^4.7.0"
   },
   "deploy": {
     "node": "4.4.6",

--- a/test/features/schema_tests.js
+++ b/test/features/schema_tests.js
@@ -1,0 +1,55 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var assert = require('../utils/assert.js');
+var server = require('../utils/server.js');
+var preq   = require('preq');
+var Ajv = require('ajv');
+
+describe('Responces should conform to the provided JSON schema of the responce', function() {
+
+    var spec;
+    var ajv;
+
+    before(function() {
+        return server.start()
+        .then(() => {
+            return preq.get({ uri: server.config.baseURL + '/?spec' });
+        })
+        .then((res) => {
+            ajv = new Ajv();
+            Object.keys(res.body.definitions).forEach(function(defName) {
+                ajv.addSchema(res.body.definitions[defName], '#/definitions/' + defName);
+            });
+        });
+    });
+
+    it('/feed/featured should conform schema', () => {
+        return preq.get({
+            uri: server.config.baseURL + '/feed/featured/2016/09/08'
+        })
+        .then(function(res) {
+            if (!ajv.validate('#/definitions/feed', res.body)) {
+                throw new assert.AssertionError({
+                    message: ajv.errorsText()
+                });
+            }
+        });
+    });
+
+    it('/page/summary/{title} should conform schema', () => {
+        return preq.get({
+            uri: server.config.baseURL + '/page/summary/Tank'
+        })
+        .then(function(res) {
+            if (!ajv.validate('#/definitions/summary', res.body)) {
+                throw new assert.AssertionError({
+                    message: ajv.errorsText()
+                });
+            }
+        });
+    });
+
+});

--- a/test/features/schema_tests.js
+++ b/test/features/schema_tests.js
@@ -32,6 +32,18 @@ describe('Responses should conform to the provided JSON schema of the responce',
         });
     });
 
+    it('/feed/featured should conform schema, ruwiki', function() {
+        return preq.get({ uri: server.config.hostPort + '/ru.wikipedia.org/v1/feed/featured/2016/09/08' })
+        .then(function(res) {
+            if (!ajv.validate('#/definitions/feed', res.body)) {
+                throw new assert.AssertionError({
+                    message: ajv.errorsText()
+                });
+            }
+        });
+    });
+
+
     it('/page/summary/{title} should conform schema', function() {
         return preq.get({ uri: server.config.baseURL + '/page/summary/Tank' })
         .then(function(res) {

--- a/test/features/schema_tests.js
+++ b/test/features/schema_tests.js
@@ -9,27 +9,20 @@ var preq   = require('preq');
 var Ajv = require('ajv');
 
 describe('Responces should conform to the provided JSON schema of the responce', function() {
-
-    var spec;
-    var ajv;
+    var ajv = new Ajv({});
 
     before(function() {
         return server.start()
-        .then(() => {
-            return preq.get({ uri: server.config.baseURL + '/?spec' });
-        })
-        .then((res) => {
-            ajv = new Ajv();
+        .then(function() { return preq.get({ uri: server.config.baseURL + '/?spec' }); })
+        .then(function(res) {
             Object.keys(res.body.definitions).forEach(function(defName) {
                 ajv.addSchema(res.body.definitions[defName], '#/definitions/' + defName);
             });
         });
     });
 
-    it('/feed/featured should conform schema', () => {
-        return preq.get({
-            uri: server.config.baseURL + '/feed/featured/2016/09/08'
-        })
+    it('/feed/featured should conform schema', function() {
+        return preq.get({ uri: server.config.baseURL + '/feed/featured/2016/09/08' })
         .then(function(res) {
             if (!ajv.validate('#/definitions/feed', res.body)) {
                 throw new assert.AssertionError({
@@ -39,10 +32,8 @@ describe('Responces should conform to the provided JSON schema of the responce',
         });
     });
 
-    it('/page/summary/{title} should conform schema', () => {
-        return preq.get({
-            uri: server.config.baseURL + '/page/summary/Tank'
-        })
+    it('/page/summary/{title} should conform schema', function() {
+        return preq.get({ uri: server.config.baseURL + '/page/summary/Tank' })
         .then(function(res) {
             if (!ajv.validate('#/definitions/summary', res.body)) {
                 throw new assert.AssertionError({
@@ -51,5 +42,4 @@ describe('Responces should conform to the provided JSON schema of the responce',
             }
         });
     });
-
 });

--- a/test/features/schema_tests.js
+++ b/test/features/schema_tests.js
@@ -8,7 +8,7 @@ var server = require('../utils/server.js');
 var preq   = require('preq');
 var Ajv = require('ajv');
 
-describe('Responces should conform to the provided JSON schema of the responce', function() {
+describe('Responses should conform to the provided JSON schema of the responce', function() {
     var ajv = new Ajv({});
 
     before(function() {

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -157,6 +157,7 @@ function checkString(result, expected, message) {
 }
 
 module.exports.ok             = assert.ok;
+module.exports.AssertionError = assert.AssertionError;
 module.exports.fails          = fails;
 module.exports.deepEqual      = deepEqual;
 module.exports.isDeepEqual    = isDeepEqual;

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -197,7 +197,7 @@ Feed.prototype.aggregated = function(hyper, req) {
             }
 
             if (feed.random) {
-                feed.random.items = assignAllSummaries(feed.random.items);
+                feed.random = assignAllSummaries(feed.random.items);
             }
 
             if (feed.news) {

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -176,7 +176,11 @@ Feed.prototype.aggregated = function(hyper, req) {
                 if (summaries[article.title]) {
                     // MCS expects the title to be a DB Key
                     delete summaries[article.title].title;
-                    return Object.assign(article, summaries[article.title]);
+                    var result = Object.assign(article, summaries[article.title]);
+                    if (!result.normalizedtitle) {
+                        result.normalizedtitle = result.title.replace(/_/g, ' ');
+                    }
+                    return result;
                 }
             }
 

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -216,14 +216,9 @@ definitions:
       $ref: '#/definitions/news_item'
 
   random:
-    type: object
-    properties:
-      items:
-        type: array
-        items:
-          $ref: '#/definitions/article_summary'
-    required:
-      - items
+    type: array
+    items:
+      $ref: '#/definitions/article_summary'
 
   image_description:
     properties:

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -37,7 +37,7 @@ paths:
         '200':
           description: JSON containing all of the featured content
           schema:
-            type: object
+            $ref: '#/definitions/feed'
         default:
           description: Error
           schema:
@@ -97,3 +97,141 @@ paths:
                   width: /.+/
                   height: /.+/
 
+definitions:
+  # A https://tools.ietf.org/html/draft-nottingham-http-problem
+  problem:
+    required:
+      - type
+    properties:
+      type:
+        type: string
+      title:
+        type: string
+      detail:
+        type: string
+      instance:
+        type: string
+
+  thumbnail:
+    type: object
+    properties:
+      source:
+        type: string
+        description: Thumbnail image URI
+      width:
+        type: integer
+        description: Thumbnail width
+      height:
+        type: integer
+        description: Thumnail height
+    required: ['source', 'width', 'height']
+
+  article_summary:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Article title in a form of DB key
+      normalizedtitle:
+        type: string
+        description: Article title as it should be presented to the user
+      thumbnail:
+        description: Lead image for the article
+        $ref: '#/definitions/thumbnail'
+      description:
+        type: string
+        description: Wikidata description of the article
+      extract:
+        type: string
+        description: First several sentences of an article in plain text
+    required:
+      - title
+      - normalizedtitle
+
+  mostread_article:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Article title in a form of DB key
+      normalizedtitle:
+        type: string
+        description: Article title as it should be presented to the user
+      views:
+        type: integer
+        description: Number of views on the requested day
+      rank:
+        type: integer
+        description: Position in the list of most viewed articles
+      fromencoded:
+        type: boolean
+      thumbnail:
+        description: Lead image for the article
+        $ref: '#/definitions/thumbnail'
+      description:
+        type: string
+        description: Wikidata description of the article
+      extract:
+        type: string
+        description: First several sentences of an article in plain text
+    required:
+      - title
+      - normalizedtitle
+      - views
+      - rank
+      - pageid
+      - fromencoded
+
+  mostread:
+    type: object
+    properties:
+      date:
+        type: string
+        description: The date which the data correspond to
+      articles:
+        type: array
+        description: Array of most popular articles
+        items:
+          $ref: '#/definitions/mostread_article'
+
+  news_item:
+    type: object
+    properties:
+      story:
+        type: string
+        description: A cover story for the news item
+      links:
+        type: array
+        description: A collection of articles related to the news item
+        items:
+          $ref: '#/definitions/article_summary'
+
+  news:
+    type: array
+    items:
+      $ref: '#/definitions/news_item'
+
+  random:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/article_summary'
+
+  feed:
+    type: object
+    description: Aggregated feed content for a given date
+    properties:
+      tfa:
+        description: Data about the featured article of the day
+        $ref: '#/definitions/article_summary'
+      mostread:
+        description: Data about most viewed articles
+        $ref: '#/definitions/mostread'
+      news:
+        description: Data about in the news section
+        $ref: '#/definitions/news'
+      random:
+        description: A single random article
+        $ref: '#/definitions/random'

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -146,7 +146,6 @@ definitions:
         description: First several sentences of an article in plain text
     required:
       - title
-      - normalizedtitle
 
   mostread_article:
     type: object
@@ -180,7 +179,6 @@ definitions:
       - views
       - rank
       - pageid
-      - fromencoded
 
   mostread:
     type: object
@@ -193,6 +191,9 @@ definitions:
         description: Array of most popular articles
         items:
           $ref: '#/definitions/mostread_article'
+    required:
+      - date
+      - articles
 
   news_item:
     type: object
@@ -205,6 +206,9 @@ definitions:
         description: A collection of articles related to the news item
         items:
           $ref: '#/definitions/article_summary'
+    required:
+      - story
+      - links
 
   news:
     type: array
@@ -218,6 +222,40 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/article_summary'
+    required:
+      - items
+
+  image_description:
+    properties:
+      text:
+        type: string
+        description: Text of the description
+      lang:
+        type: string
+        description: Language code of the description
+    required:
+      - text
+      - lang
+
+  image:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Image title
+      thumbnail:
+        description: Image thumbnail
+        $ref: '#/definitions/thumbnail'
+      image:
+        description: Full-size image
+        $ref: '#/definitions/thumbnail'
+      description:
+        descrtiption: Description of an image
+        $ref: '#/definitions/image_description'
+    required:
+      - title
+      - thumbnail
+      - image
 
   feed:
     type: object
@@ -235,3 +273,6 @@ definitions:
       random:
         description: A single random article
         $ref: '#/definitions/random'
+      image:
+        description: Featured image for a given date
+        $ref: '#/definitions/image'

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -146,6 +146,8 @@ definitions:
         description: First several sentences of an article in plain text
     required:
       - title
+      - normalizedtitle
+
 
   mostread_article:
     type: object
@@ -162,8 +164,6 @@ definitions:
       rank:
         type: integer
         description: Position in the list of most viewed articles
-      fromencoded:
-        type: boolean
       thumbnail:
         description: Lead image for the article
         $ref: '#/definitions/thumbnail'
@@ -276,3 +276,4 @@ definitions:
       image:
         description: Featured image for a given date
         $ref: '#/definitions/image'
+    additionalProperties: false

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -74,8 +74,7 @@ paths:
                     pageid: /.+/
                     normalizedtitle: /.+/
               random:
-                items:
-                  - title: /.+/
+                - title: /.+/
               news:
                 - story: /.+/
                   links:

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -218,4 +218,5 @@ definitions:
         type: string
         description: Wikidata description for the page
         example: American poet
+    additionalProperties: false
     required: ['title', 'extract', 'lang', 'dir']


### PR DESCRIPTION
We've been talking about adding a schema to the feed endpoint so that some tests could validate agains it - so here's the first iteration of the schema. Depends on https://github.com/wikimedia/restbase/pull/668, after that's merged I will create a test that would validate responses agains this schema and make some minor improvements to the schema itself.

cc @wikimedia/services @wikimedia/mobile 
Bug: https://phabricator.wikimedia.org/T141943