### PR TITLE
Take parsoid content from old storage if exists

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -176,6 +176,7 @@ class ParsoidService {
         // Set up operations
         this.operations = {
             getPageBundle: this.pagebundle.bind(this),
+            getStoredPageBundle: this.getStoredPageBundle.bind(this),
             // Revision retrieval per format
             getWikitext: this.getFormat.bind(this, 'wikitext'),
             getHtml: this.getFormat.bind(this, 'html'),
@@ -243,12 +244,30 @@ class ParsoidService {
     pagebundle(hyper, req) {
         const rp = req.params;
         const domain = rp.domain;
-        const newReq = Object.assign({}, req);
-        if (!newReq.method) { newReq.method = 'get'; }
-        const path = (newReq.method === 'get') ? 'page' : 'transform/wikitext/to';
-        newReq.uri = `${this.parsoidHost}/${domain}/v3/${path}/pagebundle/`
-            + `${encodeURIComponent(rp.title)}/${rp.revision}`;
-        return hyper.request(newReq);
+        const storedContentUri = [domain, 'sys', 'parsoid_old', 'stored_pagebundle', rp.title];
+        if (rp.revision) {
+            storedContentUri.push(rp.revision);
+        }
+        return hyper.get(new URI(storedContentUri))
+        .catch({ status: 404 }, (e) => {
+            // Don't have it in old storage. Generate.
+            const newReq = Object.assign({}, req);
+            if (!newReq.method) { newReq.method = 'get'; }
+            const path = (newReq.method === 'get') ? 'page' : 'transform/wikitext/to';
+            newReq.uri = `${this.parsoidHost}/${domain}/v3/${path}/pagebundle/`
+                + `${encodeURIComponent(rp.title)}/${rp.revision}`;
+            return hyper.request(newReq);
+        });
+
+    }
+
+    getStoredPageBundle(hyper, req) {
+        throw new HTTPError({
+            status: 500,
+            body: {
+                message: 'getStoredPageBundle must not be called on new parsoid module'
+            }
+        });
     }
 
     saveParsoidResultToLatest(hyper, req, tid, parsoidResp) {

--- a/sys/parsoid.yaml
+++ b/sys/parsoid.yaml
@@ -15,6 +15,11 @@ paths:
       summary: Retrieve a JSON bundle containing html and data-parsoid
       operationId: getPageBundle
 
+  /stored_pagebundle/{title}{/revision}:
+    get:
+      summary: Retrieve a JSON bundle containing html and data-parsoid
+      operationId: getStoredPageBundle
+
   /wikitext/{title}/:
     get:
       summary: List Wikitext revisions.

--- a/sys/parsoid_old.js
+++ b/sys/parsoid_old.js
@@ -196,6 +196,7 @@ class ParsoidService {
         // Set up operations
         this.operations = {
             getPageBundle: this.pagebundle.bind(this),
+            getStoredPageBundle: this.getStoredPageBundle.bind(this),
             // Revision retrieval per format
             getWikitext: this.getFormat.bind(this, 'wikitext'),
             getHtml: this.getFormat.bind(this, 'html'),
@@ -244,6 +245,18 @@ class ParsoidService {
         newReq.uri = `${this.parsoidHost}/${domain}/v3/${path}/pagebundle/`
             + `${encodeURIComponent(rp.title)}/${rp.revision}`;
         return hyper.request(newReq);
+    }
+
+    getStoredPageBundle(hyper, req) {
+        const rp = req.params;
+        return P.props({
+            html: hyper.get(this.getBucketURI(rp, 'html')),
+            'data-parsoid': hyper.get(this.getBucketURI(rp, 'data-parsoid'))
+        })
+        .then(results => ({
+            status: 200,
+            body: results
+        }));
     }
 
     saveParsoidResult(hyper, req, format, tid, parsoidResp) {

--- a/sys/parsoid_proxy.js
+++ b/sys/parsoid_proxy.js
@@ -3,9 +3,9 @@
 const P = require('bluebird');
 const HyperSwitch = require('hyperswitch');
 const URI = HyperSwitch.URI;
+const HTTPError = HyperSwitch.HTTPError;
 
 const mwUtil = require('../lib/mwUtil');
-
 const spec = HyperSwitch.utils.loadSpec(`${__dirname}/parsoid.yaml`);
 
 class ParsoidProxy {
@@ -22,6 +22,14 @@ class ParsoidProxy {
         // Set up operations
         this.operations = {
             getPageBundle: this.pagebundle.bind(this),
+            getStoredPageBundle: (hyper, req) => {
+                throw new HTTPError({
+                    status: 500,
+                    body: {
+                        message: 'getStoredPageBundle must not be called on new parsoid proxy'
+                    }
+                });
+            },
             // Revision retrieval per format
             getWikitext: this.getFormat.bind(this, 'wikitext'),
             getHtml: this.getFormat.bind(this, 'html'),

--- a/test/features/security/security.js
+++ b/test/features/security/security.js
@@ -85,7 +85,6 @@ describe('router - security', function() {
             }
         })
         .get('/fr.wikipedia.org/v3/page/pagebundle/' + title + '/' + revision)
-        .twice()
         .reply(200, function() {
             return {
                 'html': {


### PR DESCRIPTION
In order to avoid latency penalty switching to the new storage, try to fetch the content from old storage and transfer it to new storage where possible.

cc @wikimedia/services 