### PR TITLE
Recommendation API Public End Point

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -33,6 +33,8 @@ default_project: &default_project
           cache_control: s-maxage=86400, max-age=86400
         citoid:
           host: http://citoid-beta.wmflabs.org
+        recommendation:
+          host: https://recommendation-api-beta.wmflabs.org
         # 10 days Varnish caching, one day client-side
         purged_cache_control: s-maxage=864000, max-age=86400
         # Cache control for purged endpoints allowing short-term client caching

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -33,6 +33,8 @@ default_project: &default_project
           host: https://appservice.wmflabs.org
         citoid:
           host: https://citoid-beta.wmflabs.org
+        recommendation:
+          host: https://recommendation-api-beta.wmflabs.org
         events: {}
         purged_cache_control: test_purged_cache_control
         # Cache control for purged endpoints allowing short-term client caching

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -90,6 +90,8 @@ paths:
               x-modules:
                 - path: v1/citoid.js
                   options: '{{options.citoid}}'
+                - path: v1/recommend.yaml
+                  options: '{{options.recommendation}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -92,6 +92,8 @@ paths:
               x-modules:
                 - path: v1/citoid.js
                   options: '{{options.citoid}}'
+                - path: v1/recommend.yaml
+                  options: '{{options.recommendation}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/v1/recommend.yaml
+++ b/v1/recommend.yaml
@@ -51,6 +51,7 @@ paths:
         - get_from_backend:
             request:
               uri: '{{options.host}}/{domain}/v1/translation/articles/{from_lang}/{seed_article}'
+      x-monitor: false
 definitions:
   translation_result:
     type: object

--- a/v1/recommend.yaml
+++ b/v1/recommend.yaml
@@ -1,0 +1,77 @@
+info:
+  version: '1.0.0'
+  title: Recommendation API
+  description: Recommendation API
+  termsofservice: https://github.com/wikimedia/restbase
+  license:
+    name: Apache license, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /translation/articles/{source}{/seed}:
+    get:
+      tags:
+        - Recommend
+      summary: Recommend articles for translation.
+      description: |
+        Recommends articles to be translated from the source
+        to the domain language.
+
+        See more at [Recommendation API documentation](https://meta.wikimedia.org/wiki/Recommendation_API)
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - applicaiton/json
+      parameters:
+        - name: source
+          in: path
+          description: The source language code
+          type: string
+          required: true
+        - name: seed
+          in: path
+          description: The article to use as a search seed
+          type: string
+          required: false
+        - name: count
+          in: query
+          description: The max number of articles to return
+          type: int
+          required: false
+          default: 24
+      responses:
+        '200':
+          description: the list of articles recommended for translation
+          schema:
+            $ref: '#/definitions/translation_result'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{domain}}/translation/articles/{source}{/seed}'
+              headers:
+                x-client-ip: '{{x-client-ip}}'
+definitions:
+  translation_result:
+    type: object
+    properties:
+      count:
+        type: int
+        description: the number of recommendations returned
+      articles:
+        type: array
+        description: the list of articles recommended for translation
+        items:
+          type: object
+          properties:
+            wikidata_id:
+              type: string
+              description: wikidata id for the item
+            title:
+              type: string
+              description: title of the article in the source language
+            sitelink_count:
+              type: int
+              description: count of sites the wikidata item is linked to

--- a/v1/recommend.yaml
+++ b/v1/recommend.yaml
@@ -59,7 +59,7 @@ definitions:
       count:
         type: integer
         description: the number of recommendations returned
-      articles:
+      items:
         type: array
         description: the list of articles recommended for translation
         items:

--- a/v1/recommend.yaml
+++ b/v1/recommend.yaml
@@ -42,7 +42,7 @@ paths:
         '200':
           description: the list of articles recommended for translation
           schema:
-            $ref: '#/definitions/translation_result'
+            $ref: '#/definitions/recommendation_result'
         default:
           description: Error
           schema:
@@ -50,10 +50,10 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
-              uri: '{{options.host}}/{domain}/v1/translation/articles/{from_lang}/{seed_article}'
+              uri: '{{options.host}}/{domain}/v1/translation/articles/{from_lang}/{{default(seed_article,"")}}'
       x-monitor: false
 definitions:
-  translation_result:
+  recommendation_result:
     type: object
     properties:
       count:

--- a/v1/recommend.yaml
+++ b/v1/recommend.yaml
@@ -7,10 +7,10 @@ info:
     name: Apache license, v2
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
-  /translation/articles/{source}{/seed}:
+  /recommendation/translation/{from_lang}{/seed_article}:
     get:
       tags:
-        - Recommend
+        - Recommendation
       summary: Recommend articles for translation.
       description: |
         Recommends articles to be translated from the source
@@ -22,12 +22,12 @@ paths:
       produces:
         - applicaiton/json
       parameters:
-        - name: source
+        - name: from_lang
           in: path
           description: The source language code
           type: string
           required: true
-        - name: seed
+        - name: seed_article
           in: path
           description: The article to use as a search seed
           type: string
@@ -35,7 +35,7 @@ paths:
         - name: count
           in: query
           description: The max number of articles to return
-          type: int
+          type: integer
           required: false
           default: 24
       responses:
@@ -50,15 +50,13 @@ paths:
       x-request-handler:
         - get_from_backend:
             request:
-              uri: '{{domain}}/translation/articles/{source}{/seed}'
-              headers:
-                x-client-ip: '{{x-client-ip}}'
+              uri: '{{options.host}}/{domain}/v1/translation/articles/{from_lang}/{seed_article}'
 definitions:
   translation_result:
     type: object
     properties:
       count:
-        type: int
+        type: integer
         description: the number of recommendations returned
       articles:
         type: array
@@ -73,5 +71,5 @@ definitions:
               type: string
               description: title of the article in the source language
             sitelink_count:
-              type: int
+              type: integer
               description: count of sites the wikidata item is linked to


### PR DESCRIPTION
This PR exposes the recommendation API service's end point publicly at `https://{domain}/api/rest_v1/data/recommendation/translation/{from_lang}{/seed_article}`

This PR is a continuation of PR #835 .

Bug: [T170877](https://phabricator.wikimedia.org/T170877)