### PR TITLE
Support no-cache header for latest feed endpoint

### DIFF
--- a/v1/feed.js
+++ b/v1/feed.js
@@ -151,9 +151,17 @@ class Feed {
             _traverse(response);
             return response;
         };
-        const getContent = (bucket) => hyper.get({
-            uri: new URI([rp.domain, 'sys', 'key_value', bucket, dateKey])
-        });
+        const getContent = (bucket, forwardCacheControl) => {
+            const request = {
+                uri: new URI([rp.domain, 'sys', 'key_value', bucket, dateKey])
+            };
+            if (forwardCacheControl && req.headers && req.headers['cache-control']) {
+                request.headers = {
+                    'cache-control': req.headers['cache-control']
+                };
+            }
+            return hyper.get(request);
+        };
         const storeContent = (res, bucket) => {
             return hyper.put({
                 uri: new URI([rp.domain, 'sys', 'key_value', bucket, dateKey]),
@@ -162,7 +170,7 @@ class Feed {
             });
         };
         const getCurrentContent = () => {
-            return getContent('feed.aggregated')
+            return getContent('feed.aggregated', true)
             // TODO: Temp code while to run correctly in the mixed code environment.
             // Added only for deployment and transition period, to be removed afterwards.
             .tap((res) => {


### PR DESCRIPTION
We need to support `no-cache` header for the current date feed endpoint. In case some vadalism get's stored in cassandra we want to be able to react fast and force a rerender. We don't want to support it for the historic feed, because rerendering will loose the historic news. If vandalism gets into the historic bucket, we'd deal with it on the case-by-case basis.

Bug: T149857
cc @wikimedia/services @wikimedia/mobile 