### PR TITLE
Add explicit reference to terms of use & privacy policy; v1.0.0

### DIFF
--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -4,21 +4,26 @@ paths:
         # swagger options, overriding the shared ones from the merged specs (?)
       - spec:
           info:
-            version: 1.0.0-beta
+            version: 1.0.0
             title: Wikimedia REST API
             description: >
-                This API aims to provide coherent and low-latency access to
-                Wikimedia content and services. It is currently in beta testing, so
-                things aren't completely locked down yet. Each entry point has
-                explicit stability markers to inform you about development status
-                and change policy, according to [our API version
-                policy](https://www.mediawiki.org/wiki/API_versioning).
+                This API provides cacheable and straightforward access to
+                Wikimedia content and data, in machine-readable formats. Each
+                entry point has explicit stability markers to inform you about
+                development status and change policy, according to [our API
+                version policy](https://www.mediawiki.org/wiki/API_versioning).
+
+                See https://www.mediawiki.org/wiki/REST_API for background and details.
 
                 ### High-volume access
-                  - Don't perform more than 200 requests/s to this API.
+                  - Limit your clients to no more than 200 requests/s to this API.
                   - Set a unique `User-Agent` or `Api-User-Agent` header that
                     allows us to contact you quickly. Email addresses or URLs
                     of contact pages work well.
+
+                By using this API, you agree to Wikimedia's 
+                [Terms of Use](https://wikimediafoundation.org/wiki/Terms_of_Use) and
+                [Privacy Policy](https://wikimediafoundation.org/wiki/Privacy_policy).
 
             termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
             contact:


### PR DESCRIPTION
- Update any mentions of beta from the description.
- Improve the summary to more directly describe what this API does.
- Link to mediawiki.org documentation page.
- Add explicit mention of terms of use / privacy policy.