### PR TITLE
Citoid: Fix the monitoring example in the spec; release v0.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "REST storage and service dispatcher",
   "main": "index.js",
   "scripts": {

--- a/v1/citoid.yaml
+++ b/v1/citoid.yaml
@@ -77,14 +77,14 @@ paths:
           request:
             params:
               domain: en.wikipedia.org
-              format: bibtex
+              format: mediawiki
               query: 'https://en.wikipedia.org/wiki/Darth_Vader'
-            response:
-              status: 200
-              headers:
-                content-type:  /^application\/x-bibtex/
-              body:
-                title: 'Darth Vader'
+          response:
+            status: 200
+            headers:
+              content-type:  /^application\/json/
+            body:
+              - title: 'Darth Vader'
                 language: en
                 itemType: encyclopediaArticle
                 encyclopediaTitle: Wikipedia


### PR DESCRIPTION
The example provided in Citoid's spec was wrongly indented. Also, the
automating checking script run in prod does not understand bibtex, so
use the `mediawiki` format, which returns a JSON.