### PR TITLE
Store historic feed content in a separate bucket

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -411,7 +411,7 @@ mwUtil.hydrateResponse = (response, fetch) => {
         }
 
         if (Array.isArray(node)) {
-            for (let i = 0; i < node.length; i++) {
+            for (let i = node.length - 1; i >= 0; i--) {
                 _traverse(node[i], () => node.splice(i, 1));
             }
         } else if (typeof node === 'object') {

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -411,6 +411,10 @@ mwUtil.hydrateResponse = (response, fetch) => {
         }
 
         if (Array.isArray(node)) {
+            // If the item is not available we need to delete it from the array
+            // using the callback with splice. The callbacks are executed in the same
+            // order as they're created here, so reverse the iteration order to
+            // make removal of multiple elements work correctly.
             for (let i = node.length - 1; i >= 0; i--) {
                 _traverse(node[i], () => node.splice(i, 1));
             }

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -390,11 +390,10 @@ mwUtil.isSelfRedirect = (req, location) => {
  * Traverses through a request body and replaces the given keys with
  * the content fetched using the 'fetch' callback
  *
- * @param responce
+ * @param response
  * @param fetch
- * @param mergeKey
  */
-mwUtil.populate = (responce, fetch, mergeKey) => {
+mwUtil.hydrateResponse = (response, fetch) => {
     const requests = {};
     const setters = [];
 
@@ -407,11 +406,7 @@ mwUtil.populate = (responce, fetch, mergeKey) => {
                 } else if (removeFromParent) {
                     removeFromParent();
                 }
-                // TODO: We would normally delete it anyway,
-                // this check is here until we remove a hack with populating $merge internally
-                if (mergeKey.indexOf('$') !== -1) {
-                    delete node[mergeKey];
-                }
+                delete node.$merge;
             });
         }
 
@@ -420,20 +415,18 @@ mwUtil.populate = (responce, fetch, mergeKey) => {
                 _traverse(node[i], () => node.splice(i, 1));
             }
         } else if (typeof node === 'object') {
-            if (Array.isArray(node[mergeKey])) {
-                node[mergeKey].forEach(requestResource);
-            } else if (node[mergeKey]) {
-                requestResource(node[mergeKey]);
+            if (Array.isArray(node.$merge)) {
+                node.$merge.forEach(requestResource);
             } else {
                 Object.keys(node).forEach((key) => _traverse(node[key], () => delete node[key]));
             }
         }
     }
-    _traverse(responce.body);
+    _traverse(response.body);
 
     return P.props(requests)
     .then((content) => setters.forEach((setter) => setter(content)))
-    .thenReturn(responce);
+    .thenReturn(response);
 };
 
 module.exports = mwUtil;

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -386,4 +386,54 @@ mwUtil.isSelfRedirect = (req, location) => {
     return true;
 };
 
+/**
+ * Traverses through a request body and replaces the given keys with
+ * the content fetched using the 'fetch' callback
+ *
+ * @param responce
+ * @param fetch
+ * @param mergeKey
+ */
+mwUtil.populate = (responce, fetch, mergeKey) => {
+    const requests = {};
+    const setters = [];
+
+    function _traverse(node, removeFromParent) {
+        function requestResource(resource) {
+            requests[resource] = requests[resource] || fetch(resource);
+            setters.push((content) => {
+                if (content[resource]) {
+                    Object.assign(node, content[resource]);
+                } else if (removeFromParent) {
+                    removeFromParent();
+                }
+                // TODO: We would normally delete it anyway,
+                // this check is here until we remove a hack with populating $merge internally
+                if (mergeKey.indexOf('$') !== -1) {
+                    delete node[mergeKey];
+                }
+            });
+        }
+
+        if (Array.isArray(node)) {
+            for (let i = 0; i < node.length; i++) {
+                _traverse(node[i], () => node.splice(i, 1));
+            }
+        } else if (typeof node === 'object') {
+            if (Array.isArray(node[mergeKey])) {
+                node[mergeKey].forEach(requestResource);
+            } else if (node[mergeKey]) {
+                requestResource(node[mergeKey]);
+            } else {
+                Object.keys(node).forEach((key) => _traverse(node[key], () => delete node[key]));
+            }
+        }
+    }
+    _traverse(responce.body);
+
+    return P.props(requests)
+    .then((content) => setters.forEach((setter) => setter(content)))
+    .thenReturn(responce);
+};
+
 module.exports = mwUtil;

--- a/test/features/mwutils.js
+++ b/test/features/mwutils.js
@@ -20,6 +20,9 @@ describe('Utils.hydrateResponse', () => {
                         $merge: ['you_shall_not_pass']
                     },
                     {
+                        $merge: ['you_shall_not_pass']
+                    },
+                    {
                         prop: 'this_will_be_overwritten',
                         $merge: ['prop_contained_here']
                     }

--- a/test/features/mwutils.js
+++ b/test/features/mwutils.js
@@ -1,0 +1,60 @@
+'use strict';
+
+/**
+ * Unit tests for util methods
+ */
+
+const P = require('bluebird');
+const mwUtil = require('../../lib/mwUtil');
+const assert = require('../utils/assert');
+
+describe('Utils.populate', () => {
+    it('Should support $merge', () => {
+        const responce = {
+            body: {
+                non_existent: {
+                    $merge: ['you_shall_not_pass']
+                },
+                array: [
+                    {
+                        $merge: ['you_shall_not_pass']
+                    },
+                    {
+                        prop: 'this_will_be_overwritten',
+                        $merge: ['prop_contained_here']
+                    }
+                ],
+                object: {
+                    some_other_prop: 'hello',
+                    $merge: ['prop_contained_here']
+                }
+            }
+        };
+
+        return mwUtil.populate(responce, (uri) => {
+            switch (uri) {
+                case 'you_shall_not_pass':
+                    return P.resolve(undefined);
+                case 'prop_contained_here':
+                    return P.resolve({
+                        prop: 'prop_value'
+                    });
+                default:
+                    return P.reject(new Error('What?'));
+            }
+        }, '$merge')
+        .then((responce) => {
+            assert.deepEqual(responce, {
+                body: {
+                    array: [{
+                        prop: 'prop_value'
+                    }],
+                    object: {
+                        some_other_prop: 'hello',
+                        prop: 'prop_value'
+                    }
+                }
+            });
+        });
+    });
+});

--- a/test/features/mwutils.js
+++ b/test/features/mwutils.js
@@ -8,7 +8,7 @@ const P = require('bluebird');
 const mwUtil = require('../../lib/mwUtil');
 const assert = require('../utils/assert');
 
-describe('Utils.populate', () => {
+describe('Utils.hydrateResponse', () => {
     it('Should support $merge', () => {
         const responce = {
             body: {
@@ -31,7 +31,7 @@ describe('Utils.populate', () => {
             }
         };
 
-        return mwUtil.populate(responce, (uri) => {
+        return mwUtil.hydrateResponse(responce, (uri) => {
             switch (uri) {
                 case 'you_shall_not_pass':
                     return P.resolve(undefined);
@@ -42,7 +42,7 @@ describe('Utils.populate', () => {
                 default:
                     return P.reject(new Error('What?'));
             }
-        }, '$merge')
+        })
         .then((responce) => {
             assert.deepEqual(responce, {
                 body: {

--- a/test/features/schema_tests.js
+++ b/test/features/schema_tests.js
@@ -11,6 +11,11 @@ var Ajv = require('ajv');
 describe('Responses should conform to the provided JSON schema of the responce', function() {
     var ajv = new Ajv({});
 
+    function getToday() {
+        const now = new Date();
+        return `${now.getUTCFullYear()}/${now.getUTCMonth() + 1}/${now.getUTCDate()}`;
+    }
+
     before(function() {
         return server.start()
         .then(function() { return preq.get({ uri: server.config.baseURL + '/?spec' }); })
@@ -22,7 +27,7 @@ describe('Responses should conform to the provided JSON schema of the responce',
     });
 
     it('/feed/featured should conform schema', function() {
-        return preq.get({ uri: server.config.baseURL + '/feed/featured/2016/09/08' })
+        return preq.get({ uri: `${server.config.baseURL}/feed/featured/${getToday()}` })
         .then(function(res) {
             if (!ajv.validate('#/definitions/feed', res.body)) {
                 throw new assert.AssertionError({
@@ -33,7 +38,7 @@ describe('Responses should conform to the provided JSON schema of the responce',
     });
 
     it('/feed/featured should conform schema, ruwiki', function() {
-        return preq.get({ uri: server.config.hostPort + '/ru.wikipedia.org/v1/feed/featured/2016/09/08' })
+        return preq.get({ uri: `${server.config.hostPort}/ru.wikipedia.org/v1/feed/featured/${getToday()}` })
         .then(function(res) {
             if (!ajv.validate('#/definitions/feed', res.body)) {
                 throw new assert.AssertionError({

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -148,6 +148,9 @@ class Feed {
             _traverse(response);
             return response;
         };
+        const getContent = (bucket) => hyper.get({
+            uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated', dateKey])
+        });
         const storeContent = (res, bucket) => {
             return hyper.put({
                 uri: new URI([rp.domain, 'sys', 'key_value', bucket, date]),
@@ -156,9 +159,7 @@ class Feed {
             });
         };
         const getCurrentContent = () => {
-            return hyper.get({
-                uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated', dateKey])
-            })
+            return getContent('feed.aggregated')
             .catch({ status: 404 }, () =>
                 // it's a cache miss, so we need to request all
                 // of the components and store them
@@ -174,9 +175,7 @@ class Feed {
                 }));
         };
         const getHistoricContent = () => {
-            return hyper.get({
-                uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated.historic', dateKey])
-            })
+            return getContent('feed.aggregated.historic')
             .catch({ status: 404 }, () =>
                 // it's a cache miss, so we need to request all
                 // of the components and store them (but don't request news)
@@ -191,12 +190,7 @@ class Feed {
         };
 
 
-        let contentRequest;
-        if (isHistoric(date)) {
-            contentRequest = getHistoricContent();
-        } else {
-            contentRequest = getCurrentContent();
-        }
+        const contentRequest = isHistoric(date) ? getHistoricContent() : getCurrentContent();
         return contentRequest.then(populateSummaries);
     }
 }

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -10,7 +10,6 @@ const HTTPError = HyperSwitch.HTTPError;
 
 const spec = HyperSwitch.utils.loadSpec(`${__dirname}/feed.yaml`);
 
-
 const DEFAULT_TTL = 3600;
 
 const FEED_URIS = {
@@ -20,10 +19,46 @@ const FEED_URIS = {
     news: { uri: ['v1', 'page', 'news'], date: false }
 };
 
+/**
+ * Checks whether the date is today or in the past in UTC-0 timezone
+ *
+ * @param {Date} date a date to check
+ * @return {boolean} true if the date is in the past
+ */
 function isHistoric(date) {
     const now = new Date();
     const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
     return date < today;
+}
+
+/**
+ * Safely builds the Date from request parameters
+ *
+ * @param {Object} rp request parameters object
+ * @return {Date} the requested date.
+ */
+function getDateSafe(rp) {
+    try {
+        return new Date(Date.UTC(rp.yyyy, rp.mm - 1, rp.dd));
+    } catch (err) {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'bad_request',
+                description: 'wrong date format specified'
+            }
+        });
+    }
+}
+
+/**
+ * Converts the date to the bucket key, key the records in the format YYYY-MM-DD
+ *
+ * @param {Date} date the date to convert
+ * @return {string}
+ */
+function toKey(date) {
+    return date.toISOString().split('T').shift();
 }
 
 class Feed {
@@ -47,135 +82,158 @@ class Feed {
         return P.props(props);
     }
 
-    aggregated(hyper, req) {
-        const rp = req.params;
-        let date;
-        let dateArr;
+    _assembleResult(result, dateArr) {
+        // assemble the final response to be returned
+        const finalResult = {
+            status: 200,
+            headers: {
+                'cache-control': this.options.feed_cache_control,
+                // mimic MCS' ETag value
+                etag: `${dateArr.join('')}/${uuid.now().toString()}`,
+                // TODO: need a way to dynamically derive this
+                'content-type': 'application/json; charset=utf-8; ' +
+                'profile="https://www.mediawiki.org/wiki/Specs/aggregated-feed/0.5.0"'
+            },
+            body: {}
+        };
+        // populate its body
+        Object.keys(result).forEach((key) => {
+            if (result[key].body && Object.keys(result[key].body).length) {
+                finalResult.body[key] = result[key].body;
+            }
+        });
+        return finalResult;
+    }
 
-        // key the records on the date in the format YYYY-MM-DD
-        try {
-            date = new Date(Date.UTC(rp.yyyy, rp.mm - 1, rp.dd));
-            date = date.toISOString().split('T').shift();
-            dateArr = date.split('-');
-        } catch (err) {
-            throw new HTTPError({
-                status: 400,
-                body: {
-                    type: 'bad_request',
-                    description: 'wrong date format specified'
-                }
-            });
+    _populateSummaries(hyper, req, res) {
+        const feed = res.body;
+        const summaries = {};
+        const requestTitle = (title) => {
+            if (title && !summaries[title]) {
+                summaries[title] = hyper.get({
+                    uri: new URI([req.params.domain, 'v1', 'page', 'summary', title])
+                })
+                .get('body')
+                // Swallow the error, no need to fail the whole feed
+                // request because of one failed summary fetch
+                .catchReturn(undefined);
+            }
+        };
+
+        if (feed.tfa) {
+            requestTitle(feed.tfa.title);
         }
-
-        let feedRequest;
-        if (isHistoric(date)) {
-            feedRequest = hyper.get({
-                uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated.historic', date])
-            });
-        } else {
-            feedRequest = hyper.get({
-                uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated', date])
-            })
-            .catch({ status: 404 }, () => // it's a cache miss, so we need to request all
-                // of the components and store them
-                this._makeFeedRequests(Object.keys(FEED_URIS), hyper, rp, dateArr)
-                .then((result) => {
-                    // assemble the final response to be returned
-                    const finalResult = {
-                        status: 200,
-                        headers: {
-                            'cache-control': this.options.feed_cache_control,
-                            // mimic MCS' ETag value
-                            etag: `${dateArr.join('')}/${uuid.now().toString()}`,
-                            // TODO: need a way to dynamically derive this
-                            'content-type': 'application/json; charset=utf-8; ' +
-                            'profile="https://www.mediawiki.org/wiki/Specs/aggregated-feed/0.5.0"'
-                        },
-                        body: {}
-                    };
-                    // populate its body
-                    Object.keys(result).forEach((key) => {
-                        if (result[key].body && Object.keys(result[key].body).length) {
-                            finalResult.body[key] = result[key].body;
-                        }
+        if (feed.mostread && feed.mostread.articles) {
+            feed.mostread.articles.forEach((article) => { requestTitle(article.title); });
+        }
+        if (feed.news) {
+            feed.news.forEach((newsItem) => {
+                if (newsItem.links) {
+                    newsItem.links.forEach((article) => {
+                        requestTitle(article.title);
                     });
-                    // store it, and update the historic
-                    return hyper.put({
-                        uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated', date]),
-                        headers: finalResult.headers,
-                        body: finalResult.body
-                    }).then(() => finalResult);
-                }));
+                }
+            });
         }
 
-        return feedRequest
-        .then((res) => {
-            // We've got the titles, populate them with summaries
-            const feed = res.body;
-            const summaries = {};
-            const requestTitle = (title) => {
-                if (title && !summaries[title]) {
-                    summaries[title] = hyper.get({
-                        uri: new URI([rp.domain, 'v1', 'page', 'summary', title])
-                    })
-                    .get('body')
-                    // Swallow the error, no need to fail the whole feed
-                    // request because of one failed summary fetch
-                    .catchReturn(undefined);
+        return P.props(summaries)
+        .then((summaries) => {
+            const assignSummary = (article) => {
+                if (!summaries[article.title]) {
+                    return;
                 }
+                // MCS expects the title to be a DB Key
+                delete summaries[article.title].title;
+                const result = Object.assign(article, summaries[article.title]);
+                if (!result.normalizedtitle) {
+                    result.normalizedtitle = result.title.replace(/_/g, ' ');
+                }
+                return result;
             };
 
-            if (feed.tfa) {
-                requestTitle(feed.tfa.title);
+            const assignAllSummaries = (articles) => {
+                if (!articles) {
+                    return;
+                }
+                return articles.map(assignSummary).filter((article) => !!article);
+            };
+
+            feed.tfa = feed.tfa && assignSummary(feed.tfa);
+            if (feed.mostread) {
+                feed.mostread.articles = assignAllSummaries(feed.mostread.articles);
             }
-            if (feed.mostread && feed.mostread.articles) {
-                feed.mostread.articles.forEach((article) => { requestTitle(article.title); });
-            }
+
             if (feed.news) {
                 feed.news.forEach((newsItem) => {
-                    if (newsItem.links) {
-                        newsItem.links.forEach((article) => {
-                            requestTitle(article.title);
-                        });
-                    }
+                    newsItem.links = assignAllSummaries(newsItem.links);
                 });
             }
+            return res;
+        });
+    }
 
-            return P.props(summaries)
-            .then((summaries) => {
-                const assignSummary = (article) => {
-                    if (!summaries[article.title]) {
-                        return;
-                    }
-                    // MCS expects the title to be a DB Key
-                    delete summaries[article.title].title;
-                    const result = Object.assign(article, summaries[article.title]);
-                    if (!result.normalizedtitle) {
-                        result.normalizedtitle = result.title.replace(/_/g, ' ');
-                    }
-                    return result;
-                };
 
-                const assignAllSummaries = (articles) => {
-                    if (!articles) {
-                        return;
-                    }
-                    return articles.map(assignSummary).filter((article) => !!article);
-                };
+    _getHistoricContent(hyper, req, date) {
+        const rp = req.params;
+        const dateKey = toKey(date);
+        const dateArr = dateKey.split('-');
+        return hyper.get({
+            uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated.historic', dateKey])
+        })
+        .catch({ status: 404 }, () =>
+            // it's a cache miss, so we need to request all
+            // of the components and store them (but don't request news)
+            this._makeFeedRequests([ 'tfa', 'mostread', 'image' ], hyper, rp, dateArr)
+            .then((result) => this._assembleResult(result, dateArr))
+            .then((res) => this._populateSummaries(hyper, req, res))
+            .tap((res) => {
+                hyper.put({
+                    uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated.historic', date]),
+                    headers: res.headers,
+                    body: res.body
+                });
+            })
+        );
+    }
 
-                feed.tfa = feed.tfa && assignSummary(feed.tfa);
-                if (feed.mostread) {
-                    feed.mostread.articles = assignAllSummaries(feed.mostread.articles);
-                }
-
-                if (feed.news) {
-                    feed.news.forEach((newsItem) => {
-                        newsItem.links = assignAllSummaries(newsItem.links);
-                    });
-                }
-                return res;
+    _getCurrentContent(hyper, req, date) {
+        const rp = req.params;
+        const dateKey = toKey(date);
+        const dateArr = dateKey.split('-');
+        return hyper.get({
+            uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated', dateKey])
+        })
+        .catch({ status: 404 }, () =>
+            // it's a cache miss, so we need to request all
+            // of the components and store them
+            this._makeFeedRequests(Object.keys(FEED_URIS), hyper, rp, dateArr)
+            .then((result) => {
+                const finalResult = this._assembleResult(result, dateArr);
+                // Store it
+                return hyper.put({
+                    uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated', date]),
+                    headers: finalResult.headers,
+                    body: finalResult.body
+                }).thenReturn(finalResult);
+            }))
+        .then((res) => this._populateSummaries(hyper, req, res))
+        .tap((res) => {
+            hyper.put({
+                uri: new URI([rp.domain, 'sys', 'key_value', 'feed.aggregated.historic', date]),
+                headers: res.headers,
+                body: res.body
             });
         });
+    }
+
+    aggregated(hyper, req) {
+        const rp = req.params;
+        const date = getDateSafe(rp);
+        if (isHistoric(date)) {
+            return this._getHistoricContent(hyper, req, date);
+        } else {
+            return this._getCurrentContent(hyper, req, date);
+        }
     }
 }
 

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -121,7 +121,7 @@ class Feed {
                 return hyper.get({ uri })
                 .then((res) => {
                     res.body.normalizedtitle = res.body.title;
-                    res.body.title = res.body.title.replace(/ /g, '_'); // MSC expects title to be the db-key
+                    res.body.title = res.body.title.replace(/ /g, '_');
                     return res.body;
                 })
                 // Swallow the error, no need to fail the whole feed

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -120,8 +120,8 @@ class Feed {
             function fetchSummary(uri) {
                 return hyper.get({ uri })
                 .then((res) => {
-                    res.body.normalizedtitle = res.body.title.replace(/_/g, ' ');
-                    delete res.body.title; // MSC expects title to be the db-key
+                    res.body.normalizedtitle = res.body.title;
+                    res.body.title = res.body.title.replace(/ /g, '_'); // MSC expects title to be the db-key
                     return res.body;
                 })
                 // Swallow the error, no need to fail the whole feed

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -65,6 +65,16 @@ function toKey(date) {
     return date.toISOString().split('T').shift();
 }
 
+function constructBody(result) {
+    const body = {};
+    Object.keys(result).forEach((key) => {
+        if (result[key].body && Object.keys(result[key].body).length) {
+            body[key] = result[key].body;
+        }
+    });
+    return body;
+}
+
 
 class Feed {
     constructor(options) {
@@ -89,7 +99,7 @@ class Feed {
 
     _assembleResult(result, dateArr) {
         // assemble the final response to be returned
-        const finalResult = {
+        return {
             status: 200,
             headers: {
                 'cache-control': this.options.feed_cache_control,
@@ -97,15 +107,8 @@ class Feed {
                 etag: `${dateArr.join('')}/${uuid.now().toString()}`,
                 'content-type': CONTENT_TYPE
             },
-            body: {}
+            body: constructBody(result)
         };
-        // hydrateResponse its body
-        Object.keys(result).forEach((key) => {
-            if (result[key].body && Object.keys(result[key].body).length) {
-                finalResult.body[key] = result[key].body;
-            }
-        });
-        return finalResult;
     }
 
     aggregated(hyper, req) {

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -153,7 +153,7 @@ class Feed {
         });
         const storeContent = (res, bucket) => {
             return hyper.put({
-                uri: new URI([rp.domain, 'sys', 'key_value', bucket, date]),
+                uri: new URI([rp.domain, 'sys', 'key_value', bucket, dateKey]),
                 headers: res.headers,
                 body: res.body
             });

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -73,11 +73,6 @@ paths:
                     title: /.+/
                     pageid: /.+/
                     normalizedtitle: /.+/
-              news:
-                - story: /.+/
-                  links:
-                    - normalizedtitle: /.+/
-                      title: /.+/
               image:
                 title: /.+/
                 description:


### PR DESCRIPTION
The goal is to have historic content for the news section (and for other feed peices). The solution is to have a separate bucket for historic content. So if the date is 'today, or future' - work as before - have separate bucket with TTL. If it's yesterday - take content from a historic bucket without TTL.

Open questions:
 - Right now the latest state of the current bucket at a particular date would be forever persisted as a history - is that OK? What if some clever vandal changes the featured title at 23.59.59 UTC?
 - It's possible to get some parts of featured content for the older days. Should we attempt to do it? How long ago can we fetch the featured content? Month? Year?

cc @wikimedia/services @wikimedia/mobile
Bug: https://phabricator.wikimedia.org/T139481