### PR TITLE
Switch the feeds to the new storage completely

### DIFF
--- a/lib/base_feed.js
+++ b/lib/base_feed.js
@@ -53,7 +53,7 @@ class BaseFeed {
         const populateSummaries = res => this._hydrateResponse(hyper, req, res);
         const getContent = (bucket, forwardCacheControl) => {
             const request = {
-                uri: new URI([rp.domain, 'sys', 'key_value', bucket, dateKey])
+                uri: new URI([rp.domain, 'sys', 'key_value3', bucket, dateKey])
             };
             if (forwardCacheControl && req.headers && req.headers['cache-control']) {
                 request.headers = {
@@ -64,7 +64,7 @@ class BaseFeed {
         };
         const storeContent = (res, bucket) => {
             return hyper.put({
-                uri: new URI([rp.domain, 'sys', 'key_value', bucket, dateKey]),
+                uri: new URI([rp.domain, 'sys', 'key_value3', bucket, dateKey]),
                 headers: res.headers,
                 body: res.body
             });
@@ -130,15 +130,6 @@ class BaseFeed {
     getModuleDeclaration() {
         const resources = [];
         if (this.options.storeHistory) {
-            resources.push({
-                uri: `/{domain}/sys/key_value/${this._getHistoricBucketName()}`,
-                body: {
-                    version: 1,
-                    valueType: 'json'
-                }
-            });
-            // TODO: At first just create the buckets in the new storage
-            // to be able to transfer the content there
             resources.push({
                 uri: `/{domain}/sys/key_value3/${this._getHistoricBucketName()}`,
                 body: {

--- a/test/features/feed.js
+++ b/test/features/feed.js
@@ -7,7 +7,7 @@ const nock   = require('nock');
 
 function assertStorageRequest(requests, method, bucket, expected) {
     const storageRequests = requests.filter((log) =>
-        log.req && log.req.uri === `/en.wikipedia.org/sys/table/${bucket}/`
+        log.req && log.req.uri === `/en.wikipedia.org/sys/table3/${bucket}/`
             && log.req.method === method);
     if (expected) {
         assert.deepEqual(storageRequests.length > 0, true, `Should have made ${method} request to ${bucket}`);
@@ -48,8 +48,6 @@ describe('Featured feed', () => {
             const requests = slice.get().map(JSON.parse);
             assertStorageRequest(requests, 'get', 'feed.aggregated.historic', true);
             assertStorageRequest(requests, 'put', 'feed.aggregated.historic', true);
-            assertStorageRequest(requests, 'get', 'feed.aggregated', false);
-            assertStorageRequest(requests, 'put', 'feed.aggregated', false);
             assertMCSRequest(requests, 'page/featured', date, true);
             assertMCSRequest(requests, 'page/most-read', date, true);
             assertMCSRequest(requests, 'media/image/featured', date, true);
@@ -69,8 +67,6 @@ describe('Featured feed', () => {
             const requests = slice.get().map(JSON.parse);
             assertStorageRequest(requests, 'get', 'feed.aggregated.historic', true);
             assertStorageRequest(requests, 'put', 'feed.aggregated.historic', false);
-            assertStorageRequest(requests, 'get', 'feed.aggregated', false);
-            assertStorageRequest(requests, 'put', 'feed.aggregated', false);
             assertMCSRequest(requests, 'page/featured', date, false);
             assertMCSRequest(requests, 'page/most-read', date, false);
             assertMCSRequest(requests, 'media/image/featured', date, false);
@@ -93,8 +89,6 @@ describe('Featured feed', () => {
             const requests = slice.get().map(JSON.parse);
             assertStorageRequest(requests, 'get', 'feed.aggregated.historic', true);
             assertStorageRequest(requests, 'put', 'feed.aggregated.historic', true);
-            assertStorageRequest(requests, 'get', 'feed.aggregated', false);
-            assertStorageRequest(requests, 'put', 'feed.aggregated', false);
             assertMCSRequest(requests, 'page/featured', date, true);
             assertMCSRequest(requests, 'page/most-read', date, true);
             assertMCSRequest(requests, 'media/image/featured', date, true);


### PR DESCRIPTION
Use the new storage for all the feeds.

cc @wikimedia/services 