### PR TITLE
metrics: Update doc for timestamp format

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -81,12 +81,12 @@ paths:
           required: true
         - name: start
           in: path
-          description: The date of the first day to include, in YYYYMMDD format
+          description: The date of the first day to include, in YYYYMMDD or YYYYMMDDHH format
           type: string
           required: true
         - name: end
           in: path
-          description: The date of the last day to include, in YYYYMMDD format
+          description: The date of the last day to include, in YYYYMMDD or YYYYMMDDHH format
           type: string
           required: true
       responses:


### PR DESCRIPTION
The parameters "start" and "end" also accept the format YYMMDDHH.
See https://phabricator.wikimedia.org/T177671