### PR TITLE
Support regexes in blacklists

### DIFF
--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -120,70 +120,64 @@ paths:
                     # rarely viewed in any case.
                     rerenderBlacklist:
                       ca.wikipedia.org:
-                        Usuari:TronaBot/log:Activitat_reversors_per_hores: true
+                        - 'Usuari:TronaBot/log:Activitat_reversors_per_hores'
                       ceb.wikipedia.org:
-                        Gumagamit:Lsjbot/Anomalier-PRIVAT: true
-                        Gumagamit:Lsjbot/Kartrutor2: true
+                        - 'Gumagamit:Lsjbot/Anomalier-PRIVAT'
+                        - 'Gumagamit:Lsjbot/Kartrutor2'
                       commons.wikimedia.org:
-                        Commons:Quality_images_candidates/candidate_list: true
-                        Commons:Quality_images/Subject/Places/Natural_structures: true
-                        Commons:WikiProject_Aviation/recent_uploads/2014_February_17: true
-                        User:Darkweasel94/Vienna/2016_December_14-16: true
-                        User:J_budissin/Uploads/BiH/2016_December_11-20: true
-                        User:Jarekt/d: true
-                        User:JJMC89_bot/report/BSicons/changes/2017-03: true
-                        User:Marcus_Cyron/OgreBotCeramics/2013_May_21-31: true
-                        User:Nicolas_Rück_(WMDE)/Supported_by_Wikimedia_Deutschland_2015/1: true
-                        User:Nicolas_Rück_(WMDE)/Supported_by_Wikimedia_Deutschland_2015/2: true
-                        User:OgreBot/Uploads_by_new_users: true
-                        User:Oxyman/Buildings_in_London/2014_October_11-20: true
-                        User:Oxyman/London/2014_October_1-10: true
-                        User:Stunteltje/gallery: true
-                        User:PIERRE_ANDRE_LECLERCQ/gallery: true
+                        - 'Commons:Quality_images_candidates/candidate_list'
+                        - 'Commons:Quality_images/Subject/Places/Natural_structures'
+                        - '/Commons:WikiProject_Aviation\/recent_uploads\//'
+                        - '/^User:Darkweasel94\/Vienna\//'
+                        - '/^User:J_budissin\/Uploads\/BiH\//'
+                        - 'User:Jarekt/d'
+                        - '/^User:JJMC89_bot\/report\/BSicons\/changes\//'
+                        - '/^User:Marcus_Cyron\/OgreBotCeramics\//'
+                        - '/^User:Nicolas_Rück_(WMDE)\/Supported_by_Wikimedia_Deutschland_2015/'
+                        - 'User:OgreBot/Uploads_by_new_users'
+                        - '/^User:Oxyman\/Buildings_in_London\//'
+                        - '/^User:Oxyman\/London\//'
+                        - 'User:Stunteltje/gallery'
+                        - 'User:PIERRE_ANDRE_LECLERCQ/gallery'
                       de.wikipedia.org:
-                        Wikipedia:Café: true
-                        Wikipedia:Defekte_Weblinks/Bot2015-Problem: true
-                        Wikipedia_Diskussion:Hauptseite/Schon_gewusst: true
-                        Benutzer:Wartungsstube/Berlin: true
-                        Benutzer:Wartungsstube/Musik: true
-                        Benutzer:Wartungsstube/Unternehmen: true
-                        Benutzer:Wartungsstube/Schifffahrt: true
-                        Benutzer:Verum/ege: true
-                        Benutzer:Septembermorgen/Bottabelle/Französische_Kantone_N–Z: true
-                        Wikipedia:WikiProjekt_Planen_und_Bauen/Zu_überarbeitende_Artikel: true
+                        - 'Wikipedia:Café'
+                        - 'Wikipedia:Defekte_Weblinks/Bot2015-Problem'
+                        - 'Wikipedia_Diskussion:Hauptseite/Schon_gewusst'
+                        - 'Benutzer:Wartungsstube/Berlin'
+                        - 'Benutzer:Wartungsstube/Musik'
+                        - 'Benutzer:Wartungsstube/Unternehmen'
+                        - 'Benutzer:Wartungsstube/Schifffahrt'
+                        - 'Benutzer:Verum/ege'
+                        - 'Benutzer:Septembermorgen/Bottabelle/Französische_Kantone_N–Z'
+                        - 'Wikipedia:WikiProjekt_Planen_und_Bauen/Zu_überarbeitende_Artikel'
                       es.wikipedia.org:
