### PR TITLE
Fix basic `example` config

### DIFF
--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -1,4 +1,4 @@
-# RESTBase project config for small wiki installs
+# RESTBase project config for development environments
 paths:
   /{api:v1}:
     x-modules:
@@ -16,10 +16,27 @@ paths:
               x-modules:
                 - path: v1/content.yaml
                   options: '{{options}}'
+                - path: v1/content_segments.yaml
+                  options:
+                      purged_cache_control: '{{options.purged_cache_control}}'
+                      cx_host: '{{options.transform.cx_host}}'
                 - path: v1/common_schemas.yaml # Doesn't really matter where to mount it.
+                - path: v1/mobileapps.yaml
+                  options: '{{merge({"response_cache_control": options.purged_cache_control},
+                                options.mobileapps)}}'
             /transform:
               x-modules:
                 - path: v1/transform.yaml
+                - path: v1/transform-lang.js
+                  options: '{{options.transform}}'
+            /media:
+              x-modules:
+                - path: v1/mathoid.yaml
+                  options: '{{options.mathoid}}'
+            /data:
+              x-modules:
+                - path: v1/citoid.js
+                  options: '{{options.citoid}}'
         options: '{{options}}'
 
   /{api:sys}:
@@ -59,5 +76,10 @@ paths:
                   options:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
+            /mobileapps:
+              x-modules:
+                - path: sys/mobileapps.js
+                  options: '{{merge({"response_cache_control": options.purged_cache_control},
+                                options.mobileapps)}}'
         options: '{{options}}'
 

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -48,6 +48,8 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
+                  options: '{{options}}'
+                - path: v1/content_segments.yaml
                   options:
                     purged_cache_control: '{{options.purged_cache_control}}'
                     cx_host: '{{options.transform.cx_host}}'

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -48,6 +48,8 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
+                  options: '{{options}}'
+                - path: v1/content_segments.yaml
                   options:
                     purged_cache_control: '{{options.purged_cache_control}}'
                     cx_host: '{{options.transform.cx_host}}'

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -48,6 +48,8 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
+                  options: '{{options}}'
+                - path: v1/content_segments.yaml
                   options:
                     purged_cache_control: '{{options.purged_cache_control}}'
                     cx_host: '{{options.transform.cx_host}}'

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -52,6 +52,8 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
+                  options: '{{options}}'
+                - path: v1/content_segments.yaml
                   options:
                     purged_cache_control: '{{options.purged_cache_control}}'
                     cx_host: '{{options.transform.cx_host}}'

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: '1.0.0-beta'
+  version: '1.0.0'
   title: MediaWiki Content API
   description: Basic MediaWiki content api.
   termsofservice: https://github.com/wikimedia/restbase#restbase
@@ -890,69 +890,6 @@ paths:
               body: '{{request.body}}'
       x-monitor: false
 
-  /segments/{title}{/revision}:
-    get:
-      tags:
-        - Page content
-      summary: Fetches a segmented page to be used in machine translation
-      description: |
-        Use this end point to fetch the segmented content of a page. Clients should
-        use the returned content in conjunction with the [language transform
-        API](https://wikimedia.org/api/rest_v1/#!/Transform).
-
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-      produces:
-        - application/json
-      parameters:
-        - name: title
-          in: path
-          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
-          type: string
-          required: true
-        - name: revision
-          in: path
-          description: The revision id
-          type: integer
-          required: false
-      responses:
-        '200':
-          description: The segmented page for the given title and revision
-          schema:
-            type: object
-            properties:
-              sourceLanguage:
-                type: string
-                description: The source language of the page
-              title:
-                type: string
-                description: The title of the segmented page returned
-              revision:
-                type: integer
-                description: The revision ID of the segmented page
-              segmentedContent:
-                type: string
-                description: The segmented HTML body of the contents of the page
-        '400':
-          description: Invalid revision
-          schema:
-            $ref: '#/definitions/problem'
-        '403':
-          description: Access to the specific revision is restricted
-          schema:
-            $ref: '#/definitions/problem'
-        '404':
-          description: Unknown page or revision
-          schema:
-            $ref: '#/definitions/problem'
-        default:
-          description: Error
-          schema:
-            $ref: '#/definitions/problem'
-      x-request-handler:
-        - get_from_cx:
-            request:
-              uri: '{{options.cx_host}}/v1/page/{domain}/{title}/{revision}'
-      x-monitor: false
 
 definitions:
   revisions:

--- a/v1/content_segments.yaml
+++ b/v1/content_segments.yaml
@@ -1,0 +1,72 @@
+swagger: '2.0'
+info:
+  version: '1.0.0'
+  title: MediaWiki Section Content API
+  description: Adding translated section content to the content API.
+tags:
+  - name: Page content
+    description: page content in different formats
+paths:
+  /segments/{title}{/revision}:
+    get:
+      tags:
+        - Page content
+      summary: Fetches a segmented page to be used in machine translation
+      description: |
+        Use this end point to fetch the segmented content of a page. Clients should
+        use the returned content in conjunction with the [language transform
+        API](https://wikimedia.org/api/rest_v1/#!/Transform).
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json
+      parameters:
+        - name: title
+          in: path
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: The revision id
+          type: integer
+          required: false
+      responses:
+        '200':
+          description: The segmented page for the given title and revision
+          schema:
+            type: object
+            properties:
+              sourceLanguage:
+                type: string
+                description: The source language of the page
+              title:
+                type: string
+                description: The title of the segmented page returned
+              revision:
+                type: integer
+                description: The revision ID of the segmented page
+              segmentedContent:
+                type: string
+                description: The segmented HTML body of the contents of the page
+        '400':
+          description: Invalid revision
+          schema:
+            $ref: '#/definitions/problem'
+        '403':
+          description: Access to the specific revision is restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '404':
+          description: Unknown page or revision
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_cx:
+            request:
+              uri: '{{options.cx_host}}/v1/page/{domain}/{title}/{revision}'
+      x-monitor: false


### PR DESCRIPTION
- Restore basic `example` project config, without advanced features like
cxserver or citoid.
- Move advanced "dev" functionality into a more advanced "dev.yaml"
project.
- Move cxserver "section" content into its own module, so that it can be
enabled selectively.

Bug: https://phabricator.wikimedia.org/T171592