### PR TITLE
Start enforcing Parsoid content versions

### DIFF
--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -72,8 +72,9 @@ function checkContentType(hyper, req, next, expectedContentType, responsePromise
                     expected: expectedContentType,
                     actual: res.headers['content-type']
                 });
-                // Limit response caching to a few seconds
-                res.headers['cache-control'] = 'max-age=10, s-maxage=10';
+                // Disable response caching, as we aren't setting a vary
+                // either.
+                res.headers['cache-control'] = 'max-age=0, s-maxage=0';
             }
         }
         // Default: Just return.

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -211,6 +211,8 @@ paths:
         options:
           allowInlineStyles: true
     get:
+      x-route-filters:
+        - path: lib/ensure_content_type.js
       tags:
         - Page content
       summary: Get latest HTML for a title.
@@ -481,6 +483,8 @@ paths:
         options:
           allowInlineStyles: true
     get:
+      x-route-filters:
+        - path: lib/ensure_content_type.js
       tags:
         - Page content
       summary: Get HTML for a specific title/revision & optionally timeuuid.
@@ -601,6 +605,8 @@ paths:
           redirect_cache_control: '{{options.purged_cache_control}}'
           attach_body_to_redirect: true
     get:
+      x-route-filters:
+        - path: lib/ensure_content_type.js
       tags:
         - Page content
       summary: Get data-parsoid metadata for a specific title/revision/tid.


### PR DESCRIPTION
Start re-rendering Parsoid content (/html/{title},
/html/{title}/{revision} and data-parsoid) if the stored revision does
not match the API spec.

Note that we do not need to set vary on this response, as we are only
comparing the spec version & the returned version in this filter. We
ignore client-supplied `accept` headers for now.