### PR TITLE
RESTBase should set the 'triggered_by' field on the resource-change

### DIFF
--- a/sys/events.js
+++ b/sys/events.js
@@ -54,6 +54,7 @@ class EventService {
                 if (event.tags.indexOf('restbase') < 0) {
                     event.tags.push('restbase');
                 }
+                event.triggered_by = triggeredBy;
                 return event;
             })
             .filter((event) => !!event);

--- a/test/features/events/events.js
+++ b/test/features/events/events.js
@@ -21,7 +21,7 @@ describe('Change event emitting', function() {
         });
     });
 
-    function createEventLogging(done, topic, uri) {
+    function createEventLogging(done, topic, uri, trigger) {
         var eventLogging = http.createServer(function(request) {
             try {
                 assert.deepEqual(request.method, 'POST');
@@ -41,6 +41,9 @@ describe('Change event emitting', function() {
                         assert.deepEqual(event.meta.topic, topic);
                         assert.deepEqual(event.meta.uri, uri);
                         assert.deepEqual(event.tags, ['test', 'restbase']);
+                        if (trigger) {
+                            assert.deepEqual(event.triggered_by, trigger);
+                        }
                         done();
                     } catch (e) {
                         done(e);
@@ -99,7 +102,8 @@ describe('Change event emitting', function() {
 
         eventLogging = createEventLogging(really_done,
             'change-prop.transcludes.resource-change',
-            'http://en.wikipedia.org/api/rest_v1/page/html/User:Pchelolo');
+            'http://en.wikipedia.org/api/rest_v1/page/html/User:Pchelolo',
+            'mediawiki.revision-create:https://en.wikimedia.org/wiki/Template:One,change-prop.transcludes.resource-change:https://en.wikipedia.org/wiki/User:Pchelolo');
         return preq.post({
             uri: server.config.baseURL + '/events/',
             headers: {
@@ -132,7 +136,8 @@ describe('Change event emitting', function() {
 
         eventLogging = createEventLogging(really_done,
             'resource_change',
-            'http://en.wikipedia.org/wiki/User:Pchelolo');
+            'http://en.wikipedia.org/wiki/User:Pchelolo',
+            'resource_change:https://en.wikipedia.org/wiki/Prohibited');
 
         return preq.post({
             uri: server.config.baseURL + '/events/',

--- a/test/features/events/events.js
+++ b/test/features/events/events.js
@@ -21,7 +21,7 @@ describe('Change event emitting', function() {
         });
     });
 
-    function createEventLogging(done, topic, uri, trigger) {
+    function createEventLogging(done, eventOptions) {
         var eventLogging = http.createServer(function(request) {
             try {
                 assert.deepEqual(request.method, 'POST');
@@ -38,11 +38,11 @@ describe('Change event emitting', function() {
                         assert.deepEqual(!!new Date(event.meta.dt), true);
                         assert.deepEqual(uuid.test(event.meta.id), true);
                         assert.deepEqual(!!event.meta.request_id, true);
-                        assert.deepEqual(event.meta.topic, topic);
-                        assert.deepEqual(event.meta.uri, uri);
+                        assert.deepEqual(event.meta.topic, eventOptions.topic);
+                        assert.deepEqual(event.meta.uri, eventOptions.uri);
                         assert.deepEqual(event.tags, ['test', 'restbase']);
-                        if (trigger) {
-                            assert.deepEqual(event.triggered_by, trigger);
+                        if (eventOptions.trigger) {
+                            assert.deepEqual(event.triggered_by, eventOptions.trigger);
                         }
                         done();
                     } catch (e) {
@@ -66,9 +66,10 @@ describe('Change event emitting', function() {
             done(e)
         }
 
-        eventLogging = createEventLogging(really_done,
-            'resource_change',
-            'http://en.wikipedia.org/wiki/User:Pchelolo');
+        eventLogging = createEventLogging(really_done, {
+            topic: 'resource_change',
+            uri: 'http://en.wikipedia.org/wiki/User:Pchelolo'
+        });
         return preq.post({
             uri: server.config.baseURL + '/events/',
             headers: {
@@ -100,10 +101,11 @@ describe('Change event emitting', function() {
             done(e)
         }
 
-        eventLogging = createEventLogging(really_done,
-            'change-prop.transcludes.resource-change',
-            'http://en.wikipedia.org/api/rest_v1/page/html/User:Pchelolo',
-            'mediawiki.revision-create:https://en.wikimedia.org/wiki/Template:One,change-prop.transcludes.resource-change:https://en.wikipedia.org/wiki/User:Pchelolo');
+        eventLogging = createEventLogging(really_done, {
+            topic: 'change-prop.transcludes.resource-change',
+            uri: 'http://en.wikipedia.org/api/rest_v1/page/html/User:Pchelolo',
+            trigger: 'mediawiki.revision-create:https://en.wikimedia.org/wiki/Template:One,change-prop.transcludes.resource-change:https://en.wikipedia.org/wiki/User:Pchelolo'
+        });
         return preq.post({
             uri: server.config.baseURL + '/events/',
             headers: {
@@ -134,11 +136,11 @@ describe('Change event emitting', function() {
             done(e)
         }
 
-        eventLogging = createEventLogging(really_done,
-            'resource_change',
-            'http://en.wikipedia.org/wiki/User:Pchelolo',
-            'resource_change:https://en.wikipedia.org/wiki/Prohibited');
-
+        eventLogging = createEventLogging(really_done, {
+            topic: 'resource_change',
+            uri: 'http://en.wikipedia.org/wiki/User:Pchelolo',
+            trigger: 'resource_change:https://en.wikipedia.org/wiki/Prohibited'
+        });
         return preq.post({
             uri: server.config.baseURL + '/events/',
             headers: {


### PR DESCRIPTION
Not sure why wasn't it the case, but it would be useful to propagate the `triggered_by` field further.

cc @wikimedia/services 