### PR TITLE
Use eslint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,234 @@
+env:
+  node: true
+extends: 'eslint:recommended'
+rules:
+  accessor-pairs: error
+  array-bracket-spacing: 'off'
+  array-callback-return: error
+  arrow-body-style: error
+  arrow-parens: error
+  arrow-spacing: error
+  block-scoped-var: error
+  block-spacing:
+    - error
+    - always
+  brace-style: 'off'
+  camelcase:
+    - error
+    - properties: never
+  class-methods-use-this: error
+  comma-dangle:
+    - error
+    - only-multiline
+  comma-spacing: 'off'
+  comma-style:
+    - error
+    - last
+  complexity: error
+  computed-property-spacing:
+    - error
+    - never
+  consistent-return: 'off'
+  consistent-this: 'off'
+  curly: error
+  default-case: error
+  dot-location:
+    - error
+    - property
+  dot-notation:
+    - error
+    - allowKeywords: true
+  eol-last: error
+  eqeqeq: error
+  func-call-spacing: error
+  func-names: 'off'
+  func-style: 'off'
+  generator-star-spacing: error
+  global-require: 'off'
+  guard-for-in: error
+  handle-callback-err: 'off'
+  id-blacklist: error
+  id-length: 'off'
+  id-match: error
+  indent: 'off'
+  init-declarations: 'off'
+  jsx-quotes: error
+  key-spacing: error
+  keyword-spacing:
+    - error
+    - after: true
+      before: true
+  line-comment-position: 'off'
+  linebreak-style:
+    - error
+    - unix
+  lines-around-comment: 'off'
+  lines-around-directive: error
+  max-depth: error
+  max-len: 'off'
+  max-lines: 'off'
+  max-nested-callbacks: error
+  max-params: 'off'
+  max-statements: 'off'
+  max-statements-per-line: 'off'
+  multiline-ternary:
+    - error
+    - never
+  new-cap: error
+  new-parens: error
+  newline-after-var: 'off'
+  newline-before-return: 'off'
+  newline-per-chained-call: 'off'
+  no-alert: error
+  no-array-constructor: error
+  no-bitwise: error
+  no-caller: error
+  no-catch-shadow: error
+  no-confusing-arrow: error
+  no-continue: error
+  no-div-regex: error
+  no-duplicate-imports: error
+  no-else-return: 'off'
+  no-empty-function: 'off'
+  no-eq-null: error
+  no-eval: error
+  no-extend-native: error
+  no-extra-bind: error
+  no-extra-label: error
+  no-extra-parens: 'off'
+  no-floating-decimal: error
+  no-global-assign: error
+  no-implicit-globals: error
+  no-implied-eval: error
+  no-inline-comments: 'off'
+  no-inner-declarations:
+    - error
+    - functions
+  no-invalid-this: error
+  no-iterator: error
+  no-label-var: error
+  no-labels: error
+  no-lone-blocks: error
+  no-lonely-if: error
+  no-loop-func: error
+  no-magic-numbers: 'off'
+  no-mixed-operators: 'off'
+  no-mixed-requires: error
+  no-multi-spaces: 'off'
+  no-multi-str: error
+  no-multiple-empty-lines: error
+  no-negated-condition: 'off'
+  no-nested-ternary: error
+  no-new: error
+  no-new-func: error
+  no-new-object: error
+  no-new-require: error
+  no-new-wrappers: error
+  no-octal-escape: error
+  no-param-reassign: 'off'
+  no-path-concat: 'off'
+  no-plusplus:
+    - error
+    - allowForLoopAfterthoughts: true
+  no-process-env: error
+  no-process-exit: error
+  no-proto: error
+  no-prototype-builtins: 'off'
+  no-restricted-globals: error
+  no-restricted-imports: error
+  no-restricted-modules: error
+  no-restricted-properties: error
+  no-restricted-syntax: error
+  no-return-assign: error
+  no-script-url: error
+  no-self-compare: error
+  no-sequences: error
+  no-shadow: 'off'
+  no-shadow-restricted-names: error
+  no-spaced-func: error
+  no-sync: error
+  no-tabs: error
+  no-template-curly-in-string: error
+  no-ternary: 'off'
+  no-throw-literal: error
+  no-trailing-spaces: error
+  no-undef-init: error
+  no-undefined: 'off'
+  no-underscore-dangle: 'off'
+  no-unmodified-loop-condition: error
+  no-unneeded-ternary: error
+  no-unsafe-negation: error
+  no-unused-expressions: error
+  no-use-before-define: 'off'
+  no-useless-call: error
+  no-useless-computed-key: error
+  no-useless-concat: error
+  no-useless-constructor: error
+  no-useless-escape: error
+  no-useless-rename: error
+  no-var: 'off'
+  no-void: error
+  no-warning-comments: 'off'
+  no-whitespace-before-property: error
+  no-with: error
+  object-curly-newline: 'off'
+  object-curly-spacing:
+    - error
+    - always
+  object-property-newline:
+    - error
+    - allowMultiplePropertiesPerLine: true
+  object-shorthand: 'off'
+  one-var: 'off'
+  one-var-declaration-per-line: error
+  operator-assignment:
+    - error
+    - always
+  operator-linebreak: 'off'
+  padded-blocks: 'off'
+  prefer-arrow-callback: 'off'
+  prefer-const: error
+  prefer-numeric-literals: error
+  prefer-reflect: 'off'
+  prefer-rest-params: error
+  prefer-spread: 'off'
+  prefer-template: 'off'
+  quote-props: 'off'
+  quotes: 'off'
+  radix:
+    - error
+    - as-needed
+  require-jsdoc: 'off'
+  rest-spread-spacing: error
+  semi: error
+  semi-spacing:
+    - error
+    - after: true
+      before: false
+  sort-imports: error
+  sort-keys: 'off'
+  sort-vars: error
+  space-before-blocks: error
+  space-before-function-paren: 'off'
+  space-in-parens:
+    - error
+    - never
+  space-infix-ops: error
+  space-unary-ops: error
+  spaced-comment:
+    - error
+    - always
+  strict: error
+  symbol-description: error
+  template-curly-spacing: error
+  unicode-bom:
+    - error
+    - never
+  valid-jsdoc: 'off'
+  vars-on-top: 'off'
+  wrap-iife: error
+  wrap-regex: 'off'
+  yield-star-spacing: error
+  yoda:
+    - error
+    - never

