### PR TITLE
Stop using deprecated ServiceRunner.run()

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,4 +4,4 @@
 
 // B/C wrapper to make the old init script work with service-runner.
 var ServiceRunner = require('service-runner');
-new ServiceRunner().run();
+new ServiceRunner().start();


### PR DESCRIPTION
Those deprecation logs are pretty annoying

cc @wikimedia/services 