### PR TITLE
Fix a bug when we've tried to update historic feed while shouldn't

### DIFF
--- a/lib/base_feed.js
+++ b/lib/base_feed.js
@@ -79,11 +79,12 @@ class BaseFeed {
                 this._makeFeedRequests(hyper, req, false)
                 .then((result) => this._assembleResult(result, dateKey))
                 .tap((res) => {
+                    const storeReqs = [ storeContent(res, this._getCurrentBucketName()) ];
+                    if (this.options.storeHistory) {
+                        storeReqs.push(storeContent(res, this._getHistoricBucketName()));
+                    }
                     // Store async
-                    P.join(
-                        storeContent(res, this._getCurrentBucketName()),
-                        storeContent(res, this._getHistoricBucketName())
-                    );
+                    P.all(storeReqs);
                 }));
         };
         const requestHistoricContentFromMCS = () => {


### PR DESCRIPTION
That's a pretty obvious bug - forgot we're writing to the historic table for current content too.

cc @wikimedia/services 