### PR TITLE
Set content revision for summary

### DIFF
--- a/sys/key_value.js
+++ b/sys/key_value.js
@@ -19,7 +19,7 @@ function returnRevision(req) {
         if (dbResult.body && dbResult.body.items && dbResult.body.items.length) {
             const row = dbResult.body.items[0];
             let headers = {
-                etag: mwUtil.makeETag('0', row.tid),
+                etag: row.headers.etag || mwUtil.makeETag('0', row.tid),
                 'content-type': row['content-type']
             };
             if (row.headers) {

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -119,13 +119,14 @@ paths:
                 explaintext: true
                 piprop: 'thumbnail'
                 pithumbsize: 320
-                rvprop: 'timestamp'
+                rvprop: 'timestamp|ids'
                 titles: '{{request.params.title}}'
                 wbptterms: 'description'
             response:
               # Define the response to save & return.
               headers:
                 content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.0.0"
+                etag: "\"{{getRevision(extract.body.items[0].revisions).revid}}/{{timeuuid()}}\""
               body:
                 title: '{{extract.body.items[0].title}}'
                 extract: '{{extract.body.items[0].extract}}'


### PR DESCRIPTION
Need to include the revision on the `ETag` because we'd need to use it for access control.

Depends on https://github.com/wikimedia/swagger-router/pull/50

cc @wikimedia/services 