### PR TITLE
Use printable view for PDF printing

### DIFF
--- a/v1/pdf.yaml
+++ b/v1/pdf.yaml
@@ -60,7 +60,7 @@ paths:
         - get_pdf_from_backend:
             request:
               method: get
-              uri: '{{options.uri}}/pdf?accessKey={options.secret}&url=https://{{domain}}/wiki/{title}'
+              uri: '{{options.uri}}/pdf?accessKey={options.secret}&url=https://{{domain}}/wiki/{title}%3Fprintable=yes'
             return:
               status: 200
               headers:


### PR DESCRIPTION
The WM Germany team hooked up specific CSS fixes with the printable
view. These fixes are only delivered when the user agent matches
electron, and when ?printable=yes is specified.

So far, we used the cached, regular page view. This is better for
performance, as it leverages Varnish cache results. However, it does not
receive the specific fixes until those have become part of the normal
print styles.

So, this patch (temporarily) adds the ?printable=yes parameter to the
source URL.