### PR TITLE
Bump summary version to regenerate summaries

### DIFF
--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -29,7 +29,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
-        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.1.0"
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.1.1"
       parameters:
         - name: title
           in: path
@@ -127,7 +127,7 @@ paths:
             response:
               # Define the response to save & return.
               headers:
-                content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.1.0"
+                content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.1.1"
                 etag: "\"{{getRevision(extract.body.items[0].revisions).revid}}/{{timeuuid()}}\""
               body:
                 title: '{{extract.body.items[0].title}}'


### PR DESCRIPTION
The buggy summaries now affect hovercards, which messes with the feature rollout. Reading team asked to regenerate the summaries so that we don't rely on page edits to apply #771 

Bug: https://phabricator.wikimedia.org/T101153#3100573
cc @wikimedia/services @jdlrobson 