### PR TITLE
Allow client-side cache-control for summaries

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -35,6 +35,8 @@ default_project: &default_project
           host: http://citoid-beta.wmflabs.org
         # 10 days Varnish caching, one day client-side
         purged_cache_control: s-maxage=864000, max-age=86400
+        # Cache control for purged endpoints allowing short-term client caching
+        purged_cache_control_client_cache: s-maxage=1209600, max-age=300
         pdf:
           # Cache PDF for 5 minutes since it's not purged
           cache_control: s-maxage=600, max-age=600

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -35,6 +35,8 @@ default_project: &default_project
           host: http://citoid-beta.wmflabs.org
         events: {}
         purged_cache_control: test_purged_cache_control
+        # Cache control for purged endpoints allowing short-term client caching
+        purged_cache_control_client_cache: test_purged_cache_control_with_client_caching
         pdf:
           # Cache PDF for 5 minutes since it's not purged
           cache_control: s-maxage=600, max-age=600

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -57,7 +57,7 @@ paths:
                   options: '{{options.graphoid}}'
                 - path: v1/summary.js
                   options:
-                    response_cache_control: '{{options.purged_cache_control}}'
+                    response_cache_control: '{{options.purged_cache_control_client_cache}}'
                 - path: v1/related.js
                   options: '{{options.related}}'
                 - path: v1/random.yaml

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -57,7 +57,7 @@ paths:
                   options: '{{options.graphoid}}'
                 - path: v1/summary.js
                   options:
-                    response_cache_control: '{{options.purged_cache_control}}'
+                    response_cache_control: '{{options.purged_cache_control_client_cache}}'
                 - path: v1/related.js
                   options: '{{options.related}}'
                 - path: v1/random.yaml

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -274,7 +274,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
-            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control_with_client_caching');
             assert.deepEqual(res.body.length, 0);
         });
     });


### PR DESCRIPTION
Allow 5-minute client-side caching for the summary content. 

Depends-On: https://gerrit.wikimedia.org/r/348124
Bug: https://phabricator.wikimedia.org/T161284
cc @wikimedia/services @berndsi 