### PR TITLE
Disable sending previous content to Parsoid

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -264,7 +264,7 @@ class ParsoidService {
         const reqRevision = rp.revision;
         // Helper for retrieving original content from storage & posting it to
         // the Parsoid pagebundle end point
-        const getOrigAndPostToParsoid = (pageBundleUri, revision, contentName, updateMode) => {
+        /* const getOrigAndPostToParsoid = (pageBundleUri, revision, contentName, updateMode) => {
             return this._getOriginalContent(hyper, req, revision)
             .then((res) => {
                 const body = {
@@ -280,7 +280,7 @@ class ParsoidService {
                     body
                 });
             }, () => hyper.get({ uri: pageBundleUri })); // Fall back to plain GET
-        };
+        }; */
 
         return this.getRevisionInfo(hyper, req)
         .then((revInfo) => {
@@ -304,9 +304,11 @@ class ParsoidService {
             const pageBundleUri = new URI([rp.domain, 'sys', 'parsoid', 'pagebundle',
                 rp.title, rp.revision]);
 
-            const parentRev = parseInt(req.headers['x-restbase-parentrevision'], 10);
-            const updateMode = req.headers['x-restbase-mode'];
-            let parsoidReq;
+            // const parentRev = parseInt(req.headers['x-restbase-parentrevision'], 10);
+            // const updateMode = req.headers['x-restbase-mode'];
+            const parsoidReq =  hyper.get({ uri: pageBundleUri });
+            /* Switched off for the transition period to the new storage model. See T170997.
+
             if (parentRev) {
                 // OnEdit job update: pass along the predecessor version
                 parsoidReq = getOrigAndPostToParsoid(pageBundleUri, `${parentRev}`, 'previous');
@@ -319,7 +321,7 @@ class ParsoidService {
             } else {
                 // Plain render
                 parsoidReq = hyper.get({ uri: pageBundleUri });
-            }
+            } */
 
             return P.join(parsoidReq, mwUtil.decodeBody(currentContentRes))
             .spread((res, currentContentRes) => {

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -149,7 +149,7 @@ describe('on-demand generation of html and data-parsoid', function() {
     });
     */
 
-    it('should pass (stored) revision B content to Parsoid for image update',
+    it.skip('should pass (stored) revision B content to Parsoid for image update',
     function () {
         // Start watching for new log entries
         var slice = server.config.logStream.slice();
@@ -183,7 +183,7 @@ describe('on-demand generation of html and data-parsoid', function() {
         });
     });
 
-    it('should pass (stored) revision B content to Parsoid for edit update',
+    it.skip('should pass (stored) revision B content to Parsoid for edit update',
     function () {
         // Start watching for new log entries
         var slice = server.config.logStream.slice();


### PR DESCRIPTION
During the transition period to the new storage we want the pipeline to be as simple as possible. As the previous content is not used in Parsoid yet, let's just not send it for now. 

We can resurrect that later with great caution, as I think that with our storage model the previous versions should still be available, but for now it takes away square from my storage diagram and makes it safer to reason about the pipeline. 

Bug: https://phabricator.wikimedia.org/T170997
cc @wikimedia/services @subbuss @arlolra 