### PR TITLE
Onthisday documentation improvements

### DIFF
--- a/v1/onthisday.yaml
+++ b/v1/onthisday.yaml
@@ -97,21 +97,21 @@ definitions:
 
   onthisdayResponse:
     type: object
-    description: All the ovents that happened on the day of the year
+    description: All events which happened on this given day of the year
     properties:
       births:
-        description: Data about the births on the day
+        description: Data about births on this day
         $ref: '#/definitions/onthisday'
       deaths:
-        description: Data about the deaths on the day
+        description: Data about deaths on this day
         $ref: '#/definitions/onthisday'
       events:
-        description: Data about the events on the day
+        description: Data about events on this day
         $ref: '#/definitions/onthisday'
       holidays:
-        description: Data about the holidays on the day
+        description: Data about holidays on this day
         $ref: '#/definitions/onthisday'
       selected:
-        description: Data about the selected events on the day
+        description: Data about the selected anniversaries on this day
         $ref: '#/definitions/onthisday'
     additionalProperties: false

--- a/v1/onthisday.yaml
+++ b/v1/onthisday.yaml
@@ -10,7 +10,7 @@ paths:
         Provides events that historically happened on the provided day and month.
         Supported types of events are:
          - All: all of the following
-         - Selected: a list of a few selected anniversaries which happen on the provided day and month; often the entries are curated for the current year
+         - Selected: a list of a few selected anniversaries which occur on the provided day and month; often the entries are curated for the current year
          - Births: a list of birthdays which happened on the provided day and month
          - Deaths: a list of deaths which happened on the provided day and month
          - Holidays: a list of fixed holidays celebrated on the provided day and month
@@ -97,21 +97,21 @@ definitions:
 
   onthisdayResponse:
     type: object
-    description: All events which happened on this given day of the year
+    description: Lists of events which happened on the provided day and month
     properties:
       births:
-        description: Data about births on this day
+        description: A list of birthdays which happened on the provided day and month
         $ref: '#/definitions/onthisday'
       deaths:
-        description: Data about deaths on this day
+        description: A list of deaths which happened on the provided day and month
         $ref: '#/definitions/onthisday'
       events:
-        description: Data about events on this day
+        description: A list of significant events which happened on the provided day and month and which are not covered by the other types yet
         $ref: '#/definitions/onthisday'
       holidays:
-        description: Data about holidays on this day
+        description: A list of fixed holidays celebrated on the provided day and month
         $ref: '#/definitions/onthisday'
       selected:
-        description: Data about the selected anniversaries on this day
+        description: A list of a few selected anniversaries which occur on the provided day and month; often the entries are curated for the current year
         $ref: '#/definitions/onthisday'
     additionalProperties: false


### PR DESCRIPTION
This is mainly to get rid of the typo 'ovents'. Then I thought we could reuse some of the wording from the description earlier in the file.