### PR TITLE
Store new version if only the content-type changed

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -328,7 +328,9 @@ class ParsoidService {
                 if (format === 'html'
                         && currentContentRes
                         && currentContentRes.status === 200
-                        && sameHtml(res.body.html.body, currentContentRes.body)) {
+                        && sameHtml(res.body.html.body, currentContentRes.body)
+                        && currentContentRes.headers['content-type']
+                                === res.body.html.headers['content-type']) {
                     // New render is the same as the previous one, no need to store it.
                     hyper.metrics.increment('sys_parsoid_generateAndSave.unchanged_rev_render');
                     return currentContentRes;


### PR DESCRIPTION
After starting to rerender on the content-type mismatch #803 we need to store the new version if only the content-type has changed but HTML is still the same to avoid infinite rerendering on every request for pages where the content-type bump doesn't affect the HTML. 

cc @wikimedia/services 