### PR TITLE
Better logging for siteInfo fetching issues

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -275,17 +275,22 @@ mwUtil.getSiteInfo = (hyper, req) => {
                 siprop: 'general|namespaces|namespacealiases'
             }
         })
-        .then((res) => ({
-            general: {
-                lang: res.body.query.general.lang,
-                legaltitlechars: res.body.query.general.legaltitlechars,
-                case: res.body.query.general.case
-            },
+        .then((res) => {
+            if (!res || !res.body || !res.body.query || !res.body.query.general) {
+                throw new Error(`SiteInfo is unavailable for ${rp.domain}`);
+            }
+            return {
+                general: {
+                    lang: res.body.query.general.lang,
+                    legaltitlechars: res.body.query.general.legaltitlechars,
+                    case: res.body.query.general.case
+                },
 
-            namespaces: res.body.query.namespaces,
-            namespacealiases: res.body.query.namespacealiases,
-            sharedRepoRootURI: findSharedRepoDomain(res)
-        }))
+                namespaces: res.body.query.namespaces,
+                namespacealiases: res.body.query.namespacealiases,
+                sharedRepoRootURI: findSharedRepoDomain(res)
+            };
+        })
         .catch((e) => {
             hyper.log('error/site_info', e);
             delete siteInfoCache[rp.domain];


### PR DESCRIPTION
Properly detect that siteInfo is unavailable and log a normal message instead of failing with `TypeError`
