### PR TITLE
Add Reading List Service

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -409,7 +409,7 @@ mwUtil.hydrateResponse = (response, fetch) => {
             for (let i = node.length - 1; i >= 0; i--) {
                 _traverse(node[i], () => node.splice(i, 1));
             }
-        } else if (typeof node === 'object') {
+        } else if (node && typeof node === 'object') {
             if (Array.isArray(node.$merge)) {
                 node.$merge.forEach(requestResource);
             } else {

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -253,8 +253,14 @@ mwUtil.decodeBody = (contentResponse) => {
     });
 };
 
-mwUtil.getSiteInfo = (hyper, req) => hyper.get({
-    uri: new URI([req.params.domain, 'sys', 'action', 'siteinfo'])
+/**
+ *
+ * @param {!HyperSwitch} hyper
+ * @param {!Object} req
+ * @param {?String} domain Wiki domain to get siteinfo from (defaults to the request domain).
+ */
+mwUtil.getSiteInfo = (hyper, req, domain) => hyper.get({
+    uri: new URI([domain || req.params.domain, 'sys', 'action', 'siteinfo'])
 }).get('body');
 
 mwUtil.getQueryString = (req) => {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "service-runner": "^2.3.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "content-type": "git+https://github.com/wikimedia/content-type#master",
-    "hyperswitch": "^0.9.1",
+    "hyperswitch": "^0.9.3",
     "jsonwebtoken": "^7.4.1",
     "mediawiki-title": "^0.6.3",
     "entities": "^1.1.1"

--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -37,6 +37,8 @@ paths:
               x-modules:
                 - path: v1/citoid.js
                   options: '{{options.citoid}}'
+                - path: v1/lists.js
+                  options: '{{options.lists}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -101,6 +101,8 @@ paths:
               x-modules:
                 - path: v1/citoid.js
                   options: '{{options.citoid}}'
+                - path: v1/lists.js
+                  options: '{{options.lists}}'
                 - path: v1/recommend.yaml
                   options: '{{options.recommendation}}'
         options: '{{options}}'

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -103,6 +103,8 @@ paths:
               x-modules:
                 - path: v1/citoid.js
                   options: '{{options.citoid}}'
+                - path: v1/lists.js
+                  options: '{{options.lists}}'
                 - path: v1/recommend.yaml
                   options: '{{options.recommendation}}'
         options: '{{options}}'

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -78,6 +78,10 @@ paths:
               x-modules:
                 - path: v1/mathoid.yaml
                   options: '{{options.mathoid}}'
+            /data:
+              x-modules:
+                - path: v1/lists.js
+                  options: '{{options.lists}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -92,6 +92,8 @@ paths:
               x-modules:
                 - path: v1/citoid.js
                   options: '{{options.citoid}}'
+                - path: v1/lists.js
+                  options: '{{options.lists}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/test/features/pagecontent/revisions.js
+++ b/test/features/pagecontent/revisions.js
@@ -181,7 +181,7 @@ describe('revision requests with test2.wikipedia.org', function() {
         revOk: 51098,
         revRedirect: 157490,
         pageName: 'User:Pchelolo%2fDate',
-        pageLastRev: 157487
+        pageLastRev: 329034
     });
 });
 

--- a/v1/lists.js
+++ b/v1/lists.js
@@ -1,57 +1,128 @@
 'use strict';
 
+const P = require('bluebird');
+const mwUtil = require('../lib/mwUtil');
 const HyperSwitch = require('hyperswitch');
+const URI = HyperSwitch.URI;
 const spec = HyperSwitch.utils.loadSpec(`${__dirname}/lists.yaml`);
 
-module.exports = options => ({
-    spec,
-    globals: {
-        options,
-        /**
-         * Transform the continuation data into a string so it is easier for clients to deal with.
-         * @param {!Object|undefined} continuation Continuation object returned by the
-         *   MediaWiki API.
-         * @return {!String|undefined} Continuation string.
-         */
-        flattenContinuation(continuation) {
-            return JSON.stringify(continuation);
-        },
-        /**
-         * Inverse of flattenContinuation.
-         * @param {!String|undefined} continuation Continuation string
-         *   returned by flattenContinuation().
-         * @return {!Object} Continuation object.
-         */
-        unflattenContinuation(continuation) {
-            const sanitizedContinuation = {};
-            if ( typeof continuation === 'string' ) {
-                try {
-                    continuation = JSON.parse(continuation);
-                } catch (e) {
-                    this.options.log('error/unflatten', {
-                        msg: e.stack,
-                        json: continuation,
-                    });
-                    throw e;
-                }
-                // Make sure nothing malicious can be done by splicing the continuation data
-                // into the API parameters.
-                const allowedKeys = ['continue', 'rlcontinue', 'rlecontinue'];
-                for (let key of allowedKeys) {
-                    if (typeof continuation[key] !== 'object') {
-                        sanitizedContinuation[key] = continuation[key];
-                    }
+class ReadingLists {
+    /**
+     * Transform the continuation data into a string so it is easier for clients to deal with.
+     * @param {!Object|undefined} continuation Continuation object returned by the MediaWiki API.
+     * @return {!String|undefined} Continuation string.
+     */
+    flattenContinuation(continuation) {
+        return JSON.stringify(continuation);
+    }
+
+    /**
+     * Inverse of flattenContinuation.
+     * @param {!String|undefined} continuation Continuation string returned by flattenContinuation()
+     * @return {!Object} Continuation object.
+     */
+    unflattenContinuation(continuation) {
+        const sanitizedContinuation = {};
+        if (typeof continuation === 'string') {
+            try {
+                continuation = JSON.parse(continuation);
+            } catch (e) {
+                this.options.log('error/unflatten', {
+                    msg: e.message,
+                    json: continuation,
+                });
+                throw e;
+            }
+            // Make sure nothing malicious can be done by splicing the continuation data
+            // into the API parameters.
+            const allowedKeys = ['continue', 'rlcontinue', 'rlecontinue'];
+            for (const key of allowedKeys) {
+                if (typeof continuation[key] !== 'object') {
+                    sanitizedContinuation[key] = continuation[key];
                 }
             }
-            return sanitizedContinuation;
+        }
+        return sanitizedContinuation;
+    }
+
+    /**
+     * Convert an array of values into the format expected by the MediaWiki API.
+     * @param {!Array} list A list containing strings and numbers.
+     * @return {!String}
+     */
+    flattenMultivalue(list) {
+        return list.join('|');
+    }
+
+    /**
+     * Handle the /list/{id}/entries endpoint (get entries of a list).
+     * @param {!HyperSwitch} hyper
+     * @param {!Object} req The request object as provided by HyperSwitch.
+     * @return {!Promise<Object>} A response promise.
+     */
+    getListEntries(hyper, req) {
+        return hyper.post({
+            uri: new URI([req.params.domain, 'sys', 'action', 'rawquery']),
+            body: {
+                action: 'query',
+                list: 'readinglistentries',
+                rlelists: req.params.id,
+                rlelimit: 'max',
+                continue: this.unflattenContinuation(req.query.next).continue,
+                rlecontinue: this.unflattenContinuation(req.query.next).rlecontinue,
+            },
+        })
+        .then((res) => {
+            const entries = res.body.query.readinglistentries;
+            const next = this.flattenContinuation(res.body.continue);
+
+            return this.hydrateSummaries({
+                status: 200,
+                headers: {
+                    'content-type': 'application/json; charset=utf-8;'
+                        + 'profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"',
+                    'cache-control': 'no-cache',
+                },
+                body: {
+                    entries,
+                    next,
+                }
+            }, hyper, req);
+        });
+    }
+
+    /**
+     * Add data from the summary endpoint to an array of list entries.
+     * @param {!Object} res Response object.
+     * @param {!HyperSwitch} hyper
+     * @param {!Object} req The request object as provided by HyperSwitch.
+     * @return {!Promise<Array>} The objects, enriched with summaries.
+     */
+    hydrateSummaries(res, hyper, req) {
+        return P.map(res.body.entries, (entry) => {
+            return mwUtil.getSiteInfo(hyper, req, entry.project).then((siteinfo) => {
+                entry.$merge = [
+                    `${siteinfo.baseUri}/page/summary/${encodeURIComponent(entry.title)}`,
+                ];
+            }).catch(() => {});
+        })
+        .then(() => mwUtil.hydrateResponse(res, uri => mwUtil.fetchSummary(hyper, uri)));
+    }
+}
+
+module.exports = (options) => {
+    const rl = new ReadingLists(options);
+
+    return {
+        spec,
+        globals: {
+            options,
+            flattenContinuation: rl.flattenContinuation.bind(rl),
+            unflattenContinuation: rl.unflattenContinuation.bind(rl),
+            flattenMultivalue: rl.flattenMultivalue.bind(rl),
         },
-        /**
-         * Convert an array of values into the format expected by the MediaWiki API.
-         * @param {!Array} list A list containing strings and numbers.
-         * @return {!String}
-         */
-        flattenMultivalue(list) {
-            return list.join('|');
+        operations: {
+            getListEntries: rl.getListEntries.bind(rl),
         },
-    },
-});
+    };
+};

--- a/v1/lists.js
+++ b/v1/lists.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const HyperSwitch = require('hyperswitch');
+const spec = HyperSwitch.utils.loadSpec(`${__dirname}/lists.yaml`);
+
+module.exports = options => ({
+    spec,
+    globals: {
+        options,
+        /**
+         * Transform the continuation data into a string so it is easier for clients to deal with.
+         * @param {!Object|undefined} continuation Continuation object returned by the
+         *   MediaWiki API.
+         * @return {!String|undefined} Continuation string.
+         */
+        flattenContinuation(continuation) {
+            return JSON.stringify(continuation);
+        },
+        /**
+         * Inverse of flattenContinuation.
+         * @param {!String|undefined} continuation Continuation string
+         *   returned by flattenContinuation().
+         * @return {!Object} Continuation object.
+         */
+        unflattenContinuation(continuation) {
+            const sanitizedContinuation = {};
+            if ( typeof continuation === 'string' ) {
+                try {
+                    continuation = JSON.parse(continuation);
+                } catch (e) {
+                    this.options.log('error/unflatten', {
+                        msg: e.stack,
+                        json: continuation,
+                    });
+                    throw e;
+                }
+                // Make sure nothing malicious can be done by splicing the continuation data
+                // into the API parameters.
+                const allowedKeys = ['continue', 'rlcontinue', 'rlecontinue'];
+                for (let key of allowedKeys) {
+                    if (typeof continuation[key] !== 'object') {
+                        sanitizedContinuation[key] = continuation[key];
+                    }
+                }
+            }
+            return sanitizedContinuation;
+        },
+        /**
+         * Convert an array of values into the format expected by the MediaWiki API.
+         * @param {!Array} list A list containing strings and numbers.
+         * @return {!String}
+         */
+        flattenMultivalue(list) {
+            return list.join('|');
+        },
+    },
+});

--- a/v1/lists.yaml
+++ b/v1/lists.yaml
@@ -16,6 +16,9 @@ info:
     deletedRetentionDays: &deletedRetentionDays 30
 x-yaml-anchors:
   csrf_token: &csrf_token
+    name: csrf_token
+    in: query
+    required: true
     type: string
     description: "The CRSF edit token provided by the MediaWiki API"
     example: "f63c343876da566045e6b59c4532450559c828d3+\\"
@@ -84,7 +87,6 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
       x-monitor: false
   /lists/teardown:
     post:
@@ -122,7 +124,6 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
       x-monitor: false
   /lists/:
     get:
@@ -177,14 +178,14 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
-                cache-control: "no-cache"
+                cache-control: "max-age=0, s-maxage=0"
               body:
                 lists: '{{forward_to_mw.body.query.readinglists}}'
                 next: '{{flattenContinuation(forward_to_mw.body.continue)}}'
     post:
       tags:
         - Reading lists
-      summary: Create a new lists for the current user.
+      summary: Create a new list for the current user.
       description: |
         Creates a new empty list.
 
@@ -239,7 +240,6 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
               body:
                 id: '{{forward_to_mw.body.create.id}}'
       x-monitor: false
@@ -293,7 +293,6 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
       x-monitor: false
     delete:
       tags:
@@ -335,7 +334,6 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
       x-monitor: false
   /lists/{id}/entries/:
     get:
@@ -380,28 +378,9 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/problem'
+      operationId: getListEntries
       x-route-filters:
         - path: ./lib/mediawiki_auth_filter.js
-      x-request-handler:
-        - forward_to_mw:
-            request:
-              uri: /{domain}/sys/action/rawquery
-              body:
-                action: query
-                list: readinglistentries
-                rlelists: '{{request.params.id}}'
-                rlelimit: max
-                # FIXME there should be a nicer way to do this
-                continue: '{{unflattenContinuation(request.query.next).continue}}'
-                rlecontinue: '{{unflattenContinuation(request.query.next).rlecontinue}}'
-            return:
-              status: 200
-              headers:
-                content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
-                cache-control: "no-cache"
-              body:
-                entries: '{{forward_to_mw.body.query.readinglistentries}}'
-                next: '{{flattenContinuation(forward_to_mw.body.continue)}}'
     post:
       tags:
         - Reading lists
@@ -464,7 +443,6 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
               body:
                 id: '{{forward_to_mw.body.createentry.id}}'
       x-monitor: false
@@ -516,7 +494,6 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
       x-monitor: false
   /lists/order:
     get:
@@ -559,7 +536,7 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
+                cache-control: "max-age=0, s-maxage=0"
               body:
                 # TODO verify this is the right array item
                 list_ids: '{{forward_to_mw.body.query.readinglistorder[0].order}}'
@@ -610,7 +587,6 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
       x-monitor: false
   /lists/{id}/order:
     get:
@@ -659,7 +635,7 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
+                cache-control: "max-age=0, s-maxage=0"
               body:
                 # TODO verify this is the right array item
                 lists: '{{forward_to_mw.body.query.readinglistorder[0].order}}'
@@ -715,7 +691,6 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8
-                cache-control: "no-cache"
       x-monitor: false
   /lists/pages/{project}/{title}:
     get:
@@ -778,7 +753,7 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
-                cache-control: "no-cache"
+                cache-control: "max-age=0, s-maxage=0"
               body:
                 lists: '{{forward_to_mw.body.query.readinglists}}'
                 next: '{{flattenContinuation(forward_to_mw.body.continue)}}'
@@ -847,7 +822,7 @@ paths:
               status: 200
               headers:
                 content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
-                cache-control: "no-cache"
+                cache-control: "max-age=0, s-maxage=0"
               body:
                 lists: '{{forward_to_mw.body.query.readinglists}}'
                 entries: '{{forward_to_mw.body.query.readinglistentries}}'

--- a/v1/lists.yaml
+++ b/v1/lists.yaml
@@ -1,0 +1,928 @@
+swagger: '2.0'
+info:
+  version: '0.1'
+  title: MediaWiki Reading Lists API
+  description: API for manipulating private [reading lists](https://www.mediawiki.org/wiki/Reading/Reading_Lists)
+  termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
+  contact:
+    name: Reading Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+  license:
+    name: Apache licence, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+  x-configuration:
+    maxListsPerUser: &maxListsPerUser 100
+    maxEntriesPerList: &maxEntriesPerList 1000
+    deletedRetentionDays: &deletedRetentionDays 30
+x-yaml-anchors:
+  csrf_token: &csrf_token
+    type: string
+    description: "The CRSF edit token provided by the MediaWiki API"
+    example: "f63c343876da566045e6b59c4532450559c828d3+\\"
+  list_common: &list_common
+    name:
+      type: string
+      example: "Planets"
+    description:
+      type: string
+      example: "Planets of the Solar System"
+    color:
+      type: string
+      description: "A CSS3 color name"
+      example: "blue"
+    image:
+      type: string
+      description: "A Wikimedia Commons image name"
+      example: "Solar_system.jpg"
+    icon:
+      type: string
+      description: "(semantics TBD)"
+      example: "planet"
+  list_entry_common: &list_entry_common
+    project: &list_entry_common_project
+      type: string
+      description: 'Domain of the wiki containing the page.'
+      example: 'en.wikipedia.org'
+    title: &list_entry_common_title
+      type: string
+      description: 'Title of the page containing the page, in database format.'
+      example: 'Barack_Obama'
+paths:
+  /lists/setup:
+    post:
+      tags:
+        - Reading lists
+      summary: Opt in to use reading lists.
+      description: |
+        Must precede other list operations.
+
+        Request must be authenticated with a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json; charset=utf-8
+      parameters:
+        - <<: *csrf_token
+      responses:
+        '200':
+          description: Success.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: readinglists
+                command: setup
+                token: '{{request.query.csrf_token}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+      x-monitor: false
+  /lists/teardown:
+    post:
+      tags:
+        - Reading lists
+      summary: Opt out from using reading lists.
+      description: |
+        Deletes all data. User needs to opt in again before being able to do anything.
+
+        Request must be authenticated with a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json; charset=utf-8
+      parameters:
+        - <<: *csrf_token
+      responses:
+        '200':
+          description: Success.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: readinglists
+                command: teardown
+                token: '{{request.query.csrf_token}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+      x-monitor: false
+  /lists/:
+    get:
+      tags:
+        - Reading lists
+      summary: Get all lists of the current user.
+      description: |
+        Returns metadata describing the lists of the current user. Might be truncated and include
+        a continuation token.
+
+        Request must be authenticated with a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      parameters:
+        - name: next
+          in: query
+          description: Continuation parameter from previous request
+          type: string
+          required: false
+      produces:
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
+      responses:
+        '200':
+          description: An array of list metadata.
+          schema:
+            type: object
+            properties:
+              lists:
+                type: array
+                items:
+                  $ref: '#/definitions/list_read'
+              next:
+                type: string
+                description: Continuation token.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: query
+                meta: readinglists
+                rllimit: max
+                continue: '{{unflattenContinuation(request.query.next).continue}}'
+                rlcontinue: '{{unflattenContinuation(request.query.next).rlcontinue}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
+                cache-control: "no-cache"
+              body:
+                lists: '{{forward_to_mw.body.query.readinglists}}'
+                next: '{{flattenContinuation(forward_to_mw.body.continue)}}'
+    post:
+      tags:
+        - Reading lists
+      summary: Create a new lists for the current user.
+      description: |
+        Creates a new empty list.
+
+        Request must be authenticated with a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json; charset=utf-8
+      parameters:
+        - name: list
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/list_write'
+        - <<: *csrf_token
+      responses:
+        '200':
+          description: The ID of the new list.
+          schema:
+            type: object
+            title: response
+            properties:
+              create:
+                type: object
+                title: result
+                properties:
+                  id:
+                    type: integer
+                    description: List ID
+                    example: 7
+                    required: true
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: readinglists
+                command: create
+                name: '{{request.body.name}}'
+                description: '{{request.body.description}}'
+                color: '{{request.body.color}}'
+                image: '{{request.body.image}}'
+                icon: '{{request.body.icon}}'
+                token: '{{request.query.csrf_token}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+              body:
+                id: '{{forward_to_mw.body.create.id}}'
+      x-monitor: false
+  /lists/{id}:
+    put:
+      tags:
+        - Reading lists
+      summary: Update a list.
+      description: |
+        List must belong to current user and request must be authenticated with
+        a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      parameters:
+        - name: id
+          in: path
+          type: integer
+          example: 42
+          required: true
+        - name: list
+          in: body
+          schema:
+            $ref: '#/definitions/list_write'
+        - <<: *csrf_token
+      produces:
+        - application/json; charset=utf-8
+      responses:
+        '200':
+          description: Success.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: readinglists
+                command: update
+                list: '{{request.params.id}}'
+                name: '{{request.body.name}}'
+                description: '{{request.body.description}}'
+                color: '{{request.body.color}}'
+                image: '{{request.body.image}}'
+                icon: '{{request.body.icon}}'
+                token: '{{request.query.csrf_token}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+      x-monitor: false
+    delete:
+      tags:
+        - Reading lists
+      summary: Delete a list.
+      description: |
+        List must belong to current user and request must be authenticated with
+        a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json; charset=utf-8
+      parameters:
+        - name: id
+          in: path
+          type: integer
+          example: 42
+          required: true
+        - <<: *csrf_token
+      responses:
+        '200':
+          description: Success.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: readinglists
+                command: delete
+                list: '{{request.params.id}}'
+                token: '{{request.query.csrf_token}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+      x-monitor: false
+  /lists/{id}/entries/:
+    get:
+      tags:
+        - Reading lists
+      summary: Get all entries of a given list.
+      description: |
+        Returns pages contained by the given list. Might be truncated and include
+        a continuation token.
+
+        List must belong to current user and request must be authenticated with
+        a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      parameters:
+        - name: id
+          in: path
+          type: integer
+          example: 42
+          required: true
+        - name: next
+          in: query
+          description: Continuation parameter from previous request
+          type: string
+          required: false
+      produces:
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
+      responses:
+        '200':
+          description: An array of list entries.
+          schema:
+            type: object
+            properties:
+              entries:
+                type: array
+                items:
+                  $ref: '#/definitions/list_entry_read'
+              next:
+                type: string
+                description: Continuation token.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: query
+                list: readinglistentries
+                rlelists: '{{request.params.id}}'
+                rlelimit: max
+                # FIXME there should be a nicer way to do this
+                continue: '{{unflattenContinuation(request.query.next).continue}}'
+                rlecontinue: '{{unflattenContinuation(request.query.next).rlecontinue}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
+                cache-control: "no-cache"
+              body:
+                entries: '{{forward_to_mw.body.query.readinglistentries}}'
+                next: '{{flattenContinuation(forward_to_mw.body.continue)}}'
+    post:
+      tags:
+        - Reading lists
+      summary: Create a new list entry.
+      description: |
+        Creates a new list entry in the given list.
+
+        The list must belong to the current user and the request must be
+        authenticated with a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json; charset=utf-8
+      parameters:
+        - name: id
+          in: path
+          type: integer
+          example: 42
+          required: true
+        - name: list_entry
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/list_entry_write'
+        - <<: *csrf_token
+      responses:
+        '200':
+          description: The id of the new list entry.
+          schema:
+            type: object
+            title: response
+            properties:
+              createentry:
+                type: object
+                title: result
+                properties:
+                  id:
+                    type: integer
+                    description: List entry ID
+                    example: 13
+                    required: true
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: readinglists
+                command: createentry
+                list: '{{request.params.id}}'
+                project: '{{request.body.project}}'
+                title: '{{request.body.title}}'
+                token: '{{request.query.csrf_token}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+              body:
+                id: '{{forward_to_mw.body.createentry.id}}'
+      x-monitor: false
+  /lists/{id}/entries/{entry_id}:
+    delete:
+      tags:
+        - Reading lists
+      summary: Delete a list entry.
+      description: |
+        Deletes a given list entry.
+
+        The list must belong to the current user and the request must be
+        authenticated with a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      parameters:
+        - name: id
+          in: path
+          type: integer
+          example: 42
+          required: true
+        - name: entry_id
+          in: path
+          type: integer
+          example: 64
+          required: true
+        - <<: *csrf_token
+      produces:
+        - application/json; charset=utf-8
+      responses:
+        '200':
+          description: Success.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: readinglists
+                command: deleteentry
+                entry: '{{request.params.entry_id}}'
+                token: '{{request.query.csrf_token}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+      x-monitor: false
+  /lists/order:
+    get:
+      tags:
+        - Reading lists
+      summary: Get the order of the lists of the current user.
+      description: |
+        Returns list IDs in the user-defined order.
+
+        Request must be authenticated with a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json; charset=utf-8
+      responses:
+        '200':
+          description: An array of list IDs.
+          schema:
+            type: array
+            title: list_ids
+            example: [3, 4, 2, 1, 6, 5]
+            uniqueItems: true
+            items:
+              type: integer
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: query
+                meta: readinglistorder
+                rlolistorder: 1
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+              body:
+                # TODO verify this is the right array item
+                list_ids: '{{forward_to_mw.body.query.readinglistorder[0].order}}'
+    put:
+      tags:
+        - Reading lists
+      summary: Reorder the lists.
+      description: |
+        Request must be authenticated with a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json; charset=utf-8
+      parameters:
+        - name: list_ids
+          in: body
+          description: |
+            List IDs in the desired order. Must contain all lists of the current user
+            and nothing else.
+          required: true
+          schema:
+            type: array
+            title: list_ids
+            example: [3, 4, 2, 1, 6, 5]
+            uniqueItems: true
+            items:
+              type: integer
+        - <<: *csrf_token
+      responses:
+        '200':
+          description: Success.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: readinglists
+                command: order
+                order: '{{flattenMultivalue(request.body)}}'
+                token: '{{request.query.csrf_token}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+      x-monitor: false
+  /lists/{id}/order:
+    get:
+      tags:
+        - Reading lists
+      summary: Get the order of entries in a given list.
+      description: |
+        Returns a list of list entry IDs in the user-defined order.
+
+        List must belong to current user and request must be authenticated with
+        a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      parameters:
+        - name: id
+          in: path
+          description: List ID
+          type: integer
+          required: true
+      produces:
+        - application/json; charset=utf-8
+      responses:
+        '200':
+          description: An array of list entry IDs.
+          schema:
+            type: array
+            example: [5, 2, 3, 1, 4]
+            uniqueItems: true
+            items:
+              type: integer
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: query
+                meta: readinglistorder
+                rlolists: '{{request.params.id}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+              body:
+                # TODO verify this is the right array item
+                lists: '{{forward_to_mw.body.query.readinglistorder[0].order}}'
+    put:
+      tags:
+        - Reading lists
+      summary: Reorder a list.
+      description: |
+        List must belong to current user and request must be authenticated with
+        a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      produces:
+        - application/json; charset=utf-8
+      parameters:
+        - name: id
+          in: path
+          description: List ID
+          type: integer
+          required: true
+        - name: list_entries
+          in: body
+          description: |
+            List IDs in the desired order. Must contain all entries of the list and nothing else.
+          required: true
+          schema:
+            type: array
+            example: [5, 2, 3, 1, 4]
+            uniqueItems: true
+            items:
+              type: integer
+        - <<: *csrf_token
+      responses:
+        '200':
+          description: Success.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: readinglists
+                command: orderentry
+                list: '{{request.params.id}}'
+                order: '{{flattenMultivalue(request.body)}}'
+                token: '{{request.query.csrf_token}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8
+                cache-control: "no-cache"
+      x-monitor: false
+  /lists/pages/{project}/{title}:
+    get:
+      tags:
+        - Reading lists
+      summary: Get lists of the current user which contain a given page.
+      description: |
+        Request must be authenticated with a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      parameters:
+        - name: project
+          in: path
+          <<: *list_entry_common_project
+          required: true
+        - name: title
+          in: path
+          <<: *list_entry_common_title
+          required: true
+        - name: next
+          in: query
+          description: Continuation parameter from previous request
+          type: string
+          required: false
+      produces:
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
+      responses:
+        '200':
+          description: An array of list metadata.
+          schema:
+            type: object
+            properties:
+              lists:
+                type: array
+                items:
+                  $ref: '#/definitions/list_read'
+              next:
+                type: string
+                description: Continuation token.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: query
+                meta: readinglists
+                rllimit: max
+                rlproject: '{{request.params.project}}'
+                rltitle: '{{request.params.title}}'
+                # FIXME there should be a nicer way to do this
+                continue: '{{unflattenContinuation(request.query.next).continue}}'
+                rlcontinue: '{{unflattenContinuation(request.query.next).rlcontinue}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
+                cache-control: "no-cache"
+              body:
+                lists: '{{forward_to_mw.body.query.readinglists}}'
+                next: '{{flattenContinuation(forward_to_mw.body.continue)}}'
+  /lists/changes/since/{date}:
+    get:
+      tags:
+        - Reading lists
+      summary: Get recent changes to the lists
+      description: |
+        Returns metadata describing lists and entries which have changed. Might be truncated
+        and include a continuation token.
+
+        Request must be authenticated with a MediaWiki session cookie.
+
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+      parameters:
+        - name: date
+          in: path
+          description: Cutoff date (in ISO 8601)
+          type: string
+          format: date-time
+          required: true
+        - name: next
+          in: query
+          description: Continuation parameter from previous request
+          type: string
+          required: false
+      produces:
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
+      responses:
+        '200':
+          description: An array of list and entry metadata.
+          schema:
+            type: object
+            properties:
+              lists:
+                type: array
+                items:
+                  $ref: '#/definitions/list_read'
+              next:
+                type: string
+                description: Continuation token.
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - path: ./lib/mediawiki_auth_filter.js
+      x-request-handler:
+        - forward_to_mw:
+            request:
+              uri: /{domain}/sys/action/rawquery
+              body:
+                action: query
+                meta: readinglists
+                list: readinglistentries
+                rllimit: max
+                rlelimit: max
+                rlchangedsince: '{{request.params.date}}'
+                rlechangedsince: '{{request.params.date}}'
+                # FIXME there should be a nicer way to do this
+                continue: '{{unflattenContinuation(request.query.next).continue}}'
+                rlcontinue: '{{unflattenContinuation(request.query.next).rlcontinue}}'
+                rlecontinue: '{{unflattenContinuation(request.query.next).rlecontinue}}'
+            return:
+              status: 200
+              headers:
+                content-type: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
+                cache-control: "no-cache"
+              body:
+                lists: '{{forward_to_mw.body.query.readinglists}}'
+                entries: '{{forward_to_mw.body.query.readinglistentries}}'
+                next: '{{flattenContinuation(forward_to_mw.body.continue)}}'
+tags:
+  - name: Reading lists
+    description: Private lists of selected pages
+    externalDocs:
+      description: Project documentation
+      url: https://www.mediawiki.org/wiki/Reading/Reading_Lists
+definitions:
+  list_read:
+    title: list
+    type: object
+    properties:
+      id:
+        type: integer
+        example: 42
+      <<: *list_common
+      created:
+        type: string
+        format: date-time
+        description: "Creation date (in ISO 8601)"
+      updated:
+        type: string
+        format: date-time
+        description: "Last modification date (in ISO 8601)"
+      order:
+        type: array
+        description: All list IDs in the user-defined order
+        items:
+          type: integer
+        example: [1, 3, 2]
+        uniqueItems: true
+        maxItems: *maxListsPerUser
+    required:
+      - id
+      - name
+      - created
+      - updated
+      - order
+  list_write:
+    type: object
+    properties:
+      <<: *list_common
+    required:
+      - name
+  list_entry_read:
+    title: list_entry
+    type: object
+    properties:
+      id:
+        type: integer
+        example: 64
+      <<: *list_entry_common
+      created:
+        type: string
+        format: date-time
+        description: "Creation date (in ISO 8601)"
+      updated:
+        type: string
+        format: date-time
+        description: "Last modification date (in ISO 8601)"
+      order:
+        type: array
+        description: All IDs of the entries of the list in the user-defined order
+        items:
+          type: integer
+        example: [1, 3, 2]
+        uniqueItems: true
+        maxItems: *maxEntriesPerList
+  list_entry_write:
+    type: object
+    properties:
+      <<: *list_entry_common
+    required:
+      - project
+      - title

--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -81,12 +81,12 @@ paths:
           required: true
         - name: start
           in: path
-          description: The date of the first day to include, in YYYYMMDD format
+          description: The date of the first day to include, in YYYYMMDD or YYYYMMDDHH format
           type: string
           required: true
         - name: end
           in: path
-          description: The date of the last day to include, in YYYYMMDD format
+          description: The date of the last day to include, in YYYYMMDD or YYYYMMDDHH format
           type: string
           required: true
       responses:


### PR DESCRIPTION
Adds a bunch of endpoints under `/data/lists/` which act as a proxy towards MediaWiki's `action=readinglists`, `meta=readinglists`, `list=readinglistentries` and `meta=readinglistorder` API modules, and towards the summary endpoint on an arbitrary wiki. Task: [T168986](https://phabricator.wikimedia.org/T168986)