### PR TITLE
Add the translation public API specification

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -42,6 +42,8 @@ default_project: &default_project
           cache_control: s-maxage=600, max-age=600
           uri: https://pdfrender-beta.wmflabs.org
           secret: secret
+        transform:
+          cx_host: http://cxserver-beta.wmflabs.org
         skip_updates: false
 
 # A separate project for en.wikipedia because it is more feature-rich

--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -43,7 +43,7 @@ default_project: &default_project
           uri: https://pdfrender-beta.wmflabs.org
           secret: secret
         transform:
-          cx_host: http://cxserver-beta.wmflabs.org
+          cx_host: https://cxserver-beta.wmflabs.org
         skip_updates: false
 
 # A separate project for en.wikipedia because it is more feature-rich

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -42,6 +42,8 @@ default_project: &default_project
           cache_control: s-maxage=600, max-age=600
           uri: https://pdfrender-beta.wmflabs.org
           secret: secret
+        transform:
+          cx_host: http://cxserver-beta.wmflabs.org
         skip_updates: false
 
 # A separate project for en.wikipedia because it is more feature-rich

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -43,7 +43,7 @@ default_project: &default_project
           uri: https://pdfrender-beta.wmflabs.org
           secret: secret
         transform:
-          cx_host: http://cxserver-beta.wmflabs.org
+          cx_host: https://cxserver-beta.wmflabs.org
         skip_updates: false
 
 # A separate project for en.wikipedia because it is more feature-rich

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -36,6 +36,7 @@ paths:
                 - path: v1/content.yaml
                   options:
                     purged_cache_control: '{{options.purged_cache_control}}'
+                    cx_host: '{{options.transform.cx_host}}'
                 - path: v1/common_schemas.yaml # Doesn't really matter where to mount it.
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -44,6 +44,8 @@ paths:
             /transform:
               x-modules:
                 - path: v1/transform.yaml
+                - path: v1/transform-lang.js
+                  options: '{{options.transform}}'
             /media:
               x-modules:
                 - path: v1/mathoid.yaml

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -58,6 +58,10 @@ paths:
               x-modules:
                 - path: v1/metrics.yaml
                   options: '{{options.pageviews}}'
+            /transform:
+              x-modules:
+                - path: v1/transform-global.yaml
+                  options: '{{options.transform}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -78,6 +78,8 @@ paths:
             /transform:
               x-modules:
                 - path: v1/transform.yaml
+                - path: v1/transform-lang.js
+                  options: '{{options.transform}}'
             /media:
               x-modules:
                 - path: v1/mathoid.yaml

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -50,6 +50,7 @@ paths:
                 - path: v1/content.yaml
                   options:
                     purged_cache_control: '{{options.purged_cache_control}}'
+                    cx_host: '{{options.transform.cx_host}}'
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},
                                 options.mobileapps)}}'

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -80,6 +80,8 @@ paths:
             /transform:
               x-modules:
                 - path: v1/transform.yaml
+                - path: v1/transform-lang.js
+                  options: '{{options.transform}}'
             /media:
               x-modules:
                 - path: v1/mathoid.yaml

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -50,6 +50,7 @@ paths:
                 - path: v1/content.yaml
                   options:
                     purged_cache_control: '{{options.purged_cache_control}}'
+                    cx_host: '{{options.transform.cx_host}}'
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},
                                 options.mobileapps)}}'

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -59,6 +59,8 @@ paths:
             /transform:
               x-modules:
                 - path: v1/transform.yaml
+                - path: v1/transform-lang.js
+                  options: '{{options.transform}}'
             /media:
               x-modules:
                 - path: v1/mathoid.yaml

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -50,6 +50,7 @@ paths:
                 - path: v1/content.yaml
                   options:
                     purged_cache_control: '{{options.purged_cache_control}}'
