### PR TITLE
Added logging when some feed pieces are missing

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -377,9 +377,14 @@ mwUtil.fetchSummary = (hyper, uri) => {
         res.body.title = res.body.title.replace(/ /g, '_');
         return res.body;
     })
-    // Swallow the error, no need to fail the whole feed
-    // request because of one failed summary fetch
-    .catchReturn(undefined);
+    // Log the error and return undefined,
+    // no need to fail the whole feed request because of one failed summary fetch
+    .catch((e) => {
+        hyper.log('warn/hydration', {
+            msg: `Summary fetch failed for ${uri}`,
+            error: e
+        });
+    });
 };
 
 

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -48,6 +48,13 @@ class Feed {
             props[part] = hyper.get({
                 uri: uriArray.join('/'),
                 query: { aggregated: true }
+            })
+            .tap((res) => {
+                if (res.status !== 200 || !res.body || !Object.keys(res.body)) {
+                    hyper.log('warn/feed', {
+                        msg: `Failed to fetch ${part} from MCS`
+                    });
+                }
             });
         });
         return P.props(props);

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -50,7 +50,7 @@ class Feed {
                 query: { aggregated: true }
             })
             .tap((res) => {
-                if (res.status !== 200 || !res.body || !Object.keys(res.body)) {
+                if (res.status !== 200 || !res.body || !Object.keys(res.body).length) {
                     hyper.log('warn/feed', {
                         msg: `Failed to fetch ${part} from MCS`
                     });


### PR DESCRIPTION
Quite frequently we're missing some pieces of the feed from the response for unknown reasons. Added some login to help us investigate the problem.

Bug: https://phabricator.wikimedia.org/T150703
cc @wikimedia/services @berndsi 