### PR TITLE
Feed: Increase the table schema version

### DIFF
--- a/v1/feed.js
+++ b/v1/feed.js
@@ -184,6 +184,7 @@ module.exports = (options) => {
         resources: [{
             uri: '/{domain}/sys/key_value/feed.aggregated',
             body: {
+                version: 2,
                 valueType: 'json',
                 retention_policy: {
                     type: 'ttl',


### PR DESCRIPTION
Since we have removed the random portion, `rb-mod-table` complains that the table schemas differ, so bump the version so that it knows it has been done so intentionally.