### PR TITLE
Sample version mis-match warning 1:1000

### DIFF
--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -33,12 +33,16 @@ function checkContentType(hyper, req, next, expectedContentType, responsePromise
 
         function updateSpecWarning() {
             // Returned content type version is higher than what the
-            // spec promises. Log a warning about the need to update the spec.
-            hyper.log('warn/content-type/spec_outdated', {
-                msg: 'Spec needs update to reflect latest content type.',
-                expected: expectedContentType,
-                actual: res.headers['content-type']
-            });
+            // spec promises.
+            if (Math.random() < 0.001) {
+                // Log a warning about the need to update the spec. Sampled 1:1000.
+                hyper.log('warn/content-type/spec_outdated', {
+                    msg: 'The Swagger spec needs updating to reflect latest content type'
+                        + ' returned by the service.',
+                    expected: expectedContentType,
+                    actual: res.headers['content-type']
+                });
+            }
             // Don't fail the request.
             return res;
         }


### PR DESCRIPTION
After a backend service is upgraded, we tend to get a burst of "need to
update the spec" warnings. We don't really need to see each of those
warnings, so this patch introduces significant sampling at 1:1000.

I also changed the log message slightly to make it clear which part
needs updating.