### PR TITLE
Make a proper key_value for the new storage

### DIFF
--- a/lib/base_feed.js
+++ b/lib/base_feed.js
@@ -53,7 +53,7 @@ class BaseFeed {
         const populateSummaries = res => this._hydrateResponse(hyper, req, res);
         const getContent = (bucket, forwardCacheControl) => {
             const request = {
-                uri: new URI([rp.domain, 'sys', 'key_value', bucket, dateKey])
+                uri: new URI([rp.domain, 'sys', 'key_value_old', bucket, dateKey])
             };
             if (forwardCacheControl && req.headers && req.headers['cache-control']) {
                 request.headers = {
@@ -64,7 +64,7 @@ class BaseFeed {
         };
         const storeContent = (res, bucket) => {
             return hyper.put({
-                uri: new URI([rp.domain, 'sys', 'key_value', bucket, dateKey]),
+                uri: new URI([rp.domain, 'sys', 'key_value_old', bucket, dateKey]),
                 headers: res.headers,
                 body: res.body
             });
@@ -131,7 +131,7 @@ class BaseFeed {
         const resources = [];
         if (this.options.storeHistory) {
             resources.push({
-                uri: `/{domain}/sys/key_value/${this._getHistoricBucketName()}`,
+                uri: `/{domain}/sys/key_value_old/${this._getHistoricBucketName()}`,
                 body: {
                     version: 1,
                     valueType: 'json'
@@ -140,7 +140,7 @@ class BaseFeed {
             // TODO: At first just create the buckets in the new storage
             // to be able to transfer the content there
             resources.push({
-                uri: `/{domain}/sys/key_value3/${this._getHistoricBucketName()}`,
+                uri: `/{domain}/sys/key_value/${this.options.name}`,
                 body: {
                     version: 1,
                     valueType: 'json'

--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -53,9 +53,12 @@ paths:
                 - path: sys/table.js
                   options:
                     conf: '{{options.table_ng}}'
-            /key_value:
+            /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
+            /key_value_old: &sys_key_value_old
+              x-modules:
+                - path: sys/key_value_old.js
             /key_rev_value:
               x-modules:
                 - path: sys/key_rev_value.js

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -31,9 +31,12 @@ paths:
                 - path: sys/table.js
                   options:
                     conf: '{{options.table}}'
-            /key_value:
+            /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
+            /key_value_old: &sys_key_value_old
+              x-modules:
+                - path: sys/key_value_old.js
             /key_rev_value:
               x-modules:
                 - path: sys/key_rev_value.js

--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -88,9 +88,12 @@ paths:
                 - path: sys/table.js
                   options:
                     conf: '{{options.table}}'
-            /key_value:
+            /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
+            /key_value_old: &sys_key_value_old
+              x-modules:
+                - path: sys/key_value_old.js
             /key_rev_value:
               x-modules:
                 - path: sys/key_rev_value.js

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -122,13 +122,9 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
-                  options:
-                    backend: table
-            /key_value3: &sys_key_value
+            /key_value_old: &sys_key_value_old
               x-modules:
-                - path: sys/key_value.js
-                  options:
-                    backend: table3
+                - path: sys/key_value_old.js
             /key_rev_value:
               x-modules:
                 - path: sys/key_rev_value.js

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -124,13 +124,9 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
-                  options:
-                    backend: table
-            /key_value3: &sys_key_value
+            /key_value_old: &sys_key_value_old
               x-modules:
-                - path: sys/key_value.js
-                  options:
-                    backend: table3
+                - path: sys/key_value_old.js
             /key_rev_value:
               x-modules:
                 - path: sys/key_rev_value.js

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -97,13 +97,9 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
-                  options:
-                    backend: table
-            /key_value3: &sys_key_value
+            /key_value_old: &sys_key_value_old
               x-modules:
-                - path: sys/key_value.js
-                  options:
-                    backend: table3
+                - path: sys/key_value_old.js
             /key_rev_value:
               x-modules:
                 - path: sys/key_rev_value.js

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -111,13 +111,9 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
-                  options:
-                    backend: table
-            /key_value3: &sys_key_value
+            /key_value_old: &sys_key_value_old
               x-modules:
-                - path: sys/key_value.js
-                  options:
-                    backend: table3
+                - path: sys/key_value_old.js
             /key_rev_value:
               x-modules:
                 - path: sys/key_rev_value.js

--- a/sys/key_value.js
+++ b/sys/key_value.js
@@ -11,7 +11,7 @@ const stringify = require('json-stable-stringify');
 const HTTPError = HyperSwitch.HTTPError;
 const URI = HyperSwitch.URI;
 
-const spec = HyperSwitch.utils.loadSpec(`${__dirname}/key_value_old.yaml`);
+const spec = HyperSwitch.utils.loadSpec(`${__dirname}/key_value.yaml`);
 
 // Format a revision response. Shared between different ways to retrieve a
 // revision (latest & with explicit revision).

--- a/sys/key_value.yaml
+++ b/sys/key_value.yaml
@@ -8,12 +8,12 @@ paths:
     put:
       operationId: createBucket
 
-  /{bucket}/{key}/:
-    get:
-      operationId: listRevisions
-
   /{bucket}/{key}:
     get:
       operationId: getRevision
     put:
       operationId: putRevision
+
+  /{bucket}/{key}/:
+    get:
+      operationId: listRevisions

--- a/sys/key_value_old.js
+++ b/sys/key_value_old.js
@@ -20,7 +20,8 @@ function returnRevision(req) {
         if (dbResult.body && dbResult.body.items && dbResult.body.items.length) {
             const row = dbResult.body.items[0];
             let headers = {
-                etag: row.headers.etag || mwUtil.makeETag('0', row.tid)
+                etag: row.headers.etag || mwUtil.makeETag('0', row.tid),
+                'content-type': row['content-type']
             };
             if (row.headers) {
                 headers = Object.assign(headers, row.headers);
@@ -44,12 +45,17 @@ function returnRevision(req) {
 }
 
 class KVBucket {
+    constructor(options) {
+        this._options = options || {};
+        this._options.backend = this._options.backend || 'table';
+    }
+
     createBucket(hyper, req) {
         const schema = this.makeSchema(req.body || {});
         schema.table = req.params.bucket;
         const rp = req.params;
         const storeRequest = {
-            uri: new URI([rp.domain, 'sys', 'table3', rp.bucket]),
+            uri: new URI([rp.domain, 'sys', this._options.backend, rp.bucket]),
             body: schema
         };
         return hyper.put(storeRequest);
@@ -74,14 +80,26 @@ class KVBucket {
                     pattern: 'timeseries'
                 },
             },
+            revisionRetentionPolicy: opts.retention_policy || {
+                type: 'latest',
+                count: 1,
+                grace_ttl: 86400
+            },
             attributes: {
                 key: opts.keyType || 'string',
                 tid: 'timeuuid',
-                headers: 'json',
-                value: opts.valueType || 'blob'
+                latestTid: 'timeuuid',
+                value: opts.valueType || 'blob',
+                'content-type': 'string',
+                'content-sha256': 'blob',
+                // Redirect
+                'content-location': 'string',
+                tags: 'set<string>',
+                headers: 'json'
             },
             index: [
-                { attribute: 'key', type: 'hash' }
+                { attribute: 'key', type: 'hash' },
+                { attribute: 'tid', type: 'range', order: 'desc' }
             ]
         };
     }
@@ -94,7 +112,7 @@ class KVBucket {
 
         const rp = req.params;
         const storeReq = {
-            uri: new URI([rp.domain, 'sys', 'table3', rp.bucket, '']),
+            uri: new URI([rp.domain, 'sys', this._options.backend, rp.bucket, '']),
             body: {
                 table: rp.bucket,
                 attributes: {
@@ -103,6 +121,9 @@ class KVBucket {
                 limit: 1
             }
         };
+        if (rp.tid) {
+            storeReq.body.attributes.tid = mwUtil.coerceTid(rp.tid, 'key_value_old');
+        }
         return hyper.get(storeReq).then(returnRevision(req));
     }
 
@@ -110,7 +131,7 @@ class KVBucket {
     listRevisions(hyper, req) {
         const rp = req.params;
         const storeRequest = {
-            uri: new URI([rp.domain, 'sys', 'table3', rp.bucket, '']),
+            uri: new URI([rp.domain, 'sys', this._options.backend, rp.bucket, '']),
             body: {
                 table: req.params.bucket,
                 attributes: {
@@ -123,9 +144,11 @@ class KVBucket {
         return hyper.get(storeRequest)
         .then(res => ({
             status: 200,
+
             headers: {
                 'content-type': 'application/json'
             },
+
             body: {
                 items: res.body.items.map(row => row.tid)
             }
@@ -134,6 +157,7 @@ class KVBucket {
 
 
     putRevision(hyper, req) {
+        // TODO: support other formats! See cassandra backend getRevision impl.
         const rp = req.params;
         let tid = rp.tid && mwUtil.coerceTid(rp.tid, 'key_value_old');
 
@@ -143,7 +167,7 @@ class KVBucket {
         }
 
         const doPut = () => hyper.put({
-            uri: new URI([rp.domain, 'sys', 'table3', rp.bucket, '']),
+            uri: new URI([rp.domain, 'sys', this._options.backend, rp.bucket, '']),
             body: {
                 table: rp.bucket,
                 attributes: {
@@ -151,6 +175,8 @@ class KVBucket {
                     tid,
                     value: req.body,
                     headers: req.headers,
+                    'content-type': req.headers && req.headers['content-type']
+                    // TODO: include other data!
                 }
             }
         })
@@ -178,7 +204,7 @@ class KVBucket {
         if (req.headers['if-none-hash-match']) {
             delete req.headers['if-none-hash-match'];
             return hyper.get({
-                uri: new URI([rp.domain, 'sys', 'key_value', rp.bucket, rp.key])
+                uri: new URI([rp.domain, 'sys', 'key_value_old', rp.bucket, rp.key])
             })
             .then((oldContent) => {
                 if (stringify(req.body) === stringify(oldContent.body) &&

--- a/sys/key_value_old.yaml
+++ b/sys/key_value_old.yaml
@@ -12,7 +12,7 @@ paths:
     get:
       operationId: listRevisions
 
-  /{bucket}/{key}:
+  /{bucket}/{key}{/tid}:
     get:
       operationId: getRevision
     put:

--- a/sys/mathoid.js
+++ b/sys/mathoid.js
@@ -30,16 +30,16 @@ class MathoidService {
             }
             // check the post storage
             return hyper.get({
-                uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.check', hash])
+                uri: new URI([rp.domain, 'sys', 'key_value_old', 'mathoid.check', hash])
             }).catch({ status: 404 }, () => // let's try to find an indirection
                 hyper.get({
-                    uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.hash_table', hash])
+                    uri: new URI([rp.domain, 'sys', 'key_value_old', 'mathoid.hash_table', hash])
                 }).then((hashRes) => {
                     // we have a normalised version of the formula
                     hash = hashRes.body;
                     // grab that version from storage
                     return hyper.get({
-                        uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.check', hash])
+                        uri: new URI([rp.domain, 'sys', 'key_value_old', 'mathoid.check', hash])
                     });
                 }));
         }).catch({ status: 404 }, () => // if we are here, it means this is a new input formula
@@ -68,7 +68,7 @@ class MathoidService {
             // add the indirection to the hash table if the hashes don't match
             if (hash !== origHash) {
                 indirectionP = hyper.put({
-                    uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.hash_table',
+                    uri: new URI([rp.domain, 'sys', 'key_value_old', 'mathoid.hash_table',
                         origHash]),
                     headers: { 'content-type': 'text/plain' },
                     body: hash
@@ -82,7 +82,7 @@ class MathoidService {
             };
             return P.join(
                 hyper.put({
-                    uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.check', hash]),
+                    uri: new URI([rp.domain, 'sys', 'key_value_old', 'mathoid.check', hash]),
                     headers: checkRes.headers,
                     body: checkRes.body
                 }),
@@ -115,7 +115,7 @@ class MathoidService {
             }
             // construct the request object that will be emitted
             const reqObj = {
-                uri: new URI([domain, 'sys', 'key_value', `mathoid.${format}`, hash]),
+                uri: new URI([domain, 'sys', 'key_value_old', `mathoid.${format}`, hash]),
                 headers: Object.assign(
                     completeBody[format].headers, { 'x-resource-location': hash }),
                 body: completeBody[format].body
@@ -190,7 +190,7 @@ class MathoidService {
             return res;
         }).catch({ status: 404 }, () => // let's try to find an indirection
             hyper.get({
-                uri: new URI([rp.domain, 'sys', 'key_value', 'mathoid.hash_table', hash])
+                uri: new URI([rp.domain, 'sys', 'key_value_old', 'mathoid.hash_table', hash])
             }).then((hashRes) => {
                 // we have a normalised version of the formula
                 hash = hashRes.body;
@@ -238,10 +238,10 @@ module.exports = (options) => {
             {
                 uri: '/{domain}/sys/post_data/mathoid.input'
             }, {
-                uri: '/{domain}/sys/key_value/mathoid.hash_table',
+                uri: '/{domain}/sys/key_value_old/mathoid.hash_table',
                 body: { valueType: 'string' }
             }, {
-                uri: '/{domain}/sys/key_value/mathoid.check',
+                uri: '/{domain}/sys/key_value_old/mathoid.check',
                 body: { valueType: 'json' }
             }
         ]

--- a/sys/post_data.js
+++ b/sys/post_data.js
@@ -28,7 +28,7 @@ class PostDataBucket {
             body: key
         }))
         .catch({ status: 404 }, () => hyper.put({
-            uri: new URI([rp.domain, 'sys', 'key_value', rp.bucket, key]),
+            uri: new URI([rp.domain, 'sys', 'key_value_old', rp.bucket, key]),
             headers: {
                 'content-type': 'application/json',
             },
@@ -56,7 +56,7 @@ class PostDataBucket {
     createBucket(hyper, req) {
         const rp = req.params;
         return hyper.put({
-            uri: new URI([rp.domain, 'sys', 'key_value', rp.bucket]),
+            uri: new URI([rp.domain, 'sys', 'key_value_old', rp.bucket]),
             body: {
                 keyType: 'string',
                 valueType: 'json'
@@ -66,7 +66,7 @@ class PostDataBucket {
 
     getRevision(hyper, req) {
         const rp = req.params;
-        const path = [rp.domain, 'sys', 'key_value', rp.bucket, rp.key];
+        const path = [rp.domain, 'sys', 'key_value_old', rp.bucket, rp.key];
         if (rp.tid) {
             path.push(rp.tid);
         }

--- a/test/features/buckets/key_value_bucket.js
+++ b/test/features/buckets/key_value_bucket.js
@@ -170,5 +170,5 @@ describe('Key value buckets', function() {
         });
     }
 
-    parallel('key_value', function() { runTests('key_value') });
+    parallel('key_value', function() { runTests('key_value_old') });
 });

--- a/test/test_module.yaml
+++ b/test/test_module.yaml
@@ -14,12 +14,12 @@ paths:
               get:
                 x-setup-handler:
                   - init_storage:
-                      uri: /{domain}/sys/key_value/testservice.test
+                      uri: /{domain}/sys/key_value_old/testservice.test
 
                 x-request-handler:
                   - get_from_storage:
                       request:
-                        uri: /{domain}/sys/key_value/testservice.test/{title}
+                        uri: /{domain}/sys/key_value_old/testservice.test/{title}
                         headers:
                           'cache-control': '{{cache-control}}'
                       catch:
@@ -33,7 +33,7 @@ paths:
                   - store:
                       request:
                         method: put
-                        uri: /{domain}/sys/key_value/testservice.test/{title}
+                        uri: /{domain}/sys/key_value_old/testservice.test/{title}
                         headers: '{{get_from_api.headers}}'
                         body: '{{get_from_api.body}}'
                   - return_response:
@@ -119,9 +119,9 @@ paths:
             /buckets/key_rev_latest_value:
               x-modules:
                 - path: sys/key_rev_latest_value.js
-            /buckets/key_value:
+            /buckets/key_value_old:
               x-modules:
-                - path: sys/key_value.js
+                - path: sys/key_value_old.js
 
             /events_no_config:
               x-modules:

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -85,7 +85,7 @@ paths:
         # Set up a simple key-value bucket.
         - init:
             method: 'put'
-            uri: /{domain}/sys/key_value/term.definition
+            uri: /{domain}/sys/key_value_old/term.definition
             body:
               valueType: 'json'
 
@@ -95,7 +95,7 @@ paths:
               method: get
               headers:
                 cache-control: '{{cache-control}}'
-              uri: /{domain}/sys/key_value/term.definition/{request.params.term}
+              uri: /{domain}/sys/key_value_old/term.definition/{request.params.term}
             catch:
               status: 404
             return_if:
@@ -122,7 +122,7 @@ paths:
         - store:
             request:
               method: put
-              uri: /{domain}/sys/key_value/term.definition/{request.params.term}
+              uri: /{domain}/sys/key_value_old/term.definition/{request.params.term}
               headers: '{{merge({"if-none-hash-match": "*"}, extract.headers)}}'
               body: '{{extract.body}}'
             # With the if-none-hash-match header the storage will return 412

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -154,17 +154,17 @@ paths:
       x-monitor: false
       x-setup-handler:
         - init_svg:
-            uri: /wikimedia.org/sys/key_value/mathoid.svg
+            uri: /wikimedia.org/sys/key_value_old/mathoid.svg
             body:
               keyType: string
               valueType: string
         - init_mml:
-            uri: /wikimedia.org/sys/key_value/mathoid.mml
+            uri: /wikimedia.org/sys/key_value_old/mathoid.mml
             body:
               keyType: string
               valueType: string
         - init_png:
-            uri: /wikimedia.org/sys/key_value/mathoid.png
+            uri: /wikimedia.org/sys/key_value_old/mathoid.png
             body:
               keyType: string
               valueType: blob
@@ -172,7 +172,7 @@ paths:
         - check_storage:
             request:
               method: get
-              uri: /wikimedia.org/sys/key_value/mathoid.{$.request.params.format}/{$.request.params.hash}
+              uri: /wikimedia.org/sys/key_value_old/mathoid.{$.request.params.format}/{$.request.params.hash}
               headers:
                 cache-control: '{{ cache-control }}'
             catch:

--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -84,7 +84,7 @@ paths:
         # Set up a simple key-value bucket.
         - init:
             method: 'put'
-            uri: /{domain}/sys/key_value/summary
+            uri: /{domain}/sys/key_value_old/summary
             body:
               valueType: 'json'
 
@@ -94,7 +94,7 @@ paths:
               method: get
               headers:
                 cache-control: '{{cache-control}}'
-              uri: /{domain}/sys/key_value/summary/{request.params.title}
+              uri: /{domain}/sys/key_value_old/summary/{request.params.title}
             catch:
               status: 404
             return_if:
@@ -145,7 +145,7 @@ paths:
         - store_and_return:
             request:
               method: put
-              uri: /{domain}/sys/key_value/summary/{request.params.title}
+              uri: /{domain}/sys/key_value_old/summary/{request.params.title}
               headers: '{{merge({"if-none-hash-match": "*"}, extract.headers)}}'
               body: '{{extract.body}}'
             # With the if-none-hash-match header the storage will return 412


### PR DESCRIPTION
1. Rename `key_value` to `key_value_old` and use it everywhere
2. Adapt the `key_value` to the new storage - remove unused columns and make a `tid` a normal column, not a part of a primary key
3. Create new buckets for the new feeds.

cc @wikimedia/services 