### PR TITLE
Parallel tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,22 +46,23 @@
     "entities": "^1.1.1"
   },
   "devDependencies": {
-    "js-yaml": "^3.6.1",
-    "preq": "^0.4.10",
+    "ajv": "^4.7.0",
     "bunyan": "^1.8.1",
     "coveralls": "^2.11.12",
+    "eslint-config-node-services": "^1.0.0",
     "istanbul": "^0.4.4",
-    "mocha": "^2.5.3",
-    "mocha-jscs": "^5.0.1",
+    "js-yaml": "^3.6.1",
     "jscs": "^3.0.7",
+    "mocha": "^2.5.3",
+    "mocha-eslint": "^3.0.1",
+    "mocha-jscs": "^5.0.1",
     "mocha-jshint": "^2.3.1",
     "mocha-lcov-reporter": "^1.2.0",
+    "mocha.parallel": "^0.13.0",
     "nock": "^8.0.0",
+    "preq": "^0.4.10",
     "restbase-mod-table-sqlite": "^0.1.18",
-    "swagger-test": "0.3.0",
-    "ajv": "^4.7.0",
-    "mocha-eslint":"^3.0.1",
-    "eslint-config-node-services": "^1.0.0"
+    "swagger-test": "0.3.0"
   },
   "deploy": {
     "node": "4.6.0",

--- a/test/features/buckets/key_value_bucket.js
+++ b/test/features/buckets/key_value_bucket.js
@@ -5,6 +5,7 @@ var assert = require('../../utils/assert.js');
 var server = require('../../utils/server.js');
 var uuid = require('cassandra-uuid').TimeUuid;
 var P = require('bluebird');
+const parallel = require('mocha.parallel');
 
 describe('Key value buckets', function() {
 
@@ -137,5 +138,5 @@ describe('Key value buckets', function() {
         });
     }
 
-    describe('key_value', function() { runTests('key_value') });
+    parallel('key_value', function() { runTests('key_value') });
 });

--- a/test/features/buckets/revisioned_bucket.js
+++ b/test/features/buckets/revisioned_bucket.js
@@ -7,6 +7,7 @@ var uuid = require('cassandra-uuid').TimeUuid;
 var P = require('bluebird');
 
 var mwUtils = require('../../../lib/mwUtil');
