### PR TITLE
Log feed only for en.wiki

### DIFF
--- a/v1/feed.js
+++ b/v1/feed.js
@@ -50,7 +50,8 @@ class Feed {
                 query: { aggregated: true }
             })
             .tap((res) => {
-                if (res.status !== 200 || !res.body || !Object.keys(res.body).length) {
+                if (rp.domain === 'en.wikipedia.org'
+                        && (res.status !== 200 || !res.body || !Object.keys(res.body).length)) {
                     hyper.log('warn/feed', {
                         msg: `Failed to fetch ${part} from MCS`
                     });


### PR DESCRIPTION
Doesn't make sense to log for others, en.wiki is enough of testing what's happening.