### PR TITLE
Implemented internal siteInfo endpoint

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -20,6 +20,7 @@ default_project: &default_project
           host: http://parsoid-beta.wmflabs.org
         action:
           apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
+          baseUriTemplate: "{{'https://{domain}/api/rest_v1'}}"
         graphoid:
           host: http://graphoid.wikimedia.org
         mathoid:

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -27,6 +27,7 @@ default_project: &default_project
           host: http://parsoid-beta.wmflabs.org
         action:
           apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
+          baseUriTemplate: "{{'https://{domain}/api/rest_v1'}}"
         graphoid:
           host: http://graphoid-beta.wmflabs.org
         mathoid:
@@ -43,10 +44,7 @@ labs_project: &labs_project
   x-modules:
     - path: test/test_module.yaml
     - path: projects/wmf_default.yaml
-      options:
-        <<: *default_options
-        action:
-          apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
+      options: *default_options
 
 # A different project template, sharing configuration options.
 wikimedia.org: &wikimedia.org

--- a/lib/content_location_filter.js
+++ b/lib/content_location_filter.js
@@ -1,36 +1,39 @@
 "use strict";
 
 const HyperSwitch = require('hyperswitch');
-const Template = HyperSwitch.Template;
 const URI = HyperSwitch.URI;
 const mwUtil = require('./mwUtil');
 
