### PR TITLE
Fix tavis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 node_js:
     - "4"
     - "6"
-sudo: false
+sudo: required
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ before_install:
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
-  - bash -x ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra -f
+  - bash -x ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra
 
 script: sh test/utils/run_tests.sh coverage ${TEST_TARGET} && (npm run-script coveralls || exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
-  - echo "-Xmx1g" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
+  - echo "-Xmx512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - bash ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra > /dev/null
 
 script: sh test/utils/run_tests.sh coverage ${TEST_TARGET} && (npm run-script coveralls || exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 before_install:
   - wget https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -P ../
   - tar -xzf ../apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C ../
-  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH
+  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH _JAVA_OPTIONS=""
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,10 @@ env:
 before_install:
   - wget https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -P ../
   - tar -xzf ../apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C ../
-  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH _JAVA_OPTIONS=""
+  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH _JAVA_OPTIONS= MALLOC_ARENA_MAX=
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
-  - echo "-XX:OnError='cat hs_err_pid%p.log'" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - bash -x ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra -f
 
 script: sh test/utils/run_tests.sh coverage ${TEST_TARGET} && (npm run-script coveralls || exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 node_js:
     - "4"
     - "6"
-sudo: false
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
   - tar -xzf ../apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C ../
   - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH _JAVA_OPTIONS= MALLOC_ARENA_MAX=
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
-  - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
-  - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
+#  - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
+#  - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - bash -x ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra -f
 
 script: sh test/utils/run_tests.sh coverage ${TEST_TARGET} && (npm run-script coveralls || exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: trusty
 node_js:
     - "4"
     - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 before_install:
   - wget https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -P ../
   - tar -xzf ../apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C ../
-  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`/home/travis/apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH
+  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ env:
 before_install:
   - wget https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -P ../
   - tar -xzf ../apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C ../
-  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH _JAVA_OPTIONS= MALLOC_ARENA_MAX=
+  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
-#  - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
-#  - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
+  - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
+  - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - bash -x ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra -f
 
 script: sh test/utils/run_tests.sh coverage ${TEST_TARGET} && (npm run-script coveralls || exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 before_install:
   - wget https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -P ../
   - tar -xzf ../apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C ../
-  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" _JAVA_OPTIONS=
+  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`/home/travis/apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ before_install:
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
-  - bash ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra > /dev/null
+  - bash -x ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra -f
 
 script: sh test/utils/run_tests.sh coverage ${TEST_TARGET} && (npm run-script coveralls || exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ env:
 before_install:
   - wget https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -P ../
   - tar -xzf ../apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C ../
-  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
+  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" _JAVA_OPTIONS=
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
-  - echo "-Xmx512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
+  - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - bash ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra > /dev/null
 
 script: sh test/utils/run_tests.sh coverage ${TEST_TARGET} && (npm run-script coveralls || exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
+  - echo "-XX:OnError='cat hs_err_pid%p.log'" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - bash -x ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra -f
 
 script: sh test/utils/run_tests.sh coverage ${TEST_TARGET} && (npm run-script coveralls || exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 node_js:
     - "4"
     - "6"
-#sudo: required
+sudo: false
 
 notifications:
   irc:
@@ -22,7 +22,7 @@ env:
 before_install:
   - wget https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -P ../
   - tar -xzf ../apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C ../
-  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH
+  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH _JAVA_OPTIONS=
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms256m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - echo "-Xmx512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 node_js:
     - "4"
     - "6"
-sudo: required
+#sudo: required
 
 notifications:
   irc:
@@ -24,8 +24,8 @@ before_install:
   - tar -xzf ../apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C ../
   - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
-  - echo "-Xms512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
-  - echo "-Xmx1024m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
+  - echo "-Xms256m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
+  - echo "-Xmx512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - bash -x ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra
 
 script: sh test/utils/run_tests.sh coverage ${TEST_TARGET} && (npm run-script coveralls || exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 before_install:
   - wget https://archive.apache.org/dist/cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -P ../
   - tar -xzf ../apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz -C ../
-  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH _JAVA_OPTIONS=
+  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle" PATH=`pwd`/../apache-cassandra-${CASSANDRA_VERSION}/bin:$PATH
   - mkdir -p ../apache-cassandra-${CASSANDRA_VERSION}/logs
   - echo "-Xms256m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - echo "-Xmx512m" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options


### PR DESCRIPTION
Travis has started failing without any changes from our side. After a bunch of random poking around I've found the configuration which magically works. 

I've removed the `sudo: false` from the config, which according to the docs should be a no-op because the container-based build should be a default, but that's somehow the most important change here - without it java still crashes. I'm not sure whether the docs are incorrect and we're actually running VMs now or it's some even more bogus bug, but I propose to merge this to get at least some travis builds running and reevaluate in a month or two when travis changes something in it's internals.

When merging please squash the commits, I didn't really care providing explanatory commit messages.

Bug: https://phabricator.wikimedia.org/T176330

cc @wikimedia/services 