### PR TITLE
Blacklist some large, high-traffic, bot-generated pages

### DIFF
--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -147,6 +147,13 @@ paths:
                         Commons:Quality_images_candidates/candidate_list: true
                       ceb.wikipedia.org:
                         Gumagamit:Lsjbot/Anomalier-PRIVAT: true
+                      sv.wikipedia.org:
+                        Användare:Lsjbot/Anomalier-PRIVAT: true
+                        Användare:Lsjbot/Namnkonflikter-PRIVAT: true
+                      fr.wikipedia.org:
+                        Utilisateur:ZéroBot/Log/Erreurs: true
+                      ca.wikipedia.org:
+                        Usuari:TronaBot/log:Activitat_reversors_per_hores: true
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.yaml


### PR DESCRIPTION
As noted in the ticket, these entries come from https://docs.google.com/spreadsheets/d/1Cn2z-DPbmjigTHTW3kmuPhn5Tre-yMU6v4jnTMIv6Mo, which in turn was taken from this week's wide partition report (emailed to services@wikimedia.org).  They represent some of the widest partitions from last week, and are the ones most obviously (to me) machine-generated lists.

Bug: https://phabricator.wikimedia.org/T149203