### PR TITLE
Use Node v6.11, update dependencies and release v0.16.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "description": "REST storage and service dispatcher",
   "main": "index.js",
   "scripts": {
@@ -36,13 +36,13 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "cassandra-uuid": "^0.0.2",
-    "restbase-mod-table-cassandra": "^0.11.1",
+    "restbase-mod-table-cassandra": "^0.11.2",
     "service-runner": "^2.3.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "content-type": "git+https://github.com/wikimedia/content-type#master",
-    "hyperswitch": "^0.9.0",
+    "hyperswitch": "^0.9.1",
     "jsonwebtoken": "^7.4.1",
-    "mediawiki-title": "^0.6.0",
+    "mediawiki-title": "^0.6.3",
     "entities": "^1.1.1"
   },
   "devDependencies": {
@@ -71,7 +71,7 @@
     "node": ">=4"
   },
   "deploy": {
-    "node": "6.9.1",
+    "node": "6.11.1",
     "target": "debian",
     "dependencies": {
       "_all": []


### PR DESCRIPTION
Bug: [T170548](https://phabricator.wikimedia.org/T170548)