### PR TITLE
Bump table dependencies, remove logging that's unnesessary now

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -377,14 +377,8 @@ mwUtil.fetchSummary = (hyper, uri) => {
         res.body.title = res.body.title.replace(/ /g, '_');
         return res.body;
     })
-    // Log the error and return undefined,
     // no need to fail the whole feed request because of one failed summary fetch
-    .catch((e) => {
-        hyper.log('warn/hydration', {
-            msg: `Summary fetch failed for ${uri}`,
-            error: e
-        });
-    });
+    .catchReturn(undefined);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "cassandra-uuid": "^0.0.2",
-    "restbase-mod-table-cassandra": "^0.10.2",
+    "restbase-mod-table-cassandra": "^0.10.3",
     "service-runner": "^2.1.13",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "content-type": "git+https://github.com/wikimedia/content-type#master",
@@ -61,7 +61,7 @@
     "mocha.parallel": "^0.14.0",
     "nock": "^9.0.2",
     "preq": "^0.5.2",
-    "restbase-mod-table-sqlite": "^0.1.19",
+    "restbase-mod-table-sqlite": "^0.1.20",
     "swagger-test": "0.5.1"
   },
   "engines": {

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -48,14 +48,6 @@ class Feed {
             props[part] = hyper.get({
                 uri: uriArray.join('/'),
                 query: { aggregated: true }
-            })
-            .tap((res) => {
-                if (rp.domain === 'en.wikipedia.org'
-                        && (res.status !== 200 || !res.body || !Object.keys(res.body).length)) {
-                    hyper.log('warn/feed', {
-                        msg: `Failed to fetch ${part} from MCS`
-                    });
-                }
             });
         });
         return P.props(props);


### PR DESCRIPTION
Bump table modules dependencies versions to use new TTL optimization, remove unnecessary logging.

Bug: https://phabricator.wikimedia.org/T150703