### PR TITLE
Report siteinfo fetch failures with 500 status code

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -33,15 +33,18 @@ mwUtil.makeETag = (rev, tid, suffix) => {
  * Normalizes the request.params.title and returns it back
  */
 mwUtil.normalizeTitle = (hyper, req, title) =>  mwUtil.getSiteInfo(hyper, req)
-.then(siteInfo => Title.newFromText(title, siteInfo))
-.catch((e) => {
-    throw new HTTPError({
-        status: 400,
-        body: {
-            type: 'bad_request',
-            detail: e.message
-        }
-    });
+.then((siteInfo) => {
+    try {
+        return Title.newFromText(title, siteInfo);
+    } catch (e) {
+        throw new HTTPError({
+            status: 400,
+            body: {
+                type: 'bad_request',
+                detail: e.message
+            }
+        });
+    }
 });
 
 /**

--- a/sys/action.js
+++ b/sys/action.js
@@ -227,6 +227,12 @@ class ActionService {
         }, buildEditResponse);
     }
 
+    /**
+     * Fetch the site info for this project's domain.
+     *
+     * Expects the project domain to be passed in req.params.domain. Fetching
+     * siteinfo for other projects / domains is not supported.
+     */
     siteinfo(hyper, req) {
         const rp = req.params;
         if (!this._siteInfoCache[rp.domain]) {
@@ -263,7 +269,16 @@ class ActionService {
             .catch((e) => {
                 hyper.log('error/site_info', e);
                 delete this._siteInfoCache[rp.domain];
-                throw e;
+                // The project domain is always expected to exist, so consider
+                // any error an internal error.
+                throw new HTTPError({
+                    status: 500,
+                    body: {
+                        type: 'server_error',
+                        title: 'Site info fetch failed.',
+                        detail: e.message
+                    }
+                });
             });
         }
         return this._siteInfoCache[rp.domain];

--- a/test/features/errors/invalid_request.js
+++ b/test/features/errors/invalid_request.js
@@ -64,7 +64,7 @@ parallel('400 handling', function() {
             uri: server.config.labsBucketURL + '/title/Main_Page'
         })
         .catch(function (e) {
-            assert.deepEqual(e.status, 400);
+            assert.deepEqual(e.status, 500);
             return preq.get({
                 uri: server.config.labsBucketURL + '/title/Main_Page'
             });


### PR DESCRIPTION
We should distinguish invalid titles (returning 400) from siteinfo fetch
failures. The latter are not triggered by a property of the request, so
400 is inappropriate.

This patch catches fetch failures, and turns them into 500 responses.
Invalid titles still return 400.