### PR TITLE
Update all API descriptions; more legalese

### DIFF
--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -23,7 +23,7 @@ paths:
     x-modules:
       - spec:
           info:
-            version: 1.0.0-beta
+            version: 1.0.0
             title: Wikimedia REST API
             description: Welcome to your RESTBase API.
           x-route-filters:

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -4,20 +4,30 @@ paths:
         # swagger options, overriding the shared ones from the merged specs (?)
       - spec:
           info:
-            version: 1.0.0-beta
+            version: 1.0.0
             title: Wikimedia REST API
             description: >
-                This API aims to provide coherent and low-latency access to
-                Wikimedia content and services. It is currently in beta testing, so
-                things aren't completely locked down yet. Each entry point has
-                explicit stability markers to inform you about development status
-                and change policy, according to [our API version
-                policy](https://www.mediawiki.org/wiki/API_versioning).
+                This API provides cacheable and straightforward access to
+                Wikimedia content and data, in machine-readable formats. Each
+                entry point has explicit stability markers to inform you about
+                development status and change policy, according to [our API
+                version policy](https://www.mediawiki.org/wiki/API_versioning).
+
+                See https://www.mediawiki.org/wiki/REST_API for background and details.
 
                 ### High-volume access
-                  - Don't perform more than 500 requests/s to this API.
-                  - Set a unique `User-Agent` header that allows us to contact you
-                    quickly. Email addresses or URLs of contact pages work well.
+                  - Limit your clients to no more than 200 requests/s to this API.
+                  - Set a unique `User-Agent` or `Api-User-Agent` header that
+                    allows us to contact you quickly. Email addresses or URLs
+                    of contact pages work well.
+
+                By using this API, you agree to Wikimedia's 
+                [Terms of Use](https://wikimediafoundation.org/wiki/Terms_of_Use) and
+                [Privacy Policy](https://wikimediafoundation.org/wiki/Privacy_policy), and
+                you irrevocably agree to release modifications or additions
+                made through this API under the 
+                [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) 
+                License and the [GFDL](https://www.gnu.org/copyleft/fdl.html).
 
             termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
             contact:

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -23,7 +23,11 @@ paths:
 
                 By using this API, you agree to Wikimedia's 
                 [Terms of Use](https://wikimediafoundation.org/wiki/Terms_of_Use) and
-                [Privacy Policy](https://wikimediafoundation.org/wiki/Privacy_policy).
+                [Privacy Policy](https://wikimediafoundation.org/wiki/Privacy_policy), and
+                you irrevocably agree to release modifications or additions
+                made through this API under the 
+                [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) 
+                License and the [GFDL](https://www.gnu.org/copyleft/fdl.html).
 
             termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
             contact:

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -4,21 +4,30 @@ paths:
         # swagger options, overriding the shared ones from the merged specs (?)
       - spec:
           info:
-            version: 1.0.0-beta
+            version: 1.0.0
             title: Wikimedia REST API
             description: >
-                This API aims to provide coherent and low-latency access to
-                Wikimedia content and services. It is currently in beta testing, so
-                things aren't completely locked down yet. Each entry point has
-                explicit stability markers to inform you about development status
-                and change policy, according to [our API version
-                policy](https://www.mediawiki.org/wiki/API_versioning).
+                This API provides cacheable and straightforward access to
+                Wikimedia content and data, in machine-readable formats. Each
+                entry point has explicit stability markers to inform you about
+                development status and change policy, according to [our API
+                version policy](https://www.mediawiki.org/wiki/API_versioning).
+
+                See https://www.mediawiki.org/wiki/REST_API for background and details.
 
                 ### High-volume access
-                  - Don't perform more than 200 requests/s to this API.
+                  - Limit your clients to no more than 200 requests/s to this API.
                   - Set a unique `User-Agent` or `Api-User-Agent` header that
                     allows us to contact you quickly. Email addresses or URLs
                     of contact pages work well.
+
+                By using this API, you agree to Wikimedia's 
+                [Terms of Use](https://wikimediafoundation.org/wiki/Terms_of_Use) and
+                [Privacy Policy](https://wikimediafoundation.org/wiki/Privacy_policy), and
+                you irrevocably agree to release modifications or additions
+                made through this API under the 
+                [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) 
+                License and the [GFDL](https://www.gnu.org/copyleft/fdl.html).
 
             termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
             contact:

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -4,21 +4,30 @@ paths:
         # swagger options, overriding the shared ones from the merged specs (?)
       - spec:
           info:
-            version: 1.0.0-beta
+            version: 1.0.0
             title: Wikimedia REST API
             description: >
-                This API aims to provide coherent and low-latency access to
-                Wikimedia content and services. It is currently in beta testing, so
-                things aren't completely locked down yet. Each entry point has
-                explicit stability markers to inform you about development status
-                and change policy, according to [our API version
-                policy](https://www.mediawiki.org/wiki/API_versioning).
+                This API provides cacheable and straightforward access to
+                Wikimedia content and data, in machine-readable formats. Each
+                entry point has explicit stability markers to inform you about
+                development status and change policy, according to [our API
+                version policy](https://www.mediawiki.org/wiki/API_versioning).
+
+                See https://www.mediawiki.org/wiki/REST_API for background and details.
 
                 ### High-volume access
-                  - Don't perform more than 200 requests/s to this API.
+                  - Limit your clients to no more than 200 requests/s to this API.
                   - Set a unique `User-Agent` or `Api-User-Agent` header that
                     allows us to contact you quickly. Email addresses or URLs
                     of contact pages work well.
+
+                By using this API, you agree to Wikimedia's 
+                [Terms of Use](https://wikimediafoundation.org/wiki/Terms_of_Use) and
+                [Privacy Policy](https://wikimediafoundation.org/wiki/Privacy_policy), and
+                you irrevocably agree to release modifications or additions
+                made through this API under the 
+                [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) 
+                License and the [GFDL](https://www.gnu.org/copyleft/fdl.html).
 
             termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
             contact:

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -5,20 +5,30 @@ paths:
         # swagger options, overriding the shared ones from the merged specs (?)
       - spec:
           info:
-            version: 1.0.0-beta
+            version: 1.0.0
             title: Wikimedia REST API
             description: >
-                This API aims to provide coherent and low-latency access to
-                Wikimedia content and services. It is currently in beta testing, so
-                things aren't completely locked down yet. Each entry point has
-                explicit stability markers to inform you about development status
-                and change policy, according to [our API version
-                policy](https://www.mediawiki.org/wiki/API_versioning).
+                This API provides cacheable and straightforward access to
+                Wikimedia content and data, in machine-readable formats. Each
+                entry point has explicit stability markers to inform you about
+                development status and change policy, according to [our API
+                version policy](https://www.mediawiki.org/wiki/API_versioning).
+
+                See https://www.mediawiki.org/wiki/REST_API for background and details.
 
                 ### High-volume access
-                  - Don't perform more than 200 requests/s to this API.
-                  - Set a unique `User-Agent` header that allows us to contact you
-                    quickly. Email addresses or URLs of contact pages work well.
+                  - Limit your clients to no more than 200 requests/s to this API.
+                  - Set a unique `User-Agent` or `Api-User-Agent` header that
+                    allows us to contact you quickly. Email addresses or URLs
+                    of contact pages work well.
+
+                By using this API, you agree to Wikimedia's 
+                [Terms of Use](https://wikimediafoundation.org/wiki/Terms_of_Use) and
+                [Privacy Policy](https://wikimediafoundation.org/wiki/Privacy_policy), and
+                you irrevocably agree to release modifications or additions
+                made through this API under the 
+                [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) 
+                License and the [GFDL](https://www.gnu.org/copyleft/fdl.html).
 
             termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
             contact:


### PR DESCRIPTION
- Actually update the descriptions for all project specs.
- Add some more legalese by legal's request. While licensing is also
touched on in the ToUs, they feel that it won't hurt to make it really
explicit.