### PR TITLE
Improve filename encoding for PDF responses

### DIFF
--- a/test/features/pdf.js
+++ b/test/features/pdf.js
@@ -15,8 +15,8 @@ describe('PDF Service', () => {
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers['content-disposition'],
-                'attachment; filename=%D0%94%D0%B0%D1%80%D1%82_%D0%92%D0%B5%D0%B9%D0%B4%D0%B5%D1%80.pdf;'
-                    + ' filename*=%D0%94%D0%B0%D1%80%D1%82_%D0%92%D0%B5%D0%B9%D0%B4%D0%B5%D1%80.pdf');
+                'attachment; filename="%D0%94%D0%B0%D1%80%D1%82_%D0%92%D0%B5%D0%B9%D0%B4%D0%B5%D1%80.pdf";'
+                    + ' filename*=UTF-8\'\'%D0%94%D0%B0%D1%80%D1%82_%D0%92%D0%B5%D0%B9%D0%B4%D0%B5%D1%80.pdf');
             assert.deepEqual(res.headers['content-type'], 'application/pdf');
             assert.ok(/"\d+\/[\d\w-]+"/.test(res.headers.etag));
             assert.ok(res.body.length !== 0);

--- a/v1/pdf.yaml
+++ b/v1/pdf.yaml
@@ -65,8 +65,10 @@ paths:
             return:
               status: 200
               headers:
-                # Firefox supports filename*= syntax while Chrome respect filename=. Safari is stupid and understands neither
-                content-disposition: 'attachment; filename={request.params.title}.pdf; filename*={request.params.title}.pdf'
+                # Firefox supports filename*= syntax while Chrome respect
+                # filename=. Safari is stupid and understands neither.
+                # TODO: Quote raw `"` chars in filename.
+                content-disposition: 'attachment; filename="{request.params.title}.pdf"; filename*=UTF-8''''{request.params.title}.pdf'
                 content-type: '{{get_pdf_from_backend.headers.content-type}}'
                 content-length: '{{get_pdf_from_backend.headers.content-length}}'
                 cache-control: '{{default(options.cache_control, "s-maxage=600, max-age=600")}}'


### PR DESCRIPTION
- Use quoted string syntax for the plain filename parameter. Protecting
raw `"` remains a TODO that will require new functionality in
hyperswitch. In the meantime, adding quotes already protects many other
chars.
- Correctly pass the mandatory encoding in extended filename syntax.
This avoids Firefox picking up apostrophes in the filename as a
delimiter.

Bug: https://phabricator.wikimedia.org/T171747