+                    cx_host: '{{options.transform.cx_host}}'
                 - path: v1/graphoid.yaml
                   options: '{{options.graphoid}}'
                 - path: v1/random.yaml

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -54,6 +54,7 @@ paths:
                 - path: v1/content.yaml
                   options:
                     purged_cache_control: '{{options.purged_cache_control}}'
+                    cx_host: '{{options.transform.cx_host}}'
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},
                                     options.mobileapps)}}'

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -70,6 +70,8 @@ paths:
             /transform:
               x-modules:
                 - path: v1/transform.yaml
+                - path: v1/transform-lang.js
+                  options: '{{options.transform}}'
             /media:
               x-modules:
                 - path: v1/mathoid.yaml

--- a/v1/common_schemas.yaml
+++ b/v1/common_schemas.yaml
@@ -99,3 +99,32 @@ definitions:
             description: The longitude
         requiredProperties: [ 'lat', 'lon' ]
     required: ['title', 'extract', 'lang', 'dir']
+
+  cx_mt:
+    type: object
+    properties:
+      contents:
+        type: string
+        description: the translated content
+
+  cx_dict:
+    type: object
+    properties:
+      source:
+        type: string
+        description: the original word to look up
+      translations:
+        type: array
+        description: the translations found
+        items:
+          type: object
+          properties:
+            phrase:
+              type: string
+              description: the translated phrase
+            info:
+              type: string
+              description: extra information about the phrase
+            sources:
+              type: string
+              description: the source dictionary used for the translation

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -890,7 +890,7 @@ paths:
               body: '{{request.body}}'
       x-monitor: false
 
-  /segmented/{title}{/revision}:
+  /segments/{title}{/revision}:
     get:
       tags:
         - Page content
@@ -941,7 +941,7 @@ paths:
           schema:
             $ref: '#/definitions/problem'
         '404':
-          description: Unknown page, revision or tid
+          description: Unknown page or revision
           schema:
             $ref: '#/definitions/problem'
         default:

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -890,6 +890,70 @@ paths:
               body: '{{request.body}}'
       x-monitor: false
 
