### PR TITLE
Require minimal length for the hash parameter in mathoid API

### DIFF
--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -88,6 +88,7 @@ paths:
           description: The hash string of the previous POST data
           type: string
           required: true
+          minLength: 1
       responses:
         '200':
           description: Information about the checked formula
@@ -138,6 +139,7 @@ paths:
           description: The hash string of the previous POST data
           type: string
           required: true
+          minLength: 1
       responses:
         '200':
           description: The rendered formula


### PR DESCRIPTION
The validator treats an empty string as a string, which is kinda correct, empty string IS a string. So if you request mathoid with empty hash some nasty stuff is happening internally - don't allow it by requiring minLength for it.

cc @wikimedia/services 