### PR TITLE
Throttling limits

### DIFF
--- a/sys/events.js
+++ b/sys/events.js
@@ -29,7 +29,7 @@ EventService.prototype.emitEvent = function(hyper, req) {
         // the same event, it will cause a rerender loop. So, log an error and skip
         // the event.
         var triggeredBy = req.headers && req.headers['x-triggered-by']
-            || hyper._rootReq && hyper._rootReq['x-triggered-by'];
+            || hyper._rootReq && hyper._rootReq.headers && hyper._rootReq.headers['x-triggered-by'];
         var topic = self.options.topic;
         if (triggeredBy && self.options.transcludes_topic
                 && /transcludes/.test(triggeredBy)) {

--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -20,7 +20,7 @@ paths:
         This is the root of all pageview data endpoints.  The list of paths that this returns includes ways to query by article, project, top articles, etc.  If browsing the interactive documentation, see the specifics for each endpoint below.
 
         - Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Stable)
-        - Rate limit: 10 req/s
+        - Rate limit: 50 req/s
       produces:
         - application/json
       responses:
@@ -43,7 +43,7 @@ paths:
         Given a Mediawiki article and a date range, returns a daily timeseries of its pageview counts. You can also filter by access method and/or agent type.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-        - Rate limit: 10 req/s
+        - Rate limit: 50 req/s
       produces:
         - application/json
       parameters:
@@ -99,8 +99,8 @@ paths:
           name: ratelimit_route
           options:
             limits:
-              internal: 10
-              external: 10
+              internal: 50
+              external: 50
       x-request-handler:
         - get_from_backend:
             request:
@@ -118,7 +118,7 @@ paths:
         Given a date range, returns a timeseries of pageview counts. You can filter by project, access method and/or agent type. You can choose between daily and hourly granularity as well.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-        - Rate limit: 10 req/s
+        - Rate limit: 50 req/s
       produces:
         - application/json
       parameters:
@@ -169,8 +169,8 @@ paths:
           name: ratelimit_route
           options:
             limits:
-              internal: 10
-              external: 10
+              internal: 50
+              external: 50
       x-request-handler:
         - get_from_backend:
             request:
@@ -211,7 +211,7 @@ paths:
         Lists the 1000 most viewed articles for a given project and timespan (month or day). You can filter by access method.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-        - Rate limit: 10 req/s
+        - Rate limit: 50 req/s
       produces:
         - application/json
       parameters:
@@ -255,8 +255,8 @@ paths:
           name: ratelimit_route
           options:
             limits:
-              internal: 10
-              external: 10
+              internal: 50
+              external: 50
       x-request-handler:
         - get_from_backend:
             request:
@@ -274,7 +274,7 @@ paths:
         Given a project and a date range, returns a timeseries of unique devices counts. You need to specify a project, and can filter by accessed site (mobile or desktop). You can choose between daily and hourly granularity as well.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-        - Rate limit: 10 req/s
+        - Rate limit: 50 req/s
       produces:
         - application/json
       parameters:
@@ -319,8 +319,8 @@ paths:
           name: ratelimit_route
           options:
             limits:
-              internal: 10
-              external: 10
+              internal: 50
+              external: 50
       x-request-handler:
         - get_from_backend:
             request:

--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -20,7 +20,7 @@ paths:
         This is the root of all pageview data endpoints.  The list of paths that this returns includes ways to query by article, project, top articles, etc.  If browsing the interactive documentation, see the specifics for each endpoint below.
 
         - Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Stable)
-        - Rate limit: 50 req/s
+        - Rate limit: 100 req/s
       produces:
         - application/json
       responses:
@@ -43,7 +43,7 @@ paths:
         Given a Mediawiki article and a date range, returns a daily timeseries of its pageview counts. You can also filter by access method and/or agent type.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-        - Rate limit: 50 req/s
+        - Rate limit: 100 req/s
       produces:
         - application/json
       parameters:
@@ -99,8 +99,8 @@ paths:
           name: ratelimit_route
           options:
             limits:
-              internal: 50
-              external: 50
+              internal: 100
+              external: 100
       x-request-handler:
         - get_from_backend:
             request:
@@ -118,7 +118,7 @@ paths:
         Given a date range, returns a timeseries of pageview counts. You can filter by project, access method and/or agent type. You can choose between daily and hourly granularity as well.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-        - Rate limit: 50 req/s
+        - Rate limit: 100 req/s
       produces:
         - application/json
       parameters:
@@ -169,8 +169,8 @@ paths:
           name: ratelimit_route
           options:
             limits:
-              internal: 50
-              external: 50
+              internal: 100
+              external: 100
       x-request-handler:
         - get_from_backend:
             request:
@@ -211,7 +211,7 @@ paths:
         Lists the 1000 most viewed articles for a given project and timespan (month or day). You can filter by access method.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-        - Rate limit: 50 req/s
+        - Rate limit: 100 req/s
       produces:
         - application/json
       parameters:
@@ -255,8 +255,8 @@ paths:
           name: ratelimit_route
           options:
             limits:
-              internal: 50
-              external: 50
+              internal: 100
+              external: 100
       x-request-handler:
         - get_from_backend:
             request:
@@ -274,7 +274,7 @@ paths:
         Given a project and a date range, returns a timeseries of unique devices counts. You need to specify a project, and can filter by accessed site (mobile or desktop). You can choose between daily and hourly granularity as well.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-        - Rate limit: 50 req/s
+        - Rate limit: 100 req/s
       produces:
         - application/json
       parameters:
@@ -319,8 +319,8 @@ paths:
           name: ratelimit_route
           options:
             limits:
-              internal: 50
-              external: 50
+              internal: 100
+              external: 100
       x-request-handler:
         - get_from_backend:
             request:

--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -275,7 +275,6 @@ paths:
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
         - Rate limit: 100 req/s
->>>>>>> upstream/master
       produces:
         - application/json
       parameters:

--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -101,6 +101,10 @@ paths:
             limits:
               internal: 10
               external: 10
+<<<<<<< HEAD
+=======
+            log_only: true
+>>>>>>> Lowering throttling limits to 10 req/sec
       x-request-handler:
         - get_from_backend:
             request:


### PR DESCRIPTION
Sorry about last pull request, hopefully this one is a clean merge.

Increasing throttling threshold to 100 reqs/sec

    We have moved the pageview API to a new cluster which
    we have load tested to sustain 400 reqs per sec per host without cache.
    Bumping up limits slowly to see whether we truly can get
    the theoretical limit.

    https://wikitech.wikimedia.org/wiki/Analytics/AQS/Scaling/LoadTesting#TL:DR

    Bug: https://phabricator.wikimedia.org/T144497