### PR TITLE
Handle null values in mwUtil.hydrateResponse

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -409,7 +409,7 @@ mwUtil.hydrateResponse = (response, fetch) => {
             for (let i = node.length - 1; i >= 0; i--) {
                 _traverse(node[i], () => node.splice(i, 1));
             }
-        } else if (typeof node === 'object') {
+        } else if (node && typeof node === 'object') {
             if (Array.isArray(node.$merge)) {
                 node.$merge.forEach(requestResource);
             } else {


### PR DESCRIPTION
Avoid errors caused by `typeof null === 'object'`.