### PR TITLE
Undelete wasn't working with new restrictions table.

### DIFF
--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -477,6 +477,11 @@ PRS.prototype.fetchAndStoreMWRevision = function(hyper, req) {
             }
         })
         .catch({ status: 404 }, function() {
+            if (!revision.page_deleted) {
+                // Clear up page_deleted
+                revision.page_deleted = null;
+            }
+
             return hyper.put({ // Save / update the revision entry
                 uri: self.tableURI(rp.domain),
                 body: {

--- a/test/features/pagecontent/access_checks.js
+++ b/test/features/pagecontent/access_checks.js
@@ -191,6 +191,24 @@ describe('Access checks', function() {
     testAccess('mobile-sections-remaining', 'deleted', deletedPageTitle);
     testAccess('summary', 'deleted', deletedPageTitle);
 
+    it('Should understand that the page was undeleted', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/title/' + encodeURIComponent(deletedPageTitle),
+            headers: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            return preq.get({
+                uri: server.config.bucketURL + '/html/' + encodeURIComponent(deletedPageTitle) + '/' + deletedPageOlderRevision,
+            });
+        })
+        .then(function (res) {
+            assert.deepEqual(res.status, 200);
+        });
+    });
+
     var pageTitle = 'User:Pchelolo/restriction_testing_mock';
     var pageRev = 301375;
     it('should correctly fetch updated restrictions', function() {


### PR DESCRIPTION
No need to refetch stuff that we've just saved.

cc @wikimedia/services 