### PR TITLE
Remove no-longer-needed fields from feed spec

### DIFF
--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -79,9 +79,7 @@ paths:
               news:
                 - story: /.+/
                   links:
-                    - pageid: /.+/
-                      ns: /.+/
-                      normalizedtitle: /.+/
+                    - normalizedtitle: /.+/
                       title: /.+/
               image:
                 title: /.+/


### PR DESCRIPTION
See MCS patch: https://gerrit.wikimedia.org/r/#/c/311733/

Note: Spec-related unit tests will fail if the MCS patch is merged before
this is.

Bug: T146041