### PR TITLE
Protect special characters in PDF render backend requests

### DIFF
--- a/v1/pdf.yaml
+++ b/v1/pdf.yaml
@@ -60,7 +60,8 @@ paths:
         - get_pdf_from_backend:
             request:
               method: get
-              uri: '{{options.uri}}/pdf?accessKey={options.secret}&url=https://{{domain}}/wiki/{title}%3Fprintable=yes'
+              # Note: The title needs to be encoded twice.
+              uri: '{{options.uri}}/pdf?accessKey={options.secret}&url=https://{{domain}}/wiki/{_encodeURIComponent(title)}%3Fprintable=yes'
             return:
               status: 200
               headers:


### PR DESCRIPTION
Since we are passing a URL in a query string, we need to double-escape
special characters to ensure the preservation of special characters like
question marks.

This patch uses the existing, but internal _encodeURIComponent function.
This is primarily for expediency. We could also consider promoting
encodeURIComponent to a public function in swagger-router, and then
using that version.

Bug: T169223