### PR TITLE
Blacklist User:Cyberpower678/RfX_Report on enwiki

### DIFF
--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -144,6 +144,7 @@ paths:
                         Defnyddiwr:Cyberbot_I/Run/Adminstats: true
                         User:Cyberbot_I/Run/Datefixer: true
                         User:Cyberbot_I/adminrights-admins.js: true
+                        User:Cyberpower678/RfX_Report: true
                         User:Cyberpower678/Tally: true
                         User:Pentjuuu!.!/sandbox: true
                       ur.wikipedia.org:


### PR DESCRIPTION
This page is edited by Cyberbot every 15 minutes on average and it is
transcluded in a lot of other user pages, so it has the potential of
creating very wide rows in storage on a large number of pages, so
disabling it.