--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -85,7 +85,6 @@ function checkContentType(hyper, req, next, expectedContentType, responsePromise
 
 
 module.exports = function(hyper, req, next, options, specInfo) {
-    var rp = req.params;
     var produces = specInfo.spec.produces;
     var expectedContentType = Array.isArray(produces) && produces[0];
     var responsePromise = next(hyper, req);

--- a/lib/mediawiki_auth_filter.js
+++ b/lib/mediawiki_auth_filter.js
@@ -3,7 +3,6 @@
 var HyperSwitch = require('hyperswitch');
 var HTTPError = HyperSwitch.HTTPError;
 var URI = HyperSwitch.URI;
-var P = require('bluebird');
 
 function copyForwardedHeaders(req, rootReq, headersLins) {
     if (rootReq.headers) {

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -327,7 +327,7 @@ mwUtil.isSelfRedirect = function(req, location) {
         } else if (decodeURIComponent(locationPath[i]) !== req.uri.path[indexInPath]) {
             return false;
         } else {
-            indexInPath++;
+            indexInPath += 1;
         }
     }
     return true;

--- a/lib/security_response_header_filter.js
+++ b/lib/security_response_header_filter.js
@@ -1,4 +1,5 @@
 "use strict";
+
 var P = require('bluebird');
 
 /**

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "mocha-lcov-reporter": "^1.2.0",
     "nock": "^8.0.0",
     "restbase-mod-table-sqlite": "^0.1.18",
-    "swagger-test": "0.3.0"
+    "swagger-test": "0.3.0",
+    "mocha-eslint":"^3.0.1"
   },
   "deploy": {
     "node": "4.4.6",

--- a/sys/events.js
+++ b/sys/events.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var P         = require('bluebird');
-var HTTPError = require('hyperswitch').HTTPError;
 var uuid = require('cassandra-uuid').TimeUuid;
 
 var EventService = function(options) {

--- a/sys/key_rev_large_value.js
+++ b/sys/key_rev_large_value.js
@@ -2,7 +2,6 @@
 
 var P = require('bluebird');
 var uuid = require('cassandra-uuid').TimeUuid;
-var preq = require('preq');
 
 var HyperSwitch = require('hyperswitch');
 var HTTPError = HyperSwitch.HTTPError;

--- a/sys/key_rev_latest_value.js
+++ b/sys/key_rev_latest_value.js
@@ -11,7 +11,7 @@ var mwUtil = require('../lib/mwUtil');
 
 var spec = HyperSwitch.utils.loadSpec(__dirname + '/key_rev_value.yaml');
 
-function ArchivalBucket(options) {
+function ArchivalBucket() {
 }
 
 ArchivalBucket.prototype._latestName = function(bucket) {

--- a/sys/key_rev_value.js
+++ b/sys/key_rev_value.js
@@ -11,7 +11,7 @@ var HTTPError = HyperSwitch.HTTPError;
 var URI = HyperSwitch.URI;
 var spec = HyperSwitch.utils.loadSpec(__dirname + '/key_rev_value.yaml');
 
-function KRVBucket(options) {
+function KRVBucket() {
 }
 
 KRVBucket.prototype.makeSchema = function(opts) {

--- a/sys/key_value.js
+++ b/sys/key_value.js
@@ -12,7 +12,7 @@ var URI = HyperSwitch.URI;
 
 var spec = HyperSwitch.utils.loadSpec(__dirname + '/key_value.yaml');
 
-function KVBucket(options) {
+function KVBucket() {
 }
 
 KVBucket.prototype.makeSchema = function(opts) {

--- a/sys/mathoid.js
+++ b/sys/mathoid.js
@@ -49,7 +49,7 @@ MathoidService.prototype.getFormula = function(hyper, req) {
     }).then(function(res) {
         res.headers['x-resource-location'] = hash;
         return res;
-    }).catch({ status: 404 }, function(err) {
+    }).catch({ status: 404 }, function() {
         // let's try to find an indirection
         return hyper.get({
             uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.hash_table', hash])
@@ -90,7 +90,7 @@ MathoidService.prototype.checkInput = function(hyper, req) {
         // check the post storage
         return hyper.get({
             uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.check', hash])
-        }).catch({ status: 404 }, function(err) {
+        }).catch({ status: 404 }, function() {
             // let's try to find an indirection
             return hyper.get({
                 uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.hash_table', hash])

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -129,7 +129,7 @@ PRS.prototype._checkRevReturn = function(item) {
 };
 
 // /page/
-PRS.prototype.listTitles = function(hyper, req, options) {
+PRS.prototype.listTitles = function(hyper, req) {
     var rp = req.params;
     var listReq = {
         uri: new URI([rp.domain, 'sys', 'action', 'query']),

--- a/sys/page_save.js
+++ b/sys/page_save.js
@@ -15,7 +15,7 @@ var HTTPError = HyperSwitch.HTTPError;
 var mwUtil = require('../lib/mwUtil');
 var TimeUuid = require('cassandra-uuid').TimeUuid;
 
-function PageSave(options) {
+function PageSave() {
     var self = this;
     this.spec = {
         paths: {

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -6,7 +6,6 @@
 
 var P = require('bluebird');
 var HyperSwitch = require('hyperswitch');
-var Title = require('mediawiki-title').Title;
 var URI = HyperSwitch.URI;
 var HTTPError = HyperSwitch.HTTPError;
 
@@ -184,7 +183,7 @@ PSP.generateAndSave = function(hyper, req, format, currentContentRes) {
                 },
                 body: body
             });
-        }, function(e) {
+        }, function() {
             // Fall back to plain GET
             return hyper.get({ uri: pageBundleUri });
         });
@@ -208,7 +207,7 @@ PSP.generateAndSave = function(hyper, req, format, currentContentRes) {
             );
         }
     })
-    .then(function(revInfo) {
+    .then(function() {
         var pageBundleUri = new URI([rp.domain, 'sys', 'parsoid', 'pagebundle',
                 rp.title, rp.revision]);
 
@@ -434,7 +433,6 @@ PSP.getFormat = function(format, hyper, req) {
 };
 
 PSP.listRevisions = function(format, hyper, req) {
-    var self = this;
     var rp = req.params;
     var revReq = {
         uri: new URI([rp.domain, 'sys', this.options.bucket_type,

--- a/sys/post_data.js
+++ b/sys/post_data.js
@@ -11,7 +11,7 @@ var URI = HyperSwitch.URI;
 
 var spec = HyperSwitch.utils.loadSpec(__dirname + '/post_data.yaml');
 
-function PostDataBucket(options) {
+function PostDataBucket() {
 }
 
 PostDataBucket.prototype.createBucket = function(hyper, req) {

--- a/test/index.js
+++ b/test/index.js
@@ -5,3 +5,8 @@
 require('mocha-jshint')();
 // Run jscs as part of normal testing
 require('mocha-jscs')();
+require('mocha-eslint')([
+    'lib',
+    'sys',
+    'v1'
+]);

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -94,13 +94,12 @@ Feed.prototype.aggregated = function(hyper, req) {
             // make a new ETag since we are changing a part of the body
             res.headers.etag = dateArr.join('') + '/' + uuid.now().toString();
             return res;
-        }).catch(function(e) {
-            // something went wrong while retrieving the random part of
-            // the response from MCS, so just return the stored content
-            // as there is no need to error out for this edge case
-            return res;
-        });
-    }).catch({ status: 404 }, function(err) {
+        })
+        // something went wrong while retrieving the random part of
+        // the response from MCS, so just return the stored content
+        // as there is no need to error out for this edge case
+        .catchReturn(res);
+    }).catch({ status: 404 }, function() {
         // it's a cache miss, so we need to request all
         // of the components and store them
         return self._makeFeedRequests(Object.keys(FEED_URIS), hyper, rp, dateArr)

--- a/v1/summary.js
+++ b/v1/summary.js
@@ -3,7 +3,7 @@
 var HyperSwitch = require('hyperswitch');
 var spec = HyperSwitch.utils.loadSpec(__dirname + '/summary.yaml');
 
-module.exports = function(options, templates) {
+module.exports = function(options) {
     return {
         spec: spec,
         globals: {


### PR DESCRIPTION
ESLint is the new generation of static code analysis tools coming to replace JSCS and JSHint. 

I imagine the eslint config would become an endless source of bike shedding, because what I wanna achieve is to settle on the common eslint config for all node services we maintain :)

The current config was generated by analysing our current RESTBase code-style

cc @wikimedia/services 