### PR TITLE
Added html_extract property to the summary endpoint

### DIFF
--- a/v1/common_schemas.yaml
+++ b/v1/common_schemas.yaml
@@ -64,7 +64,7 @@ definitions:
       extract:
         type: string
         description: First several sentences of an article in plain text
-      html_extract:
+      extract_html:
         type: string
         description: First several sentences of an article in simple HTML format
       thumbnail:

--- a/v1/common_schemas.yaml
+++ b/v1/common_schemas.yaml
@@ -64,6 +64,9 @@ definitions:
       extract:
         type: string
         description: First several sentences of an article in plain text
+      html_extract:
+        type: string
+        description: First several sentences of an article in simple HTML format
       thumbnail:
         $ref: '#/definitions/thumbnail'
       originalimage:

--- a/v1/summary.js
+++ b/v1/summary.js
@@ -3,6 +3,18 @@
 const HyperSwitch = require('hyperswitch');
 const spec = HyperSwitch.utils.loadSpec(`${__dirname}/summary.yaml`);
 
+/**
+ * A RegExp to match all the tags with attributes.
+ *
+ * A tag starts with < and a letter, contains of a number of alphanumeric characters,
+ * attributes are separated by spaces, attribute might have a value surrounded by ' or ",
+ * the value is allowed to have any character.
+ *
+ * @const
+ * @type {RegExp}
+ */
+const TAGS_MATCH = /<\/?[a-zA-Z][\w-]*(?:\s+[a-zA-Z_\-:]+(?:=\\?(?:"[^"]*"|'[^']*'))?)*\s*\/?>/g;
+
 module.exports = options => ({
     spec,
     globals: {
@@ -39,6 +51,13 @@ module.exports = options => ({
                 return undefined;
             }
             return coord;
+        },
+        stripTags(extract) {
+            if (!extract) {
+                return undefined;
+            }
+
+            return extract.replace(TAGS_MATCH, '');
         }
     }
 });

--- a/v1/summary.js
+++ b/v1/summary.js
@@ -2,6 +2,7 @@
 
 const HyperSwitch = require('hyperswitch');
 const spec = HyperSwitch.utils.loadSpec(`${__dirname}/summary.yaml`);
+const entities = require('entities');
 
 /**
  * A RegExp to match all the tags with attributes.
@@ -57,7 +58,7 @@ module.exports = options => ({
                 return undefined;
             }
 
-            return extract.replace(TAGS_MATCH, '');
+            return entities.decodeHTML(extract.replace(TAGS_MATCH, ''));
         }
     }
 });

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -29,7 +29,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
-        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.1.2"
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.2.0"
       parameters:
         - name: title
           in: path
@@ -116,7 +116,6 @@ paths:
               body:
                 prop: 'info|extracts|pageimages|revisions|pageterms|coordinates'
                 exsentences: 5
-                explaintext: true
                 exintro: true
                 piprop: 'thumbnail|original'
                 inprop: 'displaytitle'
@@ -128,13 +127,14 @@ paths:
             response:
               # Define the response to save & return.
               headers:
-                content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.1.2"
+                content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.2.0"
                 etag: "\"{{getRevision(extract.body.items[0].revisions).revid}}/{{timeuuid()}}\""
               body:
                 title: '{{extract.body.items[0].title}}'
                 displaytitle: '{{extract.body.items[0].displaytitle}}'
                 pageid: '{{extract.body.items[0].pageid}}'
-                extract: '{{extract.body.items[0].extract}}'
+                extract: '{{stripTags(extract.body.items[0].extract)}}'
+                html_extract: '{{extract.body.items[0].extract}}'
                 thumbnail: '{{httpsSource(extract.body.items[0].thumbnail)}}'
                 originalimage: '{{httpsSource(extract.body.items[0].original)}}'
                 lang: '{{extract.body.items[0].pagelanguagehtmlcode}}'

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -134,7 +134,7 @@ paths:
                 displaytitle: '{{extract.body.items[0].displaytitle}}'
                 pageid: '{{extract.body.items[0].pageid}}'
                 extract: '{{stripTags(extract.body.items[0].extract)}}'
-                html_extract: '{{extract.body.items[0].extract}}'
+                extract_html: '{{extract.body.items[0].extract}}'
                 thumbnail: '{{httpsSource(extract.body.items[0].thumbnail)}}'
                 originalimage: '{{httpsSource(extract.body.items[0].original)}}'
                 lang: '{{extract.body.items[0].pagelanguagehtmlcode}}'


### PR DESCRIPTION
Per discussion on the meeting apps are not interested in migrating to the HTML summaries, so I've added a new `html_extract` property to the summary response.

Size computation for feed response:

Feed plain text -  58K
Feed with html - 94K
Feed plain text gzipped - 18K
Feed with html gzipped - 21K

So for traffic sizes the difference is negligible. 


This also bumps the content type version starting an automatic storage update, but you might still see cached versions from Varnish for 14 more days.

Bug: https://phabricator.wikimedia.org/T165017