### PR TITLE
Don't set accept-encoding: gzip on request to MCS

### DIFF
--- a/sys/mobileapps.yaml
+++ b/sys/mobileapps.yaml
@@ -39,6 +39,7 @@ paths:
             request:
               method: get
               uri: '{+options.host}/{domain}/v1/page/mobile-sections/{title}'
+              gzip: false
         - store_lead:
             request:
               method: put


### PR DESCRIPTION
Since nginx correctly strips out the `ETag` [when the content is gzipped](https://phabricator.wikimedia.org/T148676) let's try to avoid gzipping it on requests to backend services. In production that might actually be faster then using gzip encoding, because the latency within the datacenter is very low. 

It's not that easy to test the difference and the effect this is going to make, so let's try to update production and see if there's any noticeable performance improvement/degradation

cc @wikimedia/services 