### PR TITLE
A pass to stabilise endpoints

### DIFF
--- a/v1/announcements.yaml
+++ b/v1/announcements.yaml
@@ -8,7 +8,7 @@ paths:
       description: |
         Gets announcements for display in the official Wikipedia iOS and Android apps.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
         - application/problem+json

--- a/v1/announcements.yaml
+++ b/v1/announcements.yaml
@@ -8,7 +8,7 @@ paths:
       description: |
         Gets announcements for display in the official Wikipedia iOS and Android apps.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       produces:
         - application/json
         - application/problem+json

--- a/v1/citoid.yaml
+++ b/v1/citoid.yaml
@@ -30,7 +30,7 @@ paths:
           - `bibtex`: format used in conjunction with LaTeX documents.
             See [bibtex.org](http://www.bibtex.org/).
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json; charset=utf-8;
         - application/x-bibtex; charset=utf-8

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -21,7 +21,7 @@ paths:
         - Page content
       summary: List page-related API entry points.
       description: |
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+        Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       produces:
         - application/json
       responses:
@@ -212,7 +212,7 @@ paths:
         - Page content
       summary: Get latest HTML for a title.
       description: |
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       parameters:
         - name: title
           in: path
@@ -482,7 +482,7 @@ paths:
         - Page content
       summary: Get HTML for a specific title/revision & optionally timeuuid.
       description: |
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       operationId: getFormatRevision
       produces:
         - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.3.0"
@@ -612,7 +612,7 @@ paths:
         For this reason, you need to supply the exact `revision` and `tid` as
         provided in the `ETag` header of the HTML response.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [Stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       produces:
         - application/json
       parameters:

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -29,7 +29,7 @@ paths:
         page](https://www.mediawiki.org/wiki/Wikimedia_Apps/Wiktionary_definition_popups_in_the_Android_Wikipedia_Beta_app)
         for background and considerations for further development.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       produces:
         - application/json
       parameters:

--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -14,7 +14,7 @@ paths:
         the featured article of the day, most read articles for the previous day, news
         content and the featured image and video of the day.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
       parameters:

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -16,7 +16,7 @@ paths:
         formats. Just append the value of the header to `/media/math/{format}/`
         and perform a GET request against that URL.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
+        Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable).
       produces:
         - application/json
       parameters:
@@ -79,7 +79,7 @@ paths:
         Returns the previously-stored formula via `/media/math/check/{type}` for
         the given hash.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
+        Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable).
       produces:
         - application/json
       parameters:
@@ -119,7 +119,7 @@ paths:
         `x-resource-location` header denoting the hash ID of the POST data. Once
         obtained, this endpoint has to be used to obtain the actual render.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#unstable).
+        Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable).
       produces:
         - image/svg+xml
         - application/mathml+xml

--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -19,7 +19,7 @@ paths:
       description: |
         This is the root of all pageview data endpoints.  The list of paths that this returns includes ways to query by article, project, top articles, etc.  If browsing the interactive documentation, see the specifics for each endpoint below.
 
-        - Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+        - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
         - Rate limit: 100 req/s
       produces:
         - application/json
@@ -42,7 +42,7 @@ paths:
       description: |
         Given a Mediawiki article and a date range, returns a daily timeseries of its pageview counts. You can also filter by access method and/or agent type.
 
-        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
         - Rate limit: 100 req/s
       produces:
         - application/json
@@ -117,7 +117,7 @@ paths:
       description: |
         Given a date range, returns a timeseries of pageview counts. You can filter by project, access method and/or agent type. You can choose between daily and hourly granularity as well.
 
-        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
         - Rate limit: 100 req/s
       produces:
         - application/json
@@ -210,7 +210,7 @@ paths:
       description: |
         Lists the 1000 most viewed articles for a given project and timespan (month or day). You can filter by access method.
 
-        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
         - Rate limit: 100 req/s
       produces:
         - application/json
@@ -273,7 +273,7 @@ paths:
       description: |
         Given a project and a date range, returns a timeseries of unique devices counts. You need to specify a project, and can filter by accessed site (mobile or desktop). You can choose between daily and hourly granularity as well.
 
-        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
         - Rate limit: 100 req/s
       produces:
         - application/json

--- a/v1/random.yaml
+++ b/v1/random.yaml
@@ -8,7 +8,7 @@ paths:
       description: |
         Redirects the client to the URI for the desired format for a random page title.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       parameters:
         - name: format
           in: path

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -27,7 +27,7 @@ paths:
         sentences, as well as information about a thumbnail that represents
         the page.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.1.0"
       parameters:

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -30,7 +30,7 @@ paths:
         syntactic variations in wikitext, which ensures that diffs are
         readable.
 
-        - Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
         - Rate limit: 5 req/s
       consumes:
         - multipart/form-data
@@ -119,7 +119,7 @@ paths:
         Transform wikitext to HTML. Note that if you set `stash: true`, you
         also need to supply the title.
 
-        - Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
         - Rate limit: 5 req/s
       consumes:
         - multipart/form-data


### PR DESCRIPTION
1. Made a pass over all endpoints increasing stability per 1.0 release
2. Still unclear what to do with the metadata endpoints https://phabricator.wikimedia.org/T158100
3. @milimetric @nuria I've marked the page view API endpoints as [stable](https://www.mediawiki.org/wiki/API_versioning#Stable) - do you think that's appropriate? Do you plan any major changes for these APIs?
4. Finally deleted the `mobile-text` endpoint - it's not used and it seems like it will never be since it was an experiment and stuff went to a different path since. @berndsi Is that correct?

cc @wikimedia/services 