### PR TITLE
Bug fix: Wt2Lint: No response unwrapping for lint transforms

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -785,7 +785,7 @@ class ParsoidService {
                 throw e;
             })
             .then((res) => {
-                if (to !== 'wikitext') {
+                if (to !== 'wikitext' && to !== 'lint') {
                     // Unwrap to the flat response format
                     res = res.body[to];
                     res.status = 200;

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -120,6 +120,30 @@ parallel('transform api', function() {
     });
 
 
+    it('wt2lint', function () {
+        return preq.post({
+            uri: server.config.labsURL + '/transform/wikitext/to/lint',
+            body: {
+                wikitext: '== Heading =='
+            }
+        }).then(function (res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body, []);
+        });
+    });
+
+    it('wt2lint with errors', function () {
+        return preq.post({
+            uri: server.config.labsURL + '/transform/wikitext/to/lint',
+            body: {
+                wikitext: '<div>No div ending'
+            }
+        }).then(function (res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.length, 1);
+        });
+    });
+
     it('html2wt, no-selser', function () {
         return preq.post({
             uri: server.config.labsURL

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -218,7 +218,7 @@ paths:
       description: |
         Parse the supplied wikitext and check it for lint errors.
 
-        - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
         - Rate limit: 5 req/s
       consumes:
         - multipart/form-data


### PR DESCRIPTION
Also, add some tests for the endpoint and declare it experimental.

Bug: [T163091](https://phabricator.wikimedia.org/T163091)