### PR TITLE
Summary: Move back the monitoring test to enwiki

### DIFF
--- a/v1/summary.yaml
+++ b/v1/summary.yaml
@@ -182,8 +182,8 @@ paths:
         - title: Get summary from storage
           request:
             params:
-              domain: test.wikipedia.org
-              title: Summary_Test_Page
+              domain: en.wikipedia.org
+              title: San_Francisco
           response:
             status: 200
             headers:


### PR DESCRIPTION
The monitoring script has the domain set in its configuration, so we need an enwiki page to test against.