### PR TITLE
Create a kill switch for the new storage

### DIFF
--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -233,6 +233,7 @@ paths:
             /mobileapps:
               x-modules:
                 - path: sys/mobile_proxy.js
+                  options: '{{options.mobileapps}}'
             /mobileapps_old:
               x-modules:
                 - path: sys/mobileapps_old.js

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -189,6 +189,7 @@ paths:
             /mobileapps:
               x-modules:
                 - path: sys/mobile_proxy.js
+                  options: '{{options.mobileapps}}'
             /mobileapps_old:
               x-modules:
                 - path: sys/mobileapps_old.js

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -140,6 +140,7 @@ paths:
             /mobileapps:
               x-modules:
                 - path: sys/mobile_proxy.js
+                  options: '{{options.mobileapps}}'
             /mobileapps_old:
               x-modules:
                 - path: sys/mobileapps_old.js

--- a/sys/mobile_proxy.js
+++ b/sys/mobile_proxy.js
@@ -8,7 +8,8 @@ const spec = HyperSwitch.utils.loadSpec(`${__dirname}/mobileapps.yaml`);
 
 class MobileApps {
     constructor(options) {
-        this._options = options;
+        this._options = options || {};
+        this._options.storage = this._options.storage || 'both';
     }
 
     _generateDoubleFetching(hyper, req, oldPath, newPath) {
@@ -64,6 +65,18 @@ class MobileApps {
         if (rp.revision) {
             newPath.push(rp.revision);
         }
+        if (this._options.storage === 'new') {
+            return hyper.get({
+                uri: new URI(newPath),
+                headers: req.headers
+            });
+        }
+        if (this._options.storage === 'old') {
+            return hyper.get({
+                uri: new URI(oldPath),
+                headers: req.headers
+            });
+        }
         return this._generateDoubleFetching(hyper, req, oldPath, newPath);
     }
 
@@ -76,6 +89,18 @@ class MobileApps {
         const newPath = [rp.domain, 'sys', 'mobileapps_new', `mobile-sections-${part}`, rp.title];
         if (rp.revision) {
             newPath.push(rp.revision);
+        }
+        if (this._options.storage === 'new') {
+            return hyper.get({
+                uri: new URI(newPath),
+                headers: req.headers
+            });
+        }
+        if (this._options.storage === 'old') {
+            return hyper.get({
+                uri: new URI(oldPath),
+                headers: req.headers
+            });
         }
         return this._generateDoubleFetching(hyper, req, oldPath, newPath);
     }


### PR DESCRIPTION
Allow to disable new storage with a single config change.

cc @wikimedia/services 