### PR TITLE
Update security headers

### DIFF
--- a/lib/security_response_header_filter.js
+++ b/lib/security_response_header_filter.js
@@ -58,9 +58,9 @@ module.exports = function addCSPHeaders(hyper, req, next, options) {
 
         // Set up basic CORS headers
         rh['access-control-allow-origin'] = '*';
-        rh['access-control-allow-methods'] = 'GET';
+        rh['access-control-allow-methods'] = 'GET,HEAD';
         rh['access-control-allow-headers'] =
-            'accept, content-type, cache-control, accept-language, ' +
+            'accept, content-type, content-length, cache-control, accept-language, ' +
             'api-user-agent, if-match, if-modified-since, if-none-match, ' +
             // There's a bug in Safari 9 that makes it require these as allowed headers
             'dnt, accept-encoding';
@@ -70,6 +70,10 @@ module.exports = function addCSPHeaders(hyper, req, next, options) {
         // https://www.owasp.org/index.php/List_of_useful_HTTP_headers
         rh['x-content-type-options'] = 'nosniff';
         rh['x-frame-options'] = 'SAMEORIGIN';
+
+        // Restrict referrer forwarding
+        // (https://phabricator.wikimedia.org/T173509)
+        rh['referrer-policy'] = 'origin-when-cross-origin';
 
         let csp;
         if (isHtmlSvgContent(res)) {

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -21,10 +21,11 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers['access-control-allow-origin'], '*');
-            assert.deepEqual(res.headers['access-control-allow-methods'], 'GET');
-            assert.deepEqual(res.headers['access-control-allow-headers'], 'accept, content-type, cache-control, ' +
+            assert.deepEqual(res.headers['access-control-allow-methods'], 'GET,HEAD');
+            assert.deepEqual(res.headers['access-control-allow-headers'], 'accept, content-type, content-length, cache-control, ' +
                 'accept-language, api-user-agent, if-match, if-modified-since, if-none-match, dnt, accept-encoding');
             assert.deepEqual(res.headers['access-control-expose-headers'], 'etag');
+            assert.deepEqual(res.headers['referrer-policy'], 'origin-when-cross-origin');
         });
     });
     it('should transparently create a new HTML revision for Main_Page', function() {


### PR DESCRIPTION
- Allow access to response headers of HEAD requests.
- Allow access to `content-length` response header. This is useful for
clients wishing to avoid downloading large pages or resources, by first
checking for the response size with a HEAD request.
- Restrict cross-origin referrer header forwarding to relay the origin
(domain) only. This avoids revealing the precise page / API result a
client navigated from.

Bug: https://phabricator.wikimedia.org/T173509