+const parallel = require('mocha.parallel');
 
 describe('Revisioned buckets', function() {
 
@@ -30,204 +31,208 @@ describe('Revisioned buckets', function() {
             return preq.put({ uri: bucketBaseURI });
         });
 
-        it('stores a content in a bucket and gets it back', function() {
-            var testData = randomString(60000);
-            return preq.put({
-                uri: bucketBaseURI + '/Test1/10000',
-                body: new Buffer(testData)
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 201);
-                return preq.get({
-                    uri: bucketBaseURI + '/Test1/10000'
-                });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-                assert.deepEqual(res.body, new Buffer(testData));
-            });
-        });
-        
-        it('stores a content in a bucket and gets it back with small content', function() {
-            var testData = randomString(10);
-            return preq.put({
-                uri: bucketBaseURI + '/Test2/10000',
-                body: new Buffer(testData)
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 201);
-                return preq.get({
-                    uri: bucketBaseURI + '/Test2/10000'
-                });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-                assert.deepEqual(res.body, new Buffer(testData));
-            });
-        });
-
-        it('assigns etag to a revision', function() {
-            var testData = randomString(100);
-            return preq.put({
-                uri: bucketBaseURI + '/Test3/10000',
-                body: new Buffer(testData)
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 201);
-                return preq.get({
-                    uri: bucketBaseURI + '/Test3/10000'
-                });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-                assert.ok(res.headers.etag);
-                assert.ok(new RegExp('^"10000\/').test(res.headers.etag), true);
-            });
-        });
-
-        it('preserves the tid on write and in etag', function() {
-            var tid = uuid.now().toString();
-            var testData = randomString(100);
-            return preq.put({
-                uri: bucketBaseURI + '/Test3/10000/' + tid,
-                body: new Buffer(testData)
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 201);
-                return preq.get({
-                    uri: bucketBaseURI + '/Test3/10000/' + tid
-                });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-                assert.ok(res.headers.etag);
-                assert.ok(new RegExp('^"10000\/' + tid).test(res.headers.etag), true);
-            });
-        });
-
-        it('lists revisions', function() {
-            var testData = randomString(100);
-            return P.each([1, 2, 3], function(revNumber) {
+        parallel('Newer revisions', () => {
+            it('stores a content in a bucket and gets it back', function() {
+                var testData = randomString(60000);
                 return preq.put({
-                    uri: bucketBaseURI + '/Test4/' + revNumber,
+                    uri: bucketBaseURI + '/Test1/10000',
                     body: new Buffer(testData)
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 201);
+                    return preq.get({
+                        uri: bucketBaseURI + '/Test1/10000'
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 200);
+                    assert.deepEqual(res.body, new Buffer(testData));
                 });
-            })
-            .then(function() {
-                return preq.get({
-                    uri: bucketBaseURI + '/Test4/',
-                    query: {
-                        limit: 10
-                    }
-                });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 200);
-                assert.deepEqual(res.body.items.length, 3);
-                assert.deepEqual(res.body.items.map(function(r) { return r.revision; }), [3, 2, 1]);
             });
-        });
 
-        it('throws error on invalid revision', function() {
-            var testData = randomString(100);
-            return preq.put({
-                uri: bucketBaseURI + '/Test4/asdf',
-                body: new Buffer(testData)
-            })
-            .then(function() {
-                throw new Error('Error should be thrown');
-            }, function(e) {
-                assert.deepEqual(e.status, 400);
-            });
-        });
-
-        it('throws error on invalid tid parameter', function() {
-            var testData = randomString(100);
-            return preq.put({
-                uri: bucketBaseURI + '/Test4/1000/some_invalid_tid',
-                body: new Buffer(testData)
-            })
-            .then(function() {
-                throw new Error('Error should be thrown');
-            }, function(e) {
-                assert.deepEqual(e.status, 400);
-            });
-        });
-
-        it('throws 404 error if revision not found', function() {
-            return preq.get({
-                uri: bucketBaseURI + '/Test4/123456789'
-            })
-            .then(function() {
-                throw new Error('Error should be thrown');
-            }, function(e) {
-                assert.deepEqual(e.status, 404);
-            });
-        });
-
-        it('gets older revision', function() {
-            var olderUUID = uuid.now().toString();
-            var newerUUID = uuid.now().toString();
-            return preq.put({
-                uri: bucketBaseURI + '/Older_Test/1000/' + olderUUID,
-                body: new Buffer('Older_Revision')
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 201);
+            it('stores a content in a bucket and gets it back with small content', function() {
+                var testData = randomString(10);
                 return preq.put({
-                    uri: bucketBaseURI + '/Older_Test/1001/' + newerUUID,
-                    body: new Buffer('Newer_Revision')
+                    uri: bucketBaseURI + '/Test2/10000',
+                    body: new Buffer(testData)
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 201);
+                    return preq.get({
+                        uri: bucketBaseURI + '/Test2/10000'
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 200);
+                    assert.deepEqual(res.body, new Buffer(testData));
                 });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 201);
+            });
+
+            it('assigns etag to a revision', function() {
+                var testData = randomString(100);
+                return preq.put({
+                    uri: bucketBaseURI + '/Test3/10000',
+                    body: new Buffer(testData)
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 201);
+                    return preq.get({
+                        uri: bucketBaseURI + '/Test3/10000'
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 200);
+                    assert.ok(res.headers.etag);
+                    assert.ok(new RegExp('^"10000\/').test(res.headers.etag), true);
+                });
+            });
+
+            it('preserves the tid on write and in etag', function() {
+                var tid = uuid.now().toString();
+                var testData = randomString(100);
+                return preq.put({
+                    uri: bucketBaseURI + '/Test3/10000/' + tid,
+                    body: new Buffer(testData)
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 201);
+                    return preq.get({
+                        uri: bucketBaseURI + '/Test3/10000/' + tid
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 200);
+                    assert.ok(res.headers.etag);
+                    assert.ok(new RegExp('^"10000\/' + tid).test(res.headers.etag), true);
+                });
+            });
+
+            it('lists revisions', function() {
+                var testData = randomString(100);
+                return P.each([1, 2, 3], function(revNumber) {
+                    return preq.put({
+                        uri: bucketBaseURI + '/Test4/' + revNumber,
+                        body: new Buffer(testData)
+                    });
+                })
+                .then(function() {
+                    return preq.get({
+                        uri: bucketBaseURI + '/Test4/',
+                        query: {
+                            limit: 10
+                        }
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 200);
+                    assert.deepEqual(res.body.items.length, 3);
+                    assert.deepEqual(res.body.items.map(function(r) { return r.revision; }), [3, 2, 1]);
+                });
+            });
+
+            it('throws error on invalid revision', function() {
+                var testData = randomString(100);
+                return preq.put({
+                    uri: bucketBaseURI + '/Test4/asdf',
+                    body: new Buffer(testData)
+                })
+                .then(function() {
+                    throw new Error('Error should be thrown');
+                }, function(e) {
+                    assert.deepEqual(e.status, 400);
+                });
+            });
+
+            it('throws error on invalid tid parameter', function() {
+                var testData = randomString(100);
+                return preq.put({
+                    uri: bucketBaseURI + '/Test4/1000/some_invalid_tid',
+                    body: new Buffer(testData)
+                })
+                .then(function() {
+                    throw new Error('Error should be thrown');
+                }, function(e) {
+                    assert.deepEqual(e.status, 400);
+                });
+            });
+
+            it('throws 404 error if revision not found', function() {
                 return preq.get({
-                    uri: bucketBaseURI + '/Older_Test/1000'
+                    uri: bucketBaseURI + '/Test4/123456789'
+                })
+                .then(function() {
+                    throw new Error('Error should be thrown');
+                }, function(e) {
+                    assert.deepEqual(e.status, 404);
                 });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.body.toString(), 'Older_Revision');
-                assert.deepEqual(res.headers.etag, mwUtils.makeETag(1000, olderUUID));
-                return preq.get({
-                    uri: bucketBaseURI + '/Older_Test/1001'
-                });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.body.toString(), 'Newer_Revision');
-                assert.deepEqual(res.headers.etag, mwUtils.makeETag(1001, newerUUID));
             });
         });
 
-        it('gets older revision - out of order write', function() {
-            var olderUUID = uuid.now().toString();
-            var newerUUID = uuid.now().toString();
-            return preq.put({
-                uri: bucketBaseURI + '/Older_Test/1001/' + newerUUID,
-                body: new Buffer('Newer_Revision')
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 201);
+        describe('Older revisions', () => {
+            it('gets older revision', function() {
+                var olderUUID = uuid.now().toString();
+                var newerUUID = uuid.now().toString();
                 return preq.put({
                     uri: bucketBaseURI + '/Older_Test/1000/' + olderUUID,
                     body: new Buffer('Older_Revision')
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 201);
+                    return preq.put({
+                        uri: bucketBaseURI + '/Older_Test/1001/' + newerUUID,
+                        body: new Buffer('Newer_Revision')
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 201);
+                    return preq.get({
+                        uri: bucketBaseURI + '/Older_Test/1000'
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.body.toString(), 'Older_Revision');
+                    assert.deepEqual(res.headers.etag, mwUtils.makeETag(1000, olderUUID));
+                    return preq.get({
+                        uri: bucketBaseURI + '/Older_Test/1001'
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.body.toString(), 'Newer_Revision');
+                    assert.deepEqual(res.headers.etag, mwUtils.makeETag(1001, newerUUID));
                 });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.status, 201);
-                return preq.get({
-                    uri: bucketBaseURI + '/Older_Test/1000'
+            });
+
+            it('gets older revision - out of order write', function() {
+                var olderUUID = uuid.now().toString();
+                var newerUUID = uuid.now().toString();
+                return preq.put({
+                    uri: bucketBaseURI + '/Older_Test/1001/' + newerUUID,
+                    body: new Buffer('Newer_Revision')
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 201);
+                    return preq.put({
+                        uri: bucketBaseURI + '/Older_Test/1000/' + olderUUID,
+                        body: new Buffer('Older_Revision')
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.status, 201);
+                    return preq.get({
+                        uri: bucketBaseURI + '/Older_Test/1000'
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.body.toString(), 'Older_Revision');
+                    assert.deepEqual(res.headers.etag, mwUtils.makeETag(1000, olderUUID));
+                    return preq.get({
+                        uri: bucketBaseURI + '/Older_Test/1001'
+                    });
+                })
+                .then(function(res) {
+                    assert.deepEqual(res.body.toString(), 'Newer_Revision');
+                    assert.deepEqual(res.headers.etag, mwUtils.makeETag(1001, newerUUID));
                 });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.body.toString(), 'Older_Revision');
-                assert.deepEqual(res.headers.etag, mwUtils.makeETag(1000, olderUUID));
-                return preq.get({
-                    uri: bucketBaseURI + '/Older_Test/1001'
-                });
-            })
-            .then(function(res) {
-                assert.deepEqual(res.body.toString(), 'Newer_Revision');
-                assert.deepEqual(res.headers.etag, mwUtils.makeETag(1001, newerUUID));
             });
         });
     }

--- a/test/features/errors/invalid_request.js
+++ b/test/features/errors/invalid_request.js
@@ -3,13 +3,14 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, it, before, beforeEach, after, afterEach */
 
+const parallel = require('mocha.parallel');
 var assert  = require('../../utils/assert.js');
 var preq    = require('preq');
 var server  = require('../../utils/server.js');
 var nock    = require('nock');
 var mwUtils =
 
-describe('400 handling', function() {
+parallel('400 handling', function() {
     this.timeout(20000);
 
     var siteInfo;

--- a/test/features/errors/invalid_request.js
+++ b/test/features/errors/invalid_request.js
@@ -8,7 +8,6 @@ var assert  = require('../../utils/assert.js');
 var preq    = require('preq');
 var server  = require('../../utils/server.js');
 var nock    = require('nock');
-var mwUtils =
 
 parallel('400 handling', function() {
     this.timeout(20000);

--- a/test/features/errors/notfound.js
+++ b/test/features/errors/notfound.js
@@ -3,11 +3,12 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, it, before, beforeEach, after, afterEach */
 
+const parallel = require('mocha.parallel');
 var assert = require('../../utils/assert.js');
 var preq   = require('preq');
 var server = require('../../utils/server.js');
 
-describe('404 handling', function() {
+parallel('404 handling', function() {
 
     this.timeout(20000);
 

--- a/test/features/metrics.js
+++ b/test/features/metrics.js
@@ -3,8 +3,9 @@
 var assert = require('../utils/assert.js');
 var server = require('../utils/server.js');
 var preq   = require('preq');
+const parallel = require('mocha.parallel');
 
-describe('Metrics', function() {
+parallel('Metrics', function() {
     this.timeout(20000);
 
     before(function () { return server.start(); });

--- a/test/features/pagecontent/access_checks.js
+++ b/test/features/pagecontent/access_checks.js
@@ -8,6 +8,7 @@ var preq   = require('preq');
 var server = require('../../utils/server.js');
 var nock   = require('nock');
 var P      = require('bluebird');
+const parallel = require('mocha.parallel');
 
 describe('Access checks', function() {
 
@@ -94,68 +95,30 @@ describe('Access checks', function() {
         });
     });
 
-    it('should understand the page was deleted', function() {
-        var api = nock(server.config.apiURL)
-        // Other requests return nothing as if the page is deleted.
-        .post('').reply(200, emptyResponse);
-        // Fetch the page
-        return preq.get({
-            uri: server.config.bucketURL + '/title/' + encodeURIComponent(deletedPageTitle),
-            headers: {
-                'cache-control': 'no-cache'
-            }
-        })
-        .then(function() {
-            throw new Error('404 should have been returned for a deleted page');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
-        })
-        .then(function() {
-            api.done();
-        })
-        .finally(function() {
-            nock.cleanAll();
-        });
-    });
-
-    it('should restrict access to deleted page latest revision', function() {
-        // This is only required until the hack for no-cache header is in place
-        var api = nock(server.config.apiURL)
-        .post('').reply(200, emptyResponse);
-
-        return preq.get({uri: server.config.bucketURL + '/revision/' + deletedPageRevision})
-        .then(function() {
-            throw new Error('404 should have been returned for a deleted page');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
-        })
-        .then(function() {
-            api.done();
-        })
-        .finally(function() {
-            nock.cleanAll();
-        });
-    });
-
-    it('should restrict access to older revision of a deleted page', function() {
-        // This is only required until the hack for no-cache header is in place
-        var api = nock(server.config.apiURL)
-        .post('').reply(200, emptyResponse);
-
-        return preq.get({uri: server.config.bucketURL + '/revision/' + deletedPageOlderRevision})
-        .then(function() {
-            throw new Error('404 should have been returned for a deleted page');
-        }, function(e) {
-            assert.deepEqual(e.status, 404);
-            assert.contentType(e, 'application/problem+json');
-        })
-        .then(function() {
-            api.done();
-        })
-        .finally(function() {
-            nock.cleanAll();
+    describe('Deleting', () => {
+        it('should understand the page was deleted', function() {
+            var api = nock(server.config.apiURL)
+            // Other requests return nothing as if the page is deleted.
+            .post('').reply(200, emptyResponse);
+            // Fetch the page
+            return preq.get({
+                uri: server.config.bucketURL + '/title/' + encodeURIComponent(deletedPageTitle),
+                headers: {
+                    'cache-control': 'no-cache'
+                }
+            })
+            .then(function() {
+                throw new Error('404 should have been returned for a deleted page');
+            }, function(e) {
+                assert.deepEqual(e.status, 404);
+                assert.contentType(e, 'application/problem+json');
+            })
+            .then(function() {
+                api.done();
+            })
+            .finally(function() {
+                nock.cleanAll();
+            });
         });
     });
 
@@ -170,7 +133,7 @@ describe('Access checks', function() {
                 uri += '/' + rev;
             }
             return preq.get({uri: uri})
-            .then(function() {
+            .then(function(res) {
                 throw new Error('404 should have been returned for a deleted page');
             }, function(e) {
                 assert.deepEqual(e.status, 404);
@@ -179,137 +142,183 @@ describe('Access checks', function() {
         });
     }
 
-    testAccess('html', 'deleted', deletedPageTitle);
-    testAccess('data-parsoid', 'deleted', deletedPageTitle);
-    testAccess('html', 'deleted', deletedPageTitle, deletedPageOlderRevision);
-    testAccess('data-parsoid', 'deleted', deletedPageTitle, deletedPageOlderRevision);
-    testAccess('mobile-sections', 'deleted', deletedPageTitle);
-    testAccess('mobile-sections-lead', 'deleted', deletedPageTitle);
-    testAccess('mobile-sections-remaining', 'deleted', deletedPageTitle);
-    testAccess('summary', 'deleted', deletedPageTitle);
+    parallel('Checking deletions', () => {
+        it('should restrict access to deleted page latest revision', function() {
+            // This is only required until the hack for no-cache header is in place
+            var api = nock(server.config.apiURL)
+            .post('').reply(200, emptyResponse);
 
-    it('Should understand that the page was undeleted', function() {
-        return preq.get({
-            uri: server.config.bucketURL + '/title/' + encodeURIComponent(deletedPageTitle),
-            headers: {
-                'cache-control': 'no-cache'
-            }
-        })
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            return preq.get({
-                uri: server.config.bucketURL + '/html/' + encodeURIComponent(deletedPageTitle) + '/' + deletedPageOlderRevision,
+            return preq.get({uri: server.config.bucketURL + '/revision/' + deletedPageRevision})
+            .then(function() {
+                throw new Error('404 should have been returned for a deleted page');
+            }, function(e) {
+                assert.deepEqual(e.status, 404);
+                assert.contentType(e, 'application/problem+json');
+            })
+            .then(function() {
+                api.done();
+            })
+            .finally(function() {
+                nock.cleanAll();
             });
-        })
-        .then(function (res) {
-            assert.deepEqual(res.status, 200);
+        });
+
+        it('should restrict access to older revision of a deleted page', function() {
+            // This is only required until the hack for no-cache header is in place
+            var api = nock(server.config.apiURL)
+            .post('').reply(200, emptyResponse);
+
+            return preq.get({uri: server.config.bucketURL + '/revision/' + deletedPageOlderRevision})
+            .then(function() {
+                throw new Error('404 should have been returned for a deleted page');
+            }, function(e) {
+                assert.deepEqual(e.status, 404);
+                assert.contentType(e, 'application/problem+json');
+            })
+            .then(function() {
+                api.done();
+            })
+            .finally(function() {
+                nock.cleanAll();
+            });
+        });
+
+        testAccess('html', 'deleted', deletedPageTitle);
+        testAccess('data-parsoid', 'deleted', deletedPageTitle);
+        testAccess('html', 'deleted', deletedPageTitle, deletedPageOlderRevision);
+        testAccess('data-parsoid', 'deleted', deletedPageTitle, deletedPageOlderRevision);
+        testAccess('mobile-sections', 'deleted', deletedPageTitle);
+        testAccess('mobile-sections-lead', 'deleted', deletedPageTitle);
+        testAccess('mobile-sections-remaining', 'deleted', deletedPageTitle);
+        testAccess('summary', 'deleted', deletedPageTitle);
+    });
+
+    describe('Undeleting', () => {
+        it('Should understand that the page was undeleted', function() {
+            return preq.get({
+                uri: server.config.bucketURL + '/title/' + encodeURIComponent(deletedPageTitle),
+                headers: {
+                    'cache-control': 'no-cache'
+                }
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+                return preq.get({
+                    uri: server.config.bucketURL + '/html/' + encodeURIComponent(deletedPageTitle) + '/' + deletedPageOlderRevision,
+                });
+            })
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+            });
         });
     });
 
-    var pageTitle = 'User:Pchelolo/restriction_testing_mock';
-    var pageRev = 301375;
-    it('should correctly fetch updated restrictions', function() {
-        var normalRev = {
-            "revid": pageRev,
-            "user": "Pchelolo",
-            "userid": 6591,
-            "timestamp": "2015-02-03T21:15:55Z",
-            "size": 7700,
-            "contentmodel": "wikitext",
-            "tags": []
-        };
-        var normalResponse = {
-            "pageid": 152993,
-            "ns": 3,
-            "title": pageTitle,
-            "contentmodel": "wikitext",
-            "pagelanguage": "en",
-            "pagelanguagehtmlcode": "en",
-            "pagelanguagedir": "ltr",
-            "touched": "2015-12-10T23:41:54Z",
-            "lastrevid": pageRev,
-            "length": 23950,
-            "revisions": [normalRev]
-        };
-        var restrictedRev = Object.assign({}, normalRev);
-        restrictedRev.texthidden = true;
-        restrictedRev.sha1hidden = true;
-        var restrictedResponse = Object.assign({}, normalResponse);
-        restrictedResponse.revisions = [restrictedRev];
-        var api = nock(server.config.labsApiURL)
-        .post('').reply(200, {
-            "batchcomplete": "",
-            "query": {"pages": {"45161196": normalResponse}}
-        }).post('').reply(200, {
-            "batchcomplete": "",
-            "query": {"pages": {"45161196": restrictedResponse}}
+    describe('Restricting', () => {
+        var pageTitle = 'User:Pchelolo/restriction_testing_mock';
+        var pageRev = 301375;
+        it('should correctly fetch updated restrictions', function() {
+            var normalRev = {
+                "revid": pageRev,
+                "user": "Pchelolo",
+                "userid": 6591,
+                "timestamp": "2015-02-03T21:15:55Z",
+                "size": 7700,
+                "contentmodel": "wikitext",
+                "tags": []
+            };
+            var normalResponse = {
+                "pageid": 152993,
+                "ns": 3,
+                "title": pageTitle,
+                "contentmodel": "wikitext",
+                "pagelanguage": "en",
+                "pagelanguagehtmlcode": "en",
+                "pagelanguagedir": "ltr",
+                "touched": "2015-12-10T23:41:54Z",
+                "lastrevid": pageRev,
+                "length": 23950,
+                "revisions": [normalRev]
+            };
+            var restrictedRev = Object.assign({}, normalRev);
+            restrictedRev.texthidden = true;
+            restrictedRev.sha1hidden = true;
+            var restrictedResponse = Object.assign({}, normalResponse);
+            restrictedResponse.revisions = [restrictedRev];
+            var api = nock(server.config.labsApiURL)
+            .post('').reply(200, {
+                "batchcomplete": "",
+                "query": {"pages": {"45161196": normalResponse}}
+            }).post('').reply(200, {
+                "batchcomplete": "",
+                "query": {"pages": {"45161196": restrictedResponse}}
+            });
+
+            // First fetch a non-restricted revision
+            return preq.get({
+                uri: server.config.labsBucketURL + '/title/' + encodeURIComponent(pageTitle)
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body.items.length, 1);
+                // Now fetch update with restrictions
+                return preq.get({
+                    uri: server.config.labsBucketURL + '/title/' + encodeURIComponent(pageTitle),
+                    headers: {
+                        'cache-control': 'no-cache'
+                    }
+                });
+            }).then(function() {
+                throw new Error('403 should be thrown');
+            }, function(e) {
+                assert.deepEqual(e.status, 403);
+            }).then(function() {
+                api.done();
+            })
+            .finally(function() {
+                nock.cleanAll();
+            });
         });
 
-        // First fetch a non-restricted revision
-        return preq.get({
-            uri: server.config.labsBucketURL + '/title/' + encodeURIComponent(pageTitle)
-        })
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.body.items.length, 1);
-            // Now fetch update with restrictions
+
+        it('should store updated restrictions', function() {
+            return preq.get({
+                uri: server.config.labsBucketURL + '/html/' + encodeURIComponent(pageTitle)
+            })
+            .then(function() {
+                throw new Error('403 should be thrown');
+            }, function(e) {
+                assert.deepEqual(e.status, 403);
+            });
+        });
+
+        it('should restrict access to restricted revision html', function() {
+            return preq.get({
+                uri: server.config.labsBucketURL + '/html/' + encodeURIComponent(pageTitle) + '/' + pageRev
+            })
+            .then(function() {
+                throw new Error('403 should have been returned for a deleted page');
+            }, function(e) {
+                assert.deepEqual(e.status, 403);
+                assert.contentType(e, 'application/problem+json');
+            });
+        });
+
+        it('should allow to view content if restrictions disappeared', function() {
             return preq.get({
                 uri: server.config.labsBucketURL + '/title/' + encodeURIComponent(pageTitle),
                 headers: {
                     'cache-control': 'no-cache'
                 }
+            })
+            .then(function(res) {
+                assert.deepEqual(res.status, 200);
+                return preq.get({
+                    uri: server.config.labsBucketURL + '/html/' + encodeURIComponent(pageTitle) + '/' + pageRev,
+                });
+            })
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
             });
-        }).then(function() {
-            throw new Error('403 should be thrown');
-        }, function(e) {
-            assert.deepEqual(e.status, 403);
-        }).then(function() {
-            api.done();
-        })
-        .finally(function() {
-            nock.cleanAll();
-        });
-    });
-
-
-    it('should store updated restrictions', function() {
-        return preq.get({
-            uri: server.config.labsBucketURL + '/html/' + encodeURIComponent(pageTitle)
-        })
-        .then(function() {
-            throw new Error('403 should be thrown');
-        }, function(e) {
-            assert.deepEqual(e.status, 403);
-        });
-    });
-
-    it('should restrict access to restricted revision html', function() {
-        return preq.get({
-            uri: server.config.labsBucketURL + '/html/' + encodeURIComponent(pageTitle) + '/' + pageRev
-        })
-        .then(function() {
-            throw new Error('403 should have been returned for a deleted page');
-        }, function(e) {
-            assert.deepEqual(e.status, 403);
-            assert.contentType(e, 'application/problem+json');
-        });
-    });
-
-    it('should allow to view content if restrictions disappeared', function() {
-        return preq.get({
-            uri: server.config.labsBucketURL + '/title/' + encodeURIComponent(pageTitle),
-            headers: {
-                'cache-control': 'no-cache'
-            }
-        })
-        .then(function(res) {
-            assert.deepEqual(res.status, 200);
-            return preq.get({
-                uri: server.config.labsBucketURL + '/html/' + encodeURIComponent(pageTitle) + '/' + pageRev,
-            });
-        })
-        .then(function (res) {
-            assert.deepEqual(res.status, 200);
         });
     });
 });

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -6,6 +6,7 @@
 var assert = require('../../utils/assert.js');
 var server = require('../../utils/server.js');
 var preq   = require('preq');
+const parallel = require('mocha.parallel');
 
 var testPage = {
     title: 'User:Pchelolo%2fRestbase_Test',
@@ -14,7 +15,7 @@ var testPage = {
     // html is fetched dynamically
 };
 
-describe('transform api', function() {
+parallel('transform api', function() {
     this.timeout(20000);
 
     before(function () {

--- a/test/features/router/buildTree.js
+++ b/test/features/router/buildTree.js
@@ -7,6 +7,7 @@ var assert = require('assert');
 var preq   = require('preq');
 var Router = require('hyperswitch/lib/router');
 var server = require('../../utils/server');
+const parallel = require('mocha.parallel');
 
 var rootSpec = {
     paths: {
@@ -24,7 +25,7 @@ var fullSpec = server.loadConfig('config.example.wikimedia.yaml');
 
 var fakeHyperSwitch = { config: {} };
 
-describe('tree building', function() {
+parallel('tree building', function() {
 
     before(function() { server.start(); });
 

--- a/test/features/schema_tests.js
+++ b/test/features/schema_tests.js
@@ -3,12 +3,13 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, it, before, beforeEach, after, afterEach */
 
+const parallel = require('mocha.parallel');
 var assert = require('../utils/assert.js');
 var server = require('../utils/server.js');
 var preq   = require('preq');
 var Ajv = require('ajv');
 
-describe('Responses should conform to the provided JSON schema of the responce', function() {
+parallel('Responses should conform to the provided JSON schema of the responce', function() {
     var ajv = new Ajv({});
 
     function getToday() {

--- a/test/features/specification/monitoring.js
+++ b/test/features/specification/monitoring.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const parallel = require('mocha.parallel');
 var preq   = require('preq');
 var assert = require('../../utils/assert.js');
 var server = require('../../utils/server.js');
@@ -174,7 +175,7 @@ describe('Monitoring tests', function() {
                 return res.body;
             })
             .then(function(spec) {
-                describe('Monitoring routes, ' + options.domain + ' domain', function() {
+                parallel('Monitoring routes, ' + options.domain + ' domain', function() {
                     constructTests(spec, options).forEach(function(testCase) {
                         it(testCase.title, function() {
                             return preq(testCase.request)

--- a/test/features/specification/swagger.js
+++ b/test/features/specification/swagger.js
@@ -3,6 +3,7 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, it, before, beforeEach, after, afterEach */
 
+const parallel = require('mocha.parallel');
 var preq   = require('preq');
 var assert = require('../../utils/assert.js');
 var specs  = require('../../utils/specs.js');
@@ -17,8 +18,7 @@ var server = require('../../utils/server.js');
         }
     ];
 
-describe('swagger spec', function () {
-    this.timeout(20000);
+parallel('swagger spec', function () {
 
     before(function () { return server.start(); });
 


### PR DESCRIPTION
Having lots of tests is great, but now it's takes ages to complete all of them - on my laptop with sqlite it takes 130 seconds. Parallelise some test execution where possible - time down to 90 seconds - almost 30% win in speed. Also, it's nice to examine possible race condition by running some of the tests concurrently. I didn't have a goal to parallelise all parallelazable tests, just added where it seemed to fit.

cc @wikimedia/services 