### PR TITLE
Don't propagate 302 and location header

### DIFF
--- a/lib/access_check_filter.js
+++ b/lib/access_check_filter.js
@@ -28,8 +28,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
 
             // Use redirect target from restrictions table or content response.
             var redirectTarget = restriction && restriction.body
-                && restriction.body.redirect
-                || content.headers.location;
+                && restriction.body.redirect || content.headers.location;
             if (redirectTarget
                     && req.query.redirect !== false
                     && !mwUtil.isNoCacheRequest(req)) {

--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -81,6 +81,13 @@ module.exports = function(hyper, req, next, options, specInfo) {
                 }
             });
         }
-        return next(hyper, req);
+        return next(hyper, req)
+        .then(function(res) {
+            if (req.query.redirect === false || mwUtil.isNoCacheRequest(req)) {
+                res.status = 200;
+                delete res.headers.location;
+            }
+            return res;
+        });
     });
 };

--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -83,7 +83,8 @@ module.exports = function(hyper, req, next, options, specInfo) {
         }
         return next(hyper, req)
         .then(function(res) {
-            if (req.query.redirect === false || mwUtil.isNoCacheRequest(req)) {
+            if (req.status === 302
+                    && (req.query.redirect === false || mwUtil.isNoCacheRequest(req))) {
                 res.status = 200;
                 delete res.headers.location;
             }

--- a/lib/revision_table_access_check_filter.js
+++ b/lib/revision_table_access_check_filter.js
@@ -83,7 +83,7 @@ module.exports = function(hyper, req, next, options, specInfo) {
         }
         return next(hyper, req)
         .then(function(res) {
-            if (req.status === 302
+            if (res.status === 302
                     && (req.query.redirect === false || mwUtil.isNoCacheRequest(req))) {
                 res.status = 200;
                 delete res.headers.location;

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -257,7 +257,7 @@ PSP.generateAndSave = function(hyper, req, format, currentContentRes) {
                         // This revision is actually a redirect. Pass redirect target
                         // to caller, and let it rewrite the location header.
                         resp.status = 302;
-                        resp.headers.location = redirectTarget;
+                        resp.headers.location = encodeURIComponent(redirectTarget);
                         // Also save the location header.
                         res.body.html.headers.location = redirectTarget;
                         redirectUpdate = hyper.post({

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -250,7 +250,6 @@ PSP.generateAndSave = function(hyper, req, format, currentContentRes) {
                 resp.headers.etag = mwUtil.makeETag(rp.revision, tid);
                 return self.saveParsoidResult(hyper, req, format, tid, res)
                 .then(function() {
-                    var redirectUpdate = P.resolve();
                     // Extract redirect target, if any
                     var redirectTarget = mwUtil.extractRedirect(res.body.html.body);
                     if (redirectTarget) {
@@ -258,9 +257,7 @@ PSP.generateAndSave = function(hyper, req, format, currentContentRes) {
                         // to caller, and let it rewrite the location header.
                         resp.status = 302;
                         resp.headers.location = encodeURIComponent(redirectTarget);
-                        // Also save the location header.
-                        res.body.html.headers.location = redirectTarget;
-                        redirectUpdate = hyper.post({
+                        return hyper.post({
                             uri: new URI([rp.domain, 'sys', 'page_revisions',
                                          'restrictions', rp.title, rp.revision]),
                             body: {

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -138,6 +138,18 @@ describe('Redirects', function() {
         });
     });
 
+    it('should not redirect if redirect=false and page is not in storage', function() {
+        return preq.get({
+            uri: server.config.bucketURL + '/html/User:Pchelolo%2fRedirect_Test2?redirect=false',
+            followRedirect: false
+        })
+        .then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers.location, undefined);
+            assert.deepEqual(res.body.length > 0, true);
+        });
+    });
+
     var etag;
     it('should return 302 for redirect pages html', function() {
         return preq.get({

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -183,11 +183,8 @@ paths:
 
   /html/{title}:
     x-route-filters:
-      #- path: ./lib/revision_table_access_check_filter.js
-      #  options:
-      #    redirect_cache_control: '{{options.purged_cache_control}}'
-      #    attach_body_to_redirect: true
-      - path: ./lib/access_check_filter.js
+      - path: ./lib/revision_table_access_check_filter.js
+      #- path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.purged_cache_control}}'
           attach_body_to_redirect: true
@@ -440,7 +437,8 @@ paths:
 
   /html/{title}/{revision}{/tid}:
     x-route-filters:
-      - path: ./lib/access_check_filter.js
+      - path: ./lib/revision_table_access_check_filter.js
+      #- path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.purged_cache_control}}'
           attach_body_to_redirect: true
@@ -547,6 +545,7 @@ paths:
   /data-parsoid/{title}/{revision}/{tid}:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
+      #- path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.purged_cache_control}}'
           attach_body_to_redirect: true


### PR DESCRIPTION
Fixes the current weird problem with TypeError

Not quite sure why didn't I catch it in labs, perhaps because I didn't use any special characters in titles. This is like the 15th time I'm making this mental note to use special characters in titles in testing...

cc @wikimedia/services 