### PR TITLE
Created a separate project for wikidata

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -43,6 +43,10 @@ wikimedia.org: &wikimedia.org
         pageviews:
           host: https://wikimedia.org/api/rest_v1/metrics
 
+wikidata.org: &wikidata.org
+  x-modules:
+    - path: projects/wmf_wikidata.yaml
+      options: *default_options
 
 wiktionary_project: &wiktionary_project
   x-modules:
@@ -79,6 +83,9 @@ spec_root: &spec_root
 
     # global domain
     /{domain:wikimedia.org}: *wikimedia.org
+
+    # special case for wikidata
+    /{domain:www.wikidata.org}: *wikidata.org
 
     # A robots.txt to make sure that the content isn't indexed.
     /robots.txt:

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -1,0 +1,96 @@
+paths:
+  /{api:v1}:
+    x-modules:
+        # swagger options, overriding the shared ones from the merged specs (?)
+      - spec:
+          info:
+            version: 1.0.0-beta
+            title: Wikimedia REST API
+            description: >
+                This API aims to provide coherent and low-latency access to
+                Wikimedia content and services. It is currently in beta testing, so
+                things aren't completely locked down yet. Each entry point has
+                explicit stability markers to inform you about development status
+                and change policy, according to [our API version
+                policy](https://www.mediawiki.org/wiki/API_versioning).
+
+                ### High-volume access
+                  - Don't perform more than 200 requests/s to this API.
+                  - Set a unique `User-Agent` or `Api-User-Agent` header that
+                    allows us to contact you quickly. Email addresses or URLs
+                    of contact pages work well.
+
+            termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
+            contact:
+              name: the Wikimedia Services team
+              url: http://mediawiki.org/wiki/RESTBase
+            license:
+              name: Apache2
+              url: http://www.apache.org/licenses/LICENSE-2.0
+          # Override the base path for host-based (proxied) requests. In our case,
+          # we proxy https://{domain}/api/rest_v1/ to the API.
+          x-host-basePath: /api/rest_v1
+          x-route-filters:
+            - path: ./lib/normalize_title_filter.js
+              options:
+                redirect_cache_control: '{{options.purged_cache_control}}'
+            - path: lib/content_location_filter.js
+              options:
+                templates:
+                  base_uri_template: 'https://{{request.params.domain}}/api/rest_v1'
+          paths:
+            /page:
+              x-modules:
+                - path: v1/content.yaml
+                  options:
+                    purged_cache_control: '{{options.purged_cache_control}}'
+                - path: v1/random.yaml
+                  options: '{{merge({"random_cache_control": "s-maxage=2, max-age=1"},
+                                options.mobileapps)}}'
+            /transform:
+              x-modules:
+                - path: v1/transform.yaml
+        options: '{{options}}'
+
+  /{api:sys}:
+    x-modules:
+      - spec:
+          paths:
+            /table: &sys_table
+              x-modules:
+                - path: sys/table.js
+                  options:
+                    conf: '{{options.table}}'
+            /key_value: &sys_key_value
+              x-modules:
+                - path: sys/key_value.js
+            /key_rev_value:
+              x-modules:
+                - path: sys/key_rev_value.js
+            /key_rev_latest_value:
+              x-modules:
+                - path: sys/key_rev_latest_value.js
+            /page_revisions:
+              x-modules:
+                - path: sys/page_revisions.js
+            /post_data: &sys_post_data
+              x-modules:
+                - path: sys/post_data.js
+            /action:
+              x-modules:
+                - path: sys/action.js
+                  options: "{{options.action}}"
+            /page_save:
+              x-modules:
+                - path: sys/page_save.js
+            /parsoid:
+              x-modules:
+                - path: sys/parsoid.js
+                  options:
+                    parsoidHost: '{{options.parsoid.host}}'
+                    response_cache_control: '{{options.purged_cache_control}}'
+            /events:
+              x-modules:
+                - path: sys/events.js
+                  options: '{{merge({"skip_updates": options.skip_updates}, options.events)}}'
+        options: '{{options}}'


### PR DESCRIPTION
For wikidata we don't really support anything except the content endpoints, so create a separate project for it.

Bug: https://phabricator.wikimedia.org/T149114
cc @wikimedia/services 