### PR TITLE
Correct the spec for cxserver machine translation

### DIFF
--- a/v1/transform-global.yaml
+++ b/v1/transform-global.yaml
@@ -17,7 +17,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       consumes:
-        - application/json
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -41,7 +41,7 @@ paths:
            - Yandex
            - Youdao
         - name: html
-          in: body
+          in: formData
           description: The HTML content to translate
           type: string
           required: true

--- a/v1/transform-lang.yaml
+++ b/v1/transform-lang.yaml
@@ -17,7 +17,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       consumes:
-        - application/json
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -36,7 +36,7 @@ paths:
            - Yandex
            - Youdao
         - name: html
-          in: body
+          in: formData
           description: The HTML content to translate
           type: string
           required: true
@@ -93,4 +93,3 @@ paths:
             $ref: '#/definitions/problem'
       x-monitor: false
       operationId: doDict
-


### PR DESCRIPTION
1. The consume type is application/x-www-form-urlencoded like
   parsoid.
2. The html for mt should be set in formData with key as html like
   parsoid.

Fix for https://phabricator.wikimedia.org/T173801