### PR TITLE
Tests: Use TLS for Labs instances

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -19,20 +19,20 @@ default_project: &default_project
               domains: /./
           dbname: test.db.sqlite3 # ignored in cassandra, but useful in SQLite testing
         parsoid:
-          host: http://parsoid-beta.wmflabs.org
+          host: https://parsoid-beta.wmflabs.org
         action:
           apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
           baseUriTemplate: "{{'https://{domain}/api/rest_v1'}}"
         graphoid:
-          host: http://graphoid-beta.wmflabs.org
+          host: https://graphoid-beta.wmflabs.org
         mathoid:
-          host: http://mathoid-beta.wmflabs.org
+          host: https://mathoid-beta.wmflabs.org
           # 10 days Varnish caching, one day client-side
           cache-control: s-maxage=864000, max-age=86400
         mobileapps:
-          host: http://appservice.wmflabs.org
+          host: https://appservice.wmflabs.org
         citoid:
-          host: http://citoid-beta.wmflabs.org
+          host: https://citoid-beta.wmflabs.org
         events: {}
         purged_cache_control: test_purged_cache_control
         # Cache control for purged endpoints allowing short-term client caching

--- a/test/features/feed.js
+++ b/test/features/feed.js
@@ -17,7 +17,7 @@ function assertStorageRequest(requests, method, bucket, expected) {
 }
 
 function assertMCSRequest(requests, content, date, expected) {
-    let serviceURI = `http://appservice.wmflabs.org/en.wikipedia.org/v1/${content}`;
+    let serviceURI = `https://appservice.wmflabs.org/en.wikipedia.org/v1/${content}`;
     if (date) {
         serviceURI += `/${date}`;
     }

--- a/test/features/security/security.js
+++ b/test/features/security/security.js
@@ -76,7 +76,7 @@ describe('router - security', function() {
 
     it('should forward cookies on request to parsoid', function() {
         nock.enableNetConnect();
-        var parsoidURI = 'http://parsoid-beta.wmflabs.org';
+        var parsoidURI = 'https://parsoid-beta.wmflabs.org';
         var title = 'Test';
         var revision = 117795883;
         var api = nock(parsoidURI, {

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -54,7 +54,7 @@ function remoteRequests(slice, expected) {
             return false;
         }
         hasRec = true;
-        return entry.req && /^http/.test(entry.req.uri);
+        return entry.req && /^https?/.test(entry.req.uri);
     });
     if (!hasRec) {
         // there were no records in the slice, so
@@ -75,8 +75,8 @@ function remoteRequests(slice, expected) {
  */
 function findParsoidRequest(slice) {
     var logEntry = slice.get().find(function(line) {
-            var entry = JSON.parse(line);
-            return entry.req && /^http:\/\/parsoid/.test(entry.req.uri);
+        var entry = JSON.parse(line);
+        return entry.req && /^https?:\/\/parsoid/.test(entry.req.uri);
     });
     return JSON.parse(logEntry).req;
 }


### PR DESCRIPTION
It has been a while that Labs supports the HTTPS protocol, so use it in tests.