-let basePathTemplate;
-
-module.exports = (hyper, req, next, options) => {
-    basePathTemplate = basePathTemplate || new Template({
-        uri: options.templates.base_uri_template
-    });
+module.exports = (hyper, req, next) => {
     if (req.method !== 'get') {
         return next(hyper, req);
     } else {
-        const baseUri = basePathTemplate.expand({
-            request: req
-        }).uri;
         const attachLocation = (res) => {
-            if (res.status !== 301 && res.status !== 302) {
-                res.headers = res.headers || {};
-                Object.assign(res.headers, {
-                    'content-location': baseUri
-                        + new URI(req.uri.path.slice(2))
-                        + mwUtil.getQueryString(req)
-                });
+            res.headers = res.headers || {};
+            if (res.status === 301 || res.status === 302
+                    || res.headers['content-location']) {
+                return res;
             }
+            return hyper.get({
+                uri: new URI([req.params.domain, 'sys', 'action', 'siteinfo'])
+            })
+            .then((siteInfo) => {
+                Object.assign(res.headers, {
+                    'content-location': siteInfo.body.baseUri
+                    + new URI(req.uri.path.slice(2))
+                    + mwUtil.getQueryString(req)
+                });
+                return res;
+            });
+        };
+
+        return next(hyper, req)
+        .then(attachLocation)
+        .catch(attachLocation)
+        .tap((res) => {
             if (res.status >= 400) {
                 throw res;
             }
-            return res;
-        };
-        return next(hyper, req).then(attachLocation).catch(attachLocation);
+        });
     }
 };

--- a/lib/content_location_filter.js
+++ b/lib/content_location_filter.js
@@ -14,12 +14,10 @@ module.exports = (hyper, req, next) => {
                     || res.headers['content-location']) {
                 return res;
             }
-            return hyper.get({
-                uri: new URI([req.params.domain, 'sys', 'action', 'siteinfo'])
-            })
+            return mwUtil.getSiteInfo(hyper, req)
             .then((siteInfo) => {
                 Object.assign(res.headers, {
-                    'content-location': siteInfo.body.baseUri
+                    'content-location': siteInfo.baseUri
                     + new URI(req.uri.path.slice(2))
                     + mwUtil.getQueryString(req)
                 });
@@ -28,8 +26,7 @@ module.exports = (hyper, req, next) => {
         };
 
         return next(hyper, req)
-        .then(attachLocation)
-        .catch(attachLocation)
+        .then(attachLocation, attachLocation)
         .tap((res) => {
             if (res.status >= 400) {
                 throw res;

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -32,8 +32,10 @@ mwUtil.makeETag = (rev, tid, suffix) => {
 /**
  * Normalizes the request.params.title and returns it back
  */
-mwUtil.normalizeTitle = (hyper, req, title) => mwUtil.getSiteInfo(hyper, req)
-.then((siteInfo) => Title.newFromText(title, siteInfo))
+mwUtil.normalizeTitle = (hyper, req, title) => hyper.get({
+    uri: new URI([req.params.domain, 'sys', 'action', 'siteinfo'])
+})
+.then((siteInfo) => Title.newFromText(title, siteInfo.body))
 .catch((e) => {
     throw new HTTPError({
         status: 400,
@@ -253,51 +255,6 @@ mwUtil.decodeBody = (contentResponse) => {
         contentResponse.body = body;
         return contentResponse;
     });
-};
-
-function findSharedRepoDomain(siteInfoRes) {
-    const sharedRepo = (siteInfoRes.body.query.repos || []).find((repo) => repo.name === 'shared');
-    if (sharedRepo) {
-        const domainMatch = /^((:?https?:)?\/\/[^/]+)/.exec(sharedRepo.descBaseUrl);
-        if (domainMatch) {
-            return domainMatch[0];
-        }
-    }
-}
-
-const siteInfoCache = {};
-mwUtil.getSiteInfo = (hyper, req) => {
-    const rp = req.params;
-    if (!siteInfoCache[rp.domain]) {
-        siteInfoCache[rp.domain] = hyper.post({
-            uri: new URI([rp.domain, 'sys', 'action', 'siteinfo']),
-            body: {
-                siprop: 'general|namespaces|namespacealiases'
-            }
-        })
-        .then((res) => {
-            if (!res || !res.body || !res.body.query || !res.body.query.general) {
-                throw new Error(`SiteInfo is unavailable for ${rp.domain}`);
-            }
-            return {
-                general: {
-                    lang: res.body.query.general.lang,
-                    legaltitlechars: res.body.query.general.legaltitlechars,
-                    case: res.body.query.general.case
-                },
-
-                namespaces: res.body.query.namespaces,
-                namespacealiases: res.body.query.namespacealiases,
-                sharedRepoRootURI: findSharedRepoDomain(res)
-            };
-        })
-        .catch((e) => {
-            hyper.log('error/site_info', e);
-            delete siteInfoCache[rp.domain];
-            throw e;
-        });
-    }
-    return siteInfoCache[rp.domain];
 };
 
 mwUtil.getQueryString = (req) => {

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -32,10 +32,8 @@ mwUtil.makeETag = (rev, tid, suffix) => {
 /**
  * Normalizes the request.params.title and returns it back
  */
-mwUtil.normalizeTitle = (hyper, req, title) => hyper.get({
-    uri: new URI([req.params.domain, 'sys', 'action', 'siteinfo'])
-})
-.then((siteInfo) => Title.newFromText(title, siteInfo.body))
+mwUtil.normalizeTitle = (hyper, req, title) =>  mwUtil.getSiteInfo(hyper, req)
+.then((siteInfo) => Title.newFromText(title, siteInfo))
 .catch((e) => {
     throw new HTTPError({
         status: 400,
@@ -256,6 +254,10 @@ mwUtil.decodeBody = (contentResponse) => {
         return contentResponse;
     });
 };
+
+mwUtil.getSiteInfo = (hyper, req) => hyper.get({
+    uri: new URI([req.params.domain, 'sys', 'action', 'siteinfo'])
+}).get('body');
 
 mwUtil.getQueryString = (req) => {
     if (Object.keys(req.query).length) {

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -2,7 +2,6 @@
 
 const HyperSwitch = require('hyperswitch');
 const HTTPError = HyperSwitch.HTTPError;
-const URI = HyperSwitch.URI;
 const mwUtil = require('./mwUtil');
 const P = require('bluebird');
 
@@ -65,11 +64,9 @@ module.exports = (hyper, req, next, options, specInfo) => {
             }
         }
         if (normalizeResult.getNamespace().isFile() && req.query.redirect !== false) {
-            return next(hyper, req).catch({ status: 404 }, (e) => hyper.get({
-                uri: new URI([rp.domain, 'sys', 'action', 'siteinfo'])
-            })
+            return next(hyper, req).catch({ status: 404 }, (e) => mwUtil.getSiteInfo(hyper, req)
             .then((siteInfo) => {
-                if (siteInfo.body.sharedRepoRootURI && !mwUtil.isNoCacheRequest(req)) {
+                if (siteInfo.sharedRepoRootURI && !mwUtil.isNoCacheRequest(req)) {
                     // It's a file page and it might be in the shared repo.
                     // Redirect.
                     const commonsTitle = `${normalizeResult.getNamespace().getCanonicalText()}`
@@ -78,7 +75,7 @@ module.exports = (hyper, req, next, options, specInfo) => {
                     redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2)
                         .replace(encodeURIComponent(rp.title),
                             encodeURIComponent(commonsTitle));
-                    redirectPath = `${siteInfo.body.sharedRepoRootURI}/api/rest_v1`
+                    redirectPath = `${siteInfo.sharedRepoRootURI}/api/rest_v1`
                         + `${redirectPath}${mwUtil.getQueryString(req)}`;
                     return {
                         status: 302,

--- a/lib/normalize_title_filter.js
+++ b/lib/normalize_title_filter.js
@@ -2,6 +2,7 @@
 
 const HyperSwitch = require('hyperswitch');
 const HTTPError = HyperSwitch.HTTPError;
+const URI = HyperSwitch.URI;
 const mwUtil = require('./mwUtil');
 const P = require('bluebird');
 
@@ -64,9 +65,11 @@ module.exports = (hyper, req, next, options, specInfo) => {
             }
         }
         if (normalizeResult.getNamespace().isFile() && req.query.redirect !== false) {
-            return next(hyper, req).catch({ status: 404 }, (e) => mwUtil.getSiteInfo(hyper, req)
+            return next(hyper, req).catch({ status: 404 }, (e) => hyper.get({
+                uri: new URI([rp.domain, 'sys', 'action', 'siteinfo'])
+            })
             .then((siteInfo) => {
-                if (siteInfo.sharedRepoRootURI && !mwUtil.isNoCacheRequest(req)) {
+                if (siteInfo.body.sharedRepoRootURI && !mwUtil.isNoCacheRequest(req)) {
                     // It's a file page and it might be in the shared repo.
                     // Redirect.
                     const commonsTitle = `${normalizeResult.getNamespace().getCanonicalText()}`
@@ -75,7 +78,7 @@ module.exports = (hyper, req, next, options, specInfo) => {
                     redirectPath = redirectPath.substr(redirectPath.indexOf('v1') + 2)
                         .replace(encodeURIComponent(rp.title),
                             encodeURIComponent(commonsTitle));
-                    redirectPath = `${siteInfo.sharedRepoRootURI}/api/rest_v1`
+                    redirectPath = `${siteInfo.body.sharedRepoRootURI}/api/rest_v1`
                         + `${redirectPath}${mwUtil.getQueryString(req)}`;
                     return {
                         status: 302,

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -38,14 +38,6 @@ paths:
           # Override the base path for host-based (proxied) requests. In our case,
           # we proxy https://{domain}/api/rest_v1/ to the API.
           x-host-basePath: /api/rest_v1
-          x-route-filters:
-            - path: ./lib/normalize_title_filter.js
-              options:
-                redirect_cache_control: '{{options.purged_cache_control}}'
-            - path: lib/content_location_filter.js
-              options:
-                templates:
-                  base_uri_template: 'https://{{request.params.domain}}/api/rest_v1'
           paths:
             /media:
               x-modules:

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -35,9 +35,6 @@ paths:
               options:
                 redirect_cache_control: '{{options.purged_cache_control}}'
             - path: lib/content_location_filter.js
-              options:
-                templates:
-                  base_uri_template: 'https://{{request.params.domain}}/api/rest_v1'
           paths:
             /page:
               x-modules:

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -35,9 +35,6 @@ paths:
               options:
                 redirect_cache_control: '{{options.purged_cache_control}}'
             - path: lib/content_location_filter.js
-              options:
-                templates:
-                  base_uri_template: 'https://{{request.params.domain}}/api/rest_v1'
           paths:
             /page:
               x-modules:

--- a/sys/action.js
+++ b/sys/action.js
@@ -172,7 +172,7 @@ class ActionService {
         if (!options) { throw new Error("No options supplied for action module"); }
         if (!options.apiUriTemplate || !options.baseUriTemplate) {
             const e = new Error('Missing parameter in action module:\n'
-                    + '- apiRequest template function, or\n'
+                    + '- baseUriTemplate string parameter, or\n'
                     + '- apiUriTemplate string parameter.');
             e.options = options;
             throw e;

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -143,11 +143,9 @@ function replaceSections(original, sectionsJson) {
 // HTML resource_change event emission
 function _dependenciesUpdate(hyper, req) {
     const rp = req.params;
-    return hyper.get({
-        uri: new URI([rp.domain, 'sys', 'action', 'siteinfo'])
-    })
+    return mwUtil.getSiteInfo(hyper, req)
     .then((siteInfo) => {
-        const baseUri = siteInfo.body.baseUri.replace(/^htts?:/, '');
+        const baseUri = siteInfo.baseUri.replace(/^htts?:/, '');
         const publicURI = `${baseUri}/page/html/${encodeURIComponent(rp.title)}`;
         return hyper.post({
             uri: new URI([rp.domain, 'sys', 'events', '']),

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -143,16 +143,21 @@ function replaceSections(original, sectionsJson) {
 // HTML resource_change event emission
 function _dependenciesUpdate(hyper, req) {
     const rp = req.params;
-    const publicURI = `//${rp.domain}/api/rest_v1/page/html/${encodeURIComponent(rp.title)}`;
-
-    return hyper.post({
-        uri: new URI([rp.domain, 'sys', 'events', '']),
-        body: [
-            { meta: { uri: publicURI } },
-            { meta: { uri: `${publicURI}/${rp.revision}` } }
-        ]
-    }).catch((e) => {
-        hyper.log('warn/bg-updates', e);
+    return hyper.get({
+        uri: new URI([rp.domain, 'sys', 'action', 'siteinfo'])
+    })
+    .then((siteInfo) => {
+        const baseUri = siteInfo.body.baseUri.replace(/^htts?:/, '');
+        const publicURI = `${baseUri}/page/html/${encodeURIComponent(rp.title)}`;
+        return hyper.post({
+            uri: new URI([rp.domain, 'sys', 'events', '']),
+            body: [
+                { meta: { uri: publicURI } },
+                { meta: { uri: `${publicURI}/${rp.revision}` } }
+            ]
+        }).catch((e) => {
+            hyper.log('warn/bg-updates', e);
+        });
     });
 }
 

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -145,7 +145,7 @@ function _dependenciesUpdate(hyper, req) {
     const rp = req.params;
     return mwUtil.getSiteInfo(hyper, req)
     .then((siteInfo) => {
-        const baseUri = siteInfo.baseUri.replace(/^htts?:/, '');
+        const baseUri = siteInfo.baseUri.replace(/^https?:/, '');
         const publicURI = `${baseUri}/page/html/${encodeURIComponent(rp.title)}`;
         return hyper.post({
             uri: new URI([rp.domain, 'sys', 'events', '']),

--- a/test/features/errors/invalid_request.js
+++ b/test/features/errors/invalid_request.js
@@ -19,7 +19,7 @@ describe('400 handling', function() {
         .then(function() {
             // Fetch real siteInfo to return from a mock
             return preq.post({
-                uri: server.config.apiURL,
+                uri: server.config.labsApiURL,
                 body: {
                     action: 'query',
                     meta: 'siteinfo|filerepoinfo',
@@ -33,7 +33,7 @@ describe('400 handling', function() {
             siteInfo = res.body;
             // Fetch real revision info for Main_Page
             return preq.post({
-                uri: server.config.apiURL,
+                uri: server.config.labsApiURL,
                 body: {
                     action: 'query',
                     prop: 'info|revisions',
@@ -55,18 +55,18 @@ describe('400 handling', function() {
         // 1. Throw an error on siteInfo fetch
         // 2. Return correct siteInfo
         // 3. Return revision data
-        var mwApi = nock(server.config.apiURL, {allowUnmocked: true})
+        var mwApi = nock(server.config.labsApiURL, {allowUnmocked: true})
         .post('').reply(400)
         .post('').reply(200, siteInfo)
         .post('').reply(200, revisionInfo);
 
         return preq.get({
-            uri: server.config.bucketURL + '/title/Main_Page'
+            uri: server.config.labsBucketURL + '/title/Main_Page'
         })
         .catch(function (e) {
             assert.deepEqual(e.status, 400);
             return preq.get({
-                uri: server.config.bucketURL + '/title/Main_Page'
+                uri: server.config.labsBucketURL + '/title/Main_Page'
             });
         })
         .then(function(res) {

--- a/test/features/pagecontent/access_checks.js
+++ b/test/features/pagecontent/access_checks.js
@@ -6,7 +6,8 @@
 var assert = require('../../utils/assert.js');
 var preq   = require('preq');
 var server = require('../../utils/server.js');
-var nock = require('nock');
+var nock   = require('nock');
+var P      = require('bluebird');
 
 describe('Access checks', function() {
 
@@ -49,17 +50,13 @@ describe('Access checks', function() {
 
     before(function() {
         return server.start()
-        .then(function() {
-            // Do a preparation request to force siteinfo fetch so that we don't need to mock it
-            return preq.get({
-                uri: server.config.bucketURL + '/html/Main_Page'
-            });
-        })
-        .then(function() {
-            return preq.get({
-                uri: server.config.labsBucketURL + '/html/Main_Page'
-            });
-        })
+        // Do a preparation request to force siteinfo fetch so that we don't need to mock it
+        .then(() => P.join(
+            preq.get({ uri: `${server.config.bucketURL}/html/Main_Page` })
+            .catch(e => { console.log('a', e); throw e;}),
+            preq.get({ uri: `${server.config.labsBucketURL}/html/Main_Page` })
+            .catch(e => { console.log(`${server.config.labsBucketURL}/html/Main_Page`, e); throw e;})
+        ))
         // Load in the revisions
         .then(function() {
             var api = nock(server.config.apiURL);

--- a/test/features/security/security.js
+++ b/test/features/security/security.js
@@ -7,6 +7,7 @@ var assert = require('../../utils/assert.js');
 var preq   = require('preq');
 var server = require('../../utils/server.js');
 var nock   = require('nock');
+var P      = require('bluebird');
 
 describe('router - security', function() {
     this.timeout(20000);
@@ -14,10 +15,15 @@ describe('router - security', function() {
     before(function () {
         return server.start()
         .then(function() {
-            // Do a preparation request to force siteinfo fetch so that we don't need to mock it
-            return preq.get({
-                uri: server.config.bucketURL + '/html/Main_Page'
-            });
+            // Do preparation requests to force siteInfo fetch so that we don't need to mock it
+            return P.join(
+                preq.get({
+                    uri: server.config.baseURL + '/page/title/Main_Page'
+                }),
+                preq.get({
+                    uri: server.config.secureURL + '/page/title/Wikipédia:Accueil_principal'
+                })
+            )
         });
     });
 


### PR DESCRIPTION
For #699 we need to have an internal `siteinfo` endpoint, so I've implemented it.

But I went even further - the endpoint now returns the `baseUri` property that allows us to configure how RESTBase is exposed publicly in one place. This requires a config change to be deployed before this can go out.