### PR TITLE
Properly name commons in the blacklist

### DIFF
--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -124,7 +124,7 @@ paths:
                       ceb.wikipedia.org:
                         Gumagamit:Lsjbot/Anomalier-PRIVAT: true
                         Gumagamit:Lsjbot/Kartrutor2: true
-                      commons.wikipedia.org:
+                      commons.wikimedia.org:
                         Commons:Quality_images_candidates/candidate_list: true
                         User:Darkweasel94/Vienna/2016_December_14-16: true
                         User:J_budissin/Uploads/BiH/2016_December_11-20: true


### PR DESCRIPTION
It's 'commons.wikimedia.org', not 'commons.wikipedia.org'