### PR TITLE
Return non-free page images too

### DIFF
--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -119,6 +119,7 @@ paths:
                 explaintext: true
                 piprop: 'thumbnail'
                 pithumbsize: 320
+                pilicense: 'any'
                 rvprop: 'timestamp|ids'
                 titles: '{{request.params.title}}'
                 wbptterms: 'description'


### PR DESCRIPTION
The default result of the PageImages extension is going to change to show only free images. For us it's OK to show non-free image too, so add the parameter.

Right now this change is a no-op, but let's do it before we forget.

Bug: https://phabricator.wikimedia.org/T147317
cc @wikimedia/services 