### PR TITLE
Wikidata: Resurrect the /media/math endpoint

### DIFF
--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -47,6 +47,10 @@ paths:
             /transform:
               x-modules:
                 - path: v1/transform.yaml
+            /media:
+              x-modules:
+                - path: v1/mathoid.yaml
+                  options: '{{options.mathoid}}'
         options: '{{options}}'
 
   /{api:sys}:


### PR DESCRIPTION
Wikidata pages that are editable and use VE, use Mathoid as well, so
resurrect the `/media/math/` endpoint.

Bug: [T150737](https://phabricator.wikimedia.org/T150737)