+  /segmented/{title}{/revision}:
+    get:
+      tags:
+        - Page content
+      summary: Fetches a segmented page to be used in machine translation
+      description: |
+        Use this end point to fetch the segmented content of a page. Clients should
+        use the returned content in conjunction with the [language transform
+        API](https://wikimedia.org/api/rest_v1/#!/Transform).
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json
+      parameters:
+        - name: title
+          in: path
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: The revision id
+          type: integer
+          required: false
+      responses:
+        '200':
+          description: The segmented page for the given title and revision
+          schema:
+            type: object
+            properties:
+              sourceLanguage:
+                type: string
+                description: The source language of the page
+              title:
+                type: string
+                description: The title of the segmented page returned
+              revision:
+                type: integer
+                description: The revision ID of the segmented page
+              segmentedContent:
+                type: string
+                description: The segmented HTML body of the contents of the page
+        '400':
+          description: Invalid revision
+          schema:
+            $ref: '#/definitions/problem'
+        '403':
+          description: Access to the specific revision is restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '404':
+          description: Unknown page, revision or tid
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_cx:
+            request:
+              uri: '{{options.cx_host}}/v1/page/{domain}/{title}/{revision}'
+      x-monitor: false
+
 definitions:
   revisions:
     description: The result format for revision listing

--- a/v1/transform-global.yaml
+++ b/v1/transform-global.yaml
@@ -1,0 +1,254 @@
+info:
+  version: '1.0.0'
+  title: Global Transform API
+  description: Global Transform API
+  termsofservice: https://github.com/wikimedia/restbase
+  license:
+    name: Apache licence, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /html/{from}/to/{to}{/provider}:
+    post:
+      tags: ['Transform']
+      summary: Machine-translate content
+      description: |
+        Fetches the machine translation for the posted content from the source
+        to the destination language.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: from
+          in: path
+          description: The source language code
+          type: string
+          required: true
+        - name: to
+          in: path
+          description: The target language code
+          type: string
+          required: true
+        - name: provider
+          in: path
+          description: The machine translation provider id
+          type: string
+          required: false
+          enum:
+           - Apertium
+           - Yandex
+           - Youdao
+        - name: html
+          in: formData
+          description: The HTML content to translate
+          type: string
+          required: true
+          x-textarea: true
+      responses:
+        '200':
+          description: The translated content
+          schema:
+            $ref: '#/definitions/cx_mt'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-monitor: false
+      x-request-handler:
+        - get_from_cx:
+            request:
+              uri: '{{options.cx_host}}/v1/mt/{from}/{to}/{provider}'
+  /word/{from}/to/{to}/{word}{/provider}:
+    get:
+      tags: ['Transform']
+      summary: Fetch the dictionary meaning of a word
+      description: |
+        Fetches the dictionary meaning of a word from a language and displays
+        it in the target language.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json
+      parameters:
+        - name: from
+          in: path
+          description: The source language code
+          type: string
+          required: true
+        - name: to
+          in: path
+          description: The target language code
+          type: string
+          required: true
+        - name: word
+          in: path
+          description: The word to lookup
+          type: string
+          required: true
+        - name: provider
+          in: path
+          description: The dictionary provider id
+          type: string
+          required: false
+          enum:
+           - JsonDict
+           - Dictd
+      responses:
+        '200':
+          description: the dictionary translation for the given word
+          schema:
+            $ref: '#/definitions/cx_dict'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-monitor: false
+      x-request-handler:
+        - get_from_cx:
+            request:
+              uri: '{{options.cx_host}}/v1/dictionary/{word}/{from}/{to}/{provider}'
+  /list/pair/{from}/{to}/:
+    get:
+      tags: ['Transform']
+      summary: Lists the tools available for a language pair
+      description: |
+        Fetches the list of tools that are available for the given pair of languages.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json
+      parameters:
+        - name: from
+          in: path
+          description: The source language code
+          type: string
+          required: true
+        - name: to
+          in: path
+          description: The target language code
+          type: string
+          required: true
+      responses:
+        '200':
+          description: the list of tools available for the language pair
+          schema:
+            $ref: '#/definitions/cx_list_tools'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-monitor: false
+      x-request-handler:
+        - get_from_cx:
+            request:
+              uri: '{{options.cx_host}}/v1/list/pair/{from}/{to}'
+  /list/tool/{tool}/:
+    get:
+      tags: ['Transform']
+      summary: Lists the tools and language pairs available for the given tool category
+      description: |
+        Fetches the list of tools and all of the language pairs it can translate
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json
+      parameters:
+        - name: tool
+          in: path
+          description: The tool category to list tools and language pairs for
+          type: string
+          required: true
+          enum:
+            - mt
+            - dictionary
+      responses:
+        '200':
+          description: the list of language pairs available for a given translation tool
+          schema:
+            $ref: '#/definitions/cx_list_pairs_for_tool'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-monitor: false
+      x-request-handler:
+        - get_from_cx:
+            request:
+              uri: '{{options.cx_host}}/v1/list/tool/{tool}'
+  /list/languagepairs/:
+    get:
+      tags: ['Transform']
+      summary: Lists the tools and language pairs available for the given tool category
+      description: |
+        Fetches the list of tools and all of the language pairs it can translate
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: the list of source and target languages supported by the API
+          schema:
+            $ref: '#/definitions/cx_languagepairs'
+      x-monitor: false
+      x-request-handler:
+        - get_from_cx:
+            request:
+              uri: '{{options.cx_host}}/v1/list/languagepairs'
+
+definitions:
+  cx_mt:
+    type: object
+    properties:
+      contents:
+        type: string
+        description: the translated content
+  cx_dict:
+    type: object
+    properties:
+      source:
+        type: string
+        description: the original word to look up
+      translations:
+        type: array
+        description: the translations found
+        items:
+          type: object
+          properties:
+            phrase:
+              type: string
+              description: the translated phrase
+            info:
+              type: string
+              description: extra information about the phrase
+            sources:
+              type: string
+              description: the source dictionary used for the translation
+  cx_list_tools:
+    type: object
+    properties:
+      tools:
+        type: array
+        description: the list of tools available for the given language pair
+        items:
+          type: string
+          description: the tool available
+  cx_list_pairs_for_tool:
+    type: object
+  cx_languagepairs:
+    type: object
+    properties:
+      source:
+        type: array
+        description: the list of available source languages
+        items:
+          type: string
+          description: one source language
+      target:
+        type: array
+        description: the list of available destination languages
+        items:
+          type: string
+          description: one destination language

--- a/v1/transform-global.yaml
+++ b/v1/transform-global.yaml
@@ -7,7 +7,7 @@ info:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
-  /html/{from}/to/{to}{/provider}:
+  /html/from/{from_lang}/to/{to_lang}{/provider}:
     post:
       tags: ['Transform']
       summary: Machine-translate content
@@ -21,12 +21,12 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: from
+        - name: from_lang
           in: path
           description: The source language code
           type: string
           required: true
-        - name: to
+        - name: to_lang
           in: path
           description: The target language code
           type: string
@@ -41,7 +41,7 @@ paths:
            - Yandex
            - Youdao
         - name: html
-          in: formData
+          in: body
           description: The HTML content to translate
           type: string
           required: true
@@ -59,8 +59,8 @@ paths:
       x-request-handler:
         - get_from_cx:
             request:
-              uri: '{{options.cx_host}}/v1/mt/{from}/{to}/{provider}'
-  /word/{from}/to/{to}/{word}{/provider}:
+              uri: '{{options.cx_host}}/v1/mt/{from_lang}/{to_lang}/{provider}'
+  /word/from/{from_lang}/to/{to_lang}/{word}{/provider}:
     get:
       tags: ['Transform']
       summary: Fetch the dictionary meaning of a word
@@ -72,12 +72,12 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: from
+        - name: from_lang
           in: path
           description: The source language code
           type: string
           required: true
-        - name: to
+        - name: to_lang
           in: path
           description: The target language code
           type: string
@@ -108,7 +108,7 @@ paths:
       x-request-handler:
         - get_from_cx:
             request:
-              uri: '{{options.cx_host}}/v1/dictionary/{word}/{from}/{to}/{provider}'
+              uri: '{{options.cx_host}}/v1/dictionary/{word}/{from_lang}/{to_lang}/{provider}'
   /list/pair/{from}/{to}/:
     get:
       tags: ['Transform']
@@ -180,9 +180,9 @@ paths:
   /list/languagepairs/:
     get:
       tags: ['Transform']
-      summary: Lists the tools and language pairs available for the given tool category
+      summary: Lists the language pairs supported by the back-end
       description: |
-        Fetches the list of tools and all of the language pairs it can translate
+        Fetches the list of language pairs the back-end service can translate
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
@@ -199,33 +199,6 @@ paths:
               uri: '{{options.cx_host}}/v1/list/languagepairs'
 
 definitions:
-  cx_mt:
-    type: object
-    properties:
-      contents:
-        type: string
-        description: the translated content
-  cx_dict:
-    type: object
-    properties:
-      source:
-        type: string
-        description: the original word to look up
-      translations:
-        type: array
-        description: the translations found
-        items:
-          type: object
-          properties:
-            phrase:
-              type: string
-              description: the translated phrase
-            info:
-              type: string
-              description: extra information about the phrase
-            sources:
-              type: string
-              description: the source dictionary used for the translation
   cx_list_tools:
     type: object
     properties:

--- a/v1/transform-lang.js
+++ b/v1/transform-lang.js
@@ -1,0 +1,59 @@
+'use strict';
+
+
+const HyperSwitch = require('hyperswitch');
+const mwUtil = require('../lib/mwUtil');
+
+const spec = HyperSwitch.utils.loadSpec(`${__dirname}/transform-lang.yaml`);
+
+
+class TransformLang {
+    constructor(options) {
+        this._options = options;
+        if (!this._options.cx_host) {
+            throw new Error('transform-lang.js: option cx_host not present!');
+        }
+    }
+
+    doMT(hyper, req) {
+        const rp = req.params;
+        return mwUtil.getSiteInfo(hyper, req).get('general').get('lang').then((lang) => {
+            let uri = `${this._options.cx_host}/v1/mt/${rp.from}/${lang}`;
+            if (rp.provider) {
+                uri += `/${rp.provider}`;
+            }
+            hyper.post({
+                uri,
+                body: req.body
+            });
+        });
+    }
+
+    doDict(hyper, req) {
+        const rp = req.params;
+        return mwUtil.getSiteInfo(hyper, req).get('general').get('lang').then((lang) => {
+            let uri = `${this._options.cx_host}/v1/dictionary/${encodeURIComponent(rp.word)}/` +
+                `${rp.from}/${lang}`;
+            if (rp.provider) {
+                uri += `/${rp.provider}`;
+            }
+            return hyper.get({
+                uri,
+                body: req.body
+            });
+        });
+    }
+
+}
+
+
+module.exports = (options) => {
+    const transformLang = new TransformLang(options);
+    return {
+        spec,
+        operations: {
+            doMT: transformLang.doMT.bind(transformLang),
+            doDict: transformLang.doDict.bind(transformLang)
+        }
+    };
+};

--- a/v1/transform-lang.yaml
+++ b/v1/transform-lang.yaml
@@ -1,0 +1,96 @@
+info:
+  version: '1.0.0'
+  title: Transform API
+  description: Transform API
+  termsofservice: https://github.com/wikimedia/restbase
+  license:
+    name: Apache licence, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /html/from/{from}{/provider}:
+    post:
+      tags: ['Transforms']
+      summary: Machine-translate content
+      description: |
+        Fetches the machine translation for the posted content from the source
+        to the language of this wiki.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: from
+          in: path
+          description: The source language code
+          type: string
+          required: true
+        - name: provider
+          in: path
+          description: The machine translation provider id
+          type: string
+          required: false
+          enum:
+           - Apertium
+           - Yandex
+           - Youdao
+        - name: html
+          in: body
+          description: The HTML content to translate
+          type: string
+          required: true
+          x-textarea: true
+      responses:
+        '200':
+          description: The translated content
+          schema:
+            $ref: '#/definitions/cx_mt'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-monitor: false
+      operationId: doMT
+  /word/from/{from}/{word}{/provider}:
+    get:
+      tags: ['Transforms']
+      summary: Fetch the dictionary meaning of a word
+      description: |
+        Fetches the dictionary meaning of a word from a language and displays
+        it in the target language.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json
+      parameters:
+        - name: from
+          in: path
+          description: The source language code
+          type: string
+          required: true
+        - name: word
+          in: path
+          description: The word to lookup
+          type: string
+          required: true
+        - name: provider
+          in: path
+          description: The dictionary provider id
+          type: string
+          required: false
+          enum:
+           - JsonDict
+           - Dictd
+      responses:
+        '200':
+          description: the dictionary translation for the given word
+          schema:
+            $ref: '#/definitions/cx_dict'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-monitor: false
+      operationId: doDict
+


### PR DESCRIPTION
This PR adds the public API specification for the functionality
exposed in CXServer. As a first step, it is going to be exposed only on
the global wikimedia.org domain, as it doesn't really depend on a
specific wiki/project (it is Wikipedia-centric, though).

Bug: [T107914](https://phabricator.wikimedia.org/T107914)