-                        Wikipedia:Café/Archivo/Miscelánea/Actual: true
+                        - 'Wikipedia:Café/Archivo/Miscelánea/Actual'
                       fr.wikipedia.org:
-                        Utilisateur:ZéroBot/Log/Erreurs: true
-                        Utilisateur:SyntaxTerror/Ajouts_du_modèle_Autorité: true
-                        Discussion_utilisateur:NaggoBot/CommonsDR: true
-                        Projet:France/Annonces/Admissibilité: true
+                        - 'Utilisateur:ZéroBot/Log/Erreurs'
+                        - 'Utilisateur:SyntaxTerror/Ajouts_du_modèle_Autorité'
+                        - 'Discussion_utilisateur:NaggoBot/CommonsDR'
+                        - 'Projet:France/Annonces/Admissibilité'
                       it.wikipedia.org:
-                        Utente:Effems/Sandbox7: true
+                        - 'Utente:Effems/Sandbox7'
                       nl.wikipedia.org:
-                        Gebruiker:Eg-T2g/Kladblok: true
+                        - 'Gebruiker:Eg-T2g/Kladblok'
                       pt.wikipedia.org:
-                        Wikipédia:Pedidos/Bloqueio: true
+                        - 'Wikipédia:Pedidos/Bloqueio'
                       ru.wikipedia.org:
-                        Википедия:Форум/Технический: true
+                        - 'Википедия:Форум/Технический'
                       sv.wikipedia.org:
-                        Användare:Lsjbot/Anomalier-PRIVAT: true
-                        Användare:Lsjbot/Namnkonflikter-PRIVAT: true
+                        - 'Användare:Lsjbot/Anomalier-PRIVAT'
+                        - 'Användare:Lsjbot/Namnkonflikter-PRIVAT'
                       ur.wikipedia.org:
-                        نام_مقامات_ایل: true
-                        نام_مقامات_ڈی: true
-                        نام_مقامات_جے: true
-                        نام_مقامات_جی: true
-                        نام_مقامات_ایچ: true
-                        نام_مقامات_ایم: true
-                        نام_مقامات_ایس: true
+                        - 'نام_مقامات_ایل'
+                        - 'نام_مقامات_ڈی'
+                        - 'نام_مقامات_جے'
+                        - 'نام_مقامات_جی'
+                        - 'نام_مقامات_ایچ'
+                        - 'نام_مقامات_ایم'
+                        - 'نام_مقامات_ایس'
                       zh.wikipedia.org:
-                        Wikipedia:互助客栈/条目探讨: true
-                      www.wikidata.org:
-                        Q21558717: true
-                        Q21505108: true
-                        Q21481867: true
-                        Q21521425: true
+                        - 'Wikipedia:互助客栈/条目探讨'
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.js

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -122,38 +122,34 @@ paths:
                     # rarely viewed in any case.
                     rerenderBlacklist:
                       en.wikipedia.org:
-                        User:B-bot/Event_log: true
-                        User:JamesR/AdminStats: true
-                        User:Kudpung/Dashboard: true
+                        - 'User:B-bot/Event_log'
+                        - 'User:JamesR/AdminStats'
+                        - 'User:Kudpung/Dashboard'
                         # Various dashboards
-                        User:Breawycker/Wikipedia: true
-                        User:Sonia/dashboard: true
-                        User:Ocaasi/dashboard: true
-                        User:Nolelover: true
-                        User:Calmer_Waters: true
-                        User:Technical_13/dashboard: true
-                        Template:Cratstats: true
+                        - 'User:Breawycker/Wikipedia'
+                        - 'User:Sonia/dashboard'
+                        - 'User:Ocaasi/dashboard'
+                        - 'User:Nolelover'
+                        - 'User:Calmer_Waters'
+                        - 'User:Technical_13/dashboard'
+                        - 'Template:Cratstats'
                         # Cyberbot is creating 90% of null edits
