### PR TITLE
Commons: Blacklist User:Oxyman/Buildings_in_London/2014_October_11-20

### DIFF
--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -156,6 +156,7 @@ paths:
                         Commons:Quality_images_candidates/candidate_list: true
                         User:J_budissin/Uploads/BiH/2016_December_11-20: true
                         User:OgreBot/Uploads_by_new_users: true
+                        User:Oxyman/Buildings_in_London/2014_October_11-20: true
                       ceb.wikipedia.org:
                         Gumagamit:Lsjbot/Anomalier-PRIVAT: true
                       sv.wikipedia.org:


### PR DESCRIPTION
The page is basically a huge log of (included) files, which makes it
likely it will be constantly re-rendered, so blacklist it.