### PR TITLE
Fixed a bug with no headers

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -668,7 +668,8 @@ class ParsoidService {
                 page_title: rp.title,
                 page_revision: rp.revision,
                 page_tid: tid,
-                data_parsoid_etag: original.headers.etag
+                data_parsoid_etag: original['data-parsoid'].headers
+                    && original['data-parsoid'].headers.etag
             });
 
             const body2 = {


### PR DESCRIPTION
The headers are actually under the data-parsoid property

cc @d00rman 