### PR TITLE
Provide specialpagealiases to the mediawiki-title

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "content-type": "git+https://github.com/wikimedia/content-type#master",
     "hyperswitch": "^0.9.0",
     "jsonwebtoken": "^7.4.1",
-    "mediawiki-title": "^0.5.6",
+    "mediawiki-title": "^0.6.0",
     "entities": "^1.1.1"
   },
   "devDependencies": {

--- a/sys/action.js
+++ b/sys/action.js
@@ -243,7 +243,7 @@ class ActionService {
                 body: {
                     action: 'query',
                     meta: 'siteinfo|filerepoinfo',
-                    siprop: 'general|namespaces|namespacealiases',
+                    siprop: 'general|namespaces|namespacealiases|specialpagealiases',
                     format: 'json'
                 }
             }, {}, (apiReq, res) => {
@@ -261,6 +261,7 @@ class ActionService {
 
                         namespaces: res.body.query.namespaces,
                         namespacealiases: res.body.query.namespacealiases,
+                        specialpagealiases: res.body.query.specialpagealiases,
                         sharedRepoRootURI: findSharedRepoDomain(res),
                         baseUri: this._getBaseUri(req)
                     }


### PR DESCRIPTION
The newer version of `mediawiki-title` also normalizes special pages, so proved the aliases to it.

cc @wikimedia/services 