### PR TITLE
Restrict format for feed endpoint

### DIFF
--- a/test/features/feed.js
+++ b/test/features/feed.js
@@ -164,4 +164,47 @@ describe('Feed', () => {
             assertMCSRequest(requests, 'page/news', undefined, true);
         });
     });
+
+    it('Should not allow invalid yyyy param', () => {
+        return preq.get({
+            uri: `${server.config.baseURL}/feed/featured/0000/01/01`,
+            headers: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .then(() => {
+            throw new Error('Must have failed')
+        }, (e) => {
+            assert.deepEqual(e.status, 400);
+        });
+    });
+
+    it('Should not allow invalid mm param', () => {
+        return preq.get({
+            uri: `${server.config.baseURL}/feed/featured/2016/1/01`,
+            headers: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .then(() => {
+            throw new Error('Must have failed')
+        }, (e) => {
+            assert.deepEqual(e.status, 400);
+        });
+    });
+
+    it('Should not allow invalid dd param', () => {
+        return preq.get({
+            uri: `${server.config.baseURL}/feed/featured/2016/01/1`,
+            headers: {
+                'cache-control': 'no-cache'
+            }
+        })
+        .then(() => {
+            throw new Error('Must have failed')
+        }, (e) => {
+            assert.deepEqual(e.status, 400);
+        });
+    });
+
 });

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -75,6 +75,44 @@ function constructBody(result) {
     return body;
 }
 
+/**
+ * Verifies that the date parameter is in proper format.
+ *
+ * @param {Object} req the request to check
+ */
+function verifyParams(req) {
+    const rp = req.params;
+
+    if (!/^2\d\d\d$/.test(rp.yyyy)) {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'bad_request',
+                description: 'Invalid yyyy parameter'
+            }
+        });
+    }
+
+    if (!/^\d\d$/.test(rp.mm) || rp.mm === '00' || rp.mm > '12') {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'bad_request',
+                description: 'Invalid mm parameter'
+            }
+        });
+    }
+
+    if (!/^\d\d$/.test(rp.dd) || rp.dd === '00' || rp.dd > '31') {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'bad_request',
+                description: 'Invalid dd parameter'
+            }
+        });
+    }
+}
 
 class Feed {
     constructor(options) {
@@ -112,6 +150,7 @@ class Feed {
     }
 
     aggregated(hyper, req) {
+        verifyParams(req);
         const rp = req.params;
         const date = getDateSafe(rp);
         const dateKey = toKey(date);

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -25,12 +25,12 @@ paths:
           required: true
         - name: mm
           in: path
-          description: 'Month the aggregated content is requested for'
+          description: 'Month the aggregated content is requested for, 0-padded'
           type: string
           required: true
         - name: dd
           in: path
-          description: 'Day of the month the aggregated content is requested for'
+          description: 'Day of the month the aggregated content is requested for, 0-padded'
           type: string
           required: true
       responses:


### PR DESCRIPTION
To avoid cache fragmentation restrict dates to be 0-padded all the time.

Bug: https://phabricator.wikimedia.org/T149148