-                        User:Cyberbot_I/Status: true
-                        User:Cyberbot_II/Status: true
-                        صارف:Cyberbot_I/Run/Adminstats: true
-                        User:Cyberbot_I/Run/Adminstats: true
-                        Defnyddiwr:Cyberbot_I/Run/Adminstats: true
-                        User:Cyberbot_I/Run/Datefixer: true
-                        User:Cyberbot_I/adminrights-admins.js: true
-                        User:Cyberpower678/RfX_Report: true
-                        User:Cyberpower678/Tally: true
-                        User:Pentjuuu!.!/sandbox: true
-                        User:AllyD/CSDlog: true
-                        User:Peter_I._Vardy/sandbox-13: true
-                        User:I_dream_of_horses/CSD_log: true
-                        User:MJ180MJ180/sandbox: true
-                        Talk:United_States_presidential_election,_2016: true
-                        Wikipedia:Reference_desk/Humanities: true
-                        Wikipedia:WikiProject_Deletion_sorting/People: true
-                        Wikipedia:WikiProject_Deletion_sorting/United_States_of_America: true
-                        Wikipedia:Articles_for_creation/Redirects: true
-                        Wikipedia:Administrators'_noticeboard/Incidents: true
+                        - '/^User:Cyberbot_I\//'
+                        - '/^User:Cyberbot_II\//'
+                        - '/^User:Cyberpower678\//'
+                        - 'صارف:Cyberbot_I/Run/Adminstats'
+                        - 'Defnyddiwr:Cyberbot_I/Run/Adminstats'
+                        - 'User:Pentjuuu!.!/sandbox'
+                        - 'User:AllyD/CSDlog'
+                        - 'User:Peter_I._Vardy/sandbox-13'
+                        - 'User:I_dream_of_horses/CSD_log'
+                        - 'User:MJ180MJ180/sandbox'
+                        - 'Talk:United_States_presidential_election,_2016'
+                        - 'Wikipedia:Reference_desk/Humanities'
+                        - 'Wikipedia:WikiProject_Deletion_sorting/People'
+                        - 'Wikipedia:WikiProject_Deletion_sorting/United_States_of_America'
+                        - 'Wikipedia:Articles_for_creation/Redirects'
+                        - 'Wikipedia:Administrators%27_noticeboard/Incidents'
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.js

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -166,8 +166,8 @@ function compileReRenderBlacklist(blacklist) {
      * From a list of regexes and strings, constructs a regex that
      * matches any of list items
      */
-    const constructRegex = (variants) => {
-        let regex = (variants || []).map((regexString) => {
+    const constructRegex = (pages) => {
+        let regex = (pages || []).map((regexString) => {
             regexString = regexString.trim();
             if (/^\/.+\/$/.test(regexString)) {
                 return `(?:${regexString.substring(1, regexString.length - 1)})`;

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -422,7 +422,7 @@ class ParsoidService {
      * @return {boolean} Whether re-rendering this title is okay.
      */
     _okayToRerender(req) {
-        if (mwUtil.isNoCacheRequest(req)) {
+        if (mwUtil.isNoCacheRequest(req) && this._blacklist[req.params.domain]) {
             const title = req.params.title;
             return !this._blacklist[req.params.domain].some((entry) => {
                 if (typeof entry === 'string') {

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -170,10 +170,10 @@ function compileReRenderBlacklist(blacklist) {
         let regex = (variants || []).map((regexString) => {
             regexString = regexString.trim();
             if (/^\/.+\/$/.test(regexString)) {
-                return `(:?${regexString.substring(1, regexString.length - 1)})`;
+                return `(?:${regexString.substring(1, regexString.length - 1)})`;
             }
-            // Instead of comparing strings
-            return `(:?^${decodeURIComponent(regexString)
+            // Compare strings, instead
+            return `(?:^${decodeURIComponent(regexString)
                 .replace(/[-[\]/{}()*+?.\\^$|]/g, "\\$&")})`;
         }).join('|');
         regex = regex && regex.length > 0 ? new RegExp(regex) : undefined;

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -174,7 +174,7 @@ function compileReRenderBlacklist(blacklist) {
             }
             // Compare strings, instead
             return `(?:^${decodeURIComponent(regexString)
-                .replace(/[-[\]/{}()*+?.\\^$|]/g, "\\$&")})`;
+                .replace(/[-[\]/{}()*+?.\\^$|]/g, "\\$&")}$)`;
         }).join('|');
         regex = regex && regex.length > 0 ? new RegExp(regex) : undefined;
         return regex;


### PR DESCRIPTION
Some of the pages we blacklist are subpages of some use/bot page. Often they are partitioned by month/date/etc, so we need to support regexes to block all the subpages right away. 

Also, added more blacklists based on the report of the most problematic pages in Change-Prop: https://gist.github.com/Pchelolo/4cbfd3c38623234395cb3c6ee1a85d9a That's generated by running through the `error` topic in kafka, filtering for 500/504 errors and getting the most problematic ones.

cc @wikimedia/services @subbuss 