### PR TITLE
Reading lists: add tests

### DIFF
--- a/test/features/lists.js
+++ b/test/features/lists.js
@@ -1,0 +1,1182 @@
+'use strict';
+
+const nock = require('nock');
+const assert = require('../utils/assert.js');
+const server = require('../utils/server.js');
+const querystring = require('querystring');
+const preq = require('preq');
+
+
+describe('reading lists', function() {
+    const csrfToken = '<mock>';
+    const sessionCookies = '<mock>';
+    const config = {
+        domain: 'dev.wiki.local.wmftest.net',
+        baseURL: 'http://localhost:7231/dev.wiki.local.wmftest.net/v1',
+        apiDomain: 'http://localhost:10123',
+        apiPath: '/w/api.php',
+    };
+
+    function getApi() {
+        return nock(config.apiDomain, {
+            reqheaders: {
+                'Cookie': sessionCookies,
+                'Host': config.domain,
+            },
+        })
+        .defaultReplyHeaders({
+            'Content-Type': 'application/json; charset=utf-8',
+        });
+    }
+
+    // workaround for https://github.com/node-nock/nock/issues/852
+    // also for object ordering issues
+    function nockDiff(expected) {
+        return (actual) => {
+            if (typeof actual === 'string' && typeof expected === 'object') {
+                actual = querystring.parse(actual);
+            }
+            try {
+                assert.deepEqual(actual, expected, 'nock failure');
+                return true;
+            } catch (e) {
+                console.log(e);
+                return false;
+            }
+        }
+    }
+
+    this.timeout(20000);
+
+    before(function() {
+        //nock.recorder.rec();
+        return server.start()
+        // Do a preparation request to force siteinfo fetch so that we don't need to mock it
+        .then(() => preq.get({
+            uri: `${config.baseURL}/page/html/Main_Page`,
+        }))
+        // After this, there should be no unmocked requests other than those to /lists
+        .then(() => nock.emitter.on('no match', req => {
+            if (!req.href.startsWith(`${config.baseURL}/data/lists/`)) {
+                throw Error(`Unmocked request to ${req.href}`);
+            }
+        }));
+    });
+
+    afterEach(function() {
+        nock.cleanAll();
+    });
+
+    describe('POST /lists/setup', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'readinglists',
+                    command: 'setup',
+                    token: csrfToken,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {});
+
+            return preq.post({
+                uri: `${config.baseURL}/data/lists/setup`,
+                query: {
+                    csrf_token: csrfToken,
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(res => {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+
+        it('error handling', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'readinglists',
+                    command: 'setup',
+                    token: csrfToken,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    error: {
+                        code: 'badtoken',
+                        info: 'Invalid CSRF token.',
+                    },
+                }, {
+                   'MediaWiki-API-Error': 'badtoken',
+                });
+
+            return preq.post({
+                uri: `${config.baseURL}/data/lists/setup`,
+                query: {
+                    csrf_token: csrfToken,
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .tap(() => {
+                throw new Error('should not have succeeded');
+            })
+            .catch({ name: 'HTTPError' }, res => {
+                assert.deepEqual(res.status, 400);
+                assert.deepEqual(res.body.title, 'badtoken');
+                assert.deepEqual(res.body.detail, 'Invalid CSRF token.');
+            });
+        });
+    });
+
+    describe('POST /lists/teardown', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'readinglists',
+                    command: 'teardown',
+                    token: csrfToken,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {});
+
+            return preq.post({
+                uri: `${config.baseURL}/data/lists/teardown`,
+                query: {
+                    csrf_token: csrfToken,
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+    });
+
+    describe('GET /lists/', function() {
+        const listEntry = {
+            id: 1,
+            name: 'default',
+            default: true,
+            description: '',
+            color: '',
+            image: '',
+            icon: '',
+            created: '2017-09-27T06:59:13Z',
+            updated: '2017-10-17T07:40:50Z',
+            order: [ 1, 2, 3 ],
+            listOrder: [ 1, 2 ],
+        };
+
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglists',
+                    rllimit: 'max',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglists: [ listEntry ],
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    lists: [ listEntry ],
+                });
+            });
+        });
+
+        it('paging', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglists',
+                    rllimit: 'max',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglists: [ listEntry ],
+                    },
+                    continue: {
+                        rlcontinue: 1,
+                        continue: '-||',
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    lists: [ listEntry ],
+                    next: '{"rlcontinue":1,"continue":"-||"}',
+                });
+            });
+        });
+
+        it('paging 2', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglists',
+                    rllimit: 'max',
+                    rlcontinue: 1,
+                    continue: '-||',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglists: [ listEntry ],
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/`,
+                query: {
+                    next: '{"rlcontinue":1,"continue":"-||"}',
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    lists: [ listEntry ],
+                });
+            });
+        });
+
+        it('paging error', function() {
+            const scope = getApi();
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/`,
+                query: {
+                    next: '{invalid}',
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .tap(() => {
+                throw new Error('should not have succeeded');
+            })
+            .catch({ name: 'HTTPError' }, res => {
+                assert.deepEqual(res.status, 400);
+                assert.deepEqual(res.body.type,
+                    'https://mediawiki.org/wiki/HyperSwitch/errors/server_error#invalid_paging_parameter');
+            });
+        });
+    });
+
+    describe('POST /lists/', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'readinglists',
+                    command: 'create',
+                    name: 'Test list',
+                    description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+                    color: 'red',
+                    image: 'Foo.png',
+                    icon: 'foo',
+                    token: csrfToken,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    create: {
+                        id: 2,
+                    },
+                });
+
+            return preq.post({
+                uri: `${config.baseURL}/data/lists/`,
+                query: {
+                    csrf_token: csrfToken,
+                },
+                body: {
+                    name: 'Test list',
+                    description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+                    color: 'red',
+                    image: 'Foo.png',
+                    icon: 'foo',
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                    'content-type': 'application/json',
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body.id, 2);
+            });
+        });
+    });
+
+    describe('PUT /lists/{id}', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'readinglists',
+                    command: 'update',
+                    list: 2,
+                    name: 'Test list!',
+                    description: 'Lorem ipsum dolor sit amet, integre fabellas partiendo has ei.',
+                    color: 'blue',
+                    image: 'Bar.png',
+                    icon: 'bar',
+                    token: csrfToken,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {});
+
+            return preq.put({
+                uri: `${config.baseURL}/data/lists/2`,
+                query: {
+                    csrf_token: csrfToken,
+                },
+                body: {
+                    name: 'Test list!',
+                    description: 'Lorem ipsum dolor sit amet, integre fabellas partiendo has ei.',
+                    color: 'blue',
+                    image: 'Bar.png',
+                    icon: 'bar',
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                    'content-type': 'application/json',
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+    });
+
+    describe('DELETE /lists/{id}', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'readinglists',
+                    command: 'delete',
+                    list: 2,
+                    token: csrfToken,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {});
+
+            return preq.delete({
+                uri: `${config.baseURL}/data/lists/2`,
+                query: {
+                    csrf_token: csrfToken,
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+    });
+
+    describe('GET /lists/{id}/entries/', function() {
+        const entries =  [
+            {
+                id: 10,
+                listId: 4,
+                project: 'en.wikipedia.org',
+                title: 'Foo Bar',
+                created: '2017-09-27T06:59:13Z',
+                updated: '2017-10-17T07:40:50Z',
+            },
+            {
+                id: 11,
+                listId: 4,
+                project: 'en.wikipedia.org',
+                title: 'Boo(m)?',
+                created: '2017-09-27T06:59:13Z',
+                updated: '2017-10-17T07:40:50Z',
+            },
+        ];
+        const expectedEntries = [
+            {
+                id: 10,
+                listId: 4,
+                project: 'en.wikipedia.org',
+                title: 'Foo Bar',
+                summary: {
+                    title: 'Foo_Bar',
+                    normalizedtitle: 'Foo Bar',
+                    summaryData: '<data1>',
+                },
+                created: '2017-09-27T06:59:13Z',
+                updated: '2017-10-17T07:40:50Z',
+            },
+            {
+                id: 11,
+                listId: 4,
+                project: 'en.wikipedia.org',
+                title: 'Boo(m)?',
+                summary: {
+                    title: 'Boo(m)?',
+                    normalizedtitle: 'Boo(m)?',
+                    summaryData: '<data2>',
+                },
+                created: '2017-09-27T06:59:13Z',
+                updated: '2017-10-17T07:40:50Z',
+            },
+        ];
+        function getEnwikiMock() {
+            return nock('https://en.wikipedia.org', {
+                // FIXME should not send cookies to a different domain
+                // badheaders: [ 'Cookie' ],
+            })
+            .defaultReplyHeaders({
+                'Content-Type': 'application/json; charset=utf-8',
+            })
+            .post(config.apiPath, query => {
+                const params = (typeof query === 'string') ? querystring.parse(query) : query;
+                return params.action === 'query' && params.meta === 'siteinfo|filerepoinfo'
+                    && !params.list && !params.prop;
+            })
+            .optionally()
+            // The siteinfo response is huge and /lists only uses it to verify the domain.
+            // Only mock enough of it to make ActionService.siteinfo not fail.
+            .reply(200, {
+                query: {
+                    general: {
+                        lang: 'en',
+                        legaltitlechars: ' %!"$&\'()*,\\-.\\/0-9:;=?@A-Z\\\\^_`a-z~\\x80-\\xFF+',
+                        case: 'first-letter',
+                    },
+                    namespaces: {
+                        '0': {
+                            id: 0,
+                            case: 'first-letter',
+                            content: '',
+                            '*': ''
+                        },
+                    },
+                    namespacealiases: [],
+                    specialpagealiases: [],
+                    repos: [
+                        {
+                            name: 'shared',
+                            descBaseUrl: 'https://commons.wikimedia.org/wiki/File:',
+                        },
+                    ],
+                },
+            });
+        }
+
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    list: 'readinglistentries',
+                    rlelists: 4,
+                    rlelimit: 'max',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglistentries: entries,
+                    },
+                });
+            const scope2 = getEnwikiMock()
+                .get('/api/rest_v1/page/summary/Foo_Bar')
+                .reply(200, { title: 'Foo Bar', summaryData: '<data1>' })
+                .get('/api/rest_v1/page/summary/Boo(m)%3F')
+                .reply(200, { title: 'Boo(m)?', summaryData: '<data2>' });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/4/entries/`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => {
+                scope.done();
+                scope2.done();
+            })
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    entries: expectedEntries,
+                });
+            });
+        });
+
+        it('paging', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    list: 'readinglistentries',
+                    rlelists: 4,
+                    rlelimit: 'max',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglistentries: entries.slice(0, 1),
+                    },
+                    continue: {
+                        rlecontinue: 1,
+                        continue: '-||',
+                    },
+                });
+            const scope2 = getEnwikiMock()
+                .get('/api/rest_v1/page/summary/Foo_Bar')
+                .reply(200, { title: 'Foo Bar', summaryData: '<data1>' });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/4/entries/`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => {
+                scope.done();
+                scope2.done();
+            })
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    entries: expectedEntries.slice(0, 1),
+                    next: '{"rlecontinue":1,"continue":"-||"}',
+                });
+            });
+        });
+
+        it('paging2', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    list: 'readinglistentries',
+                    rlelists: 4,
+                    rlelimit: 'max',
+                    rlecontinue: 1,
+                    continue: '-||',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglistentries: entries.slice(1),
+                    },
+                });
+            const scope2 = getEnwikiMock()
+                .get('/api/rest_v1/page/summary/Boo(m)%3F')
+                .reply(200, { title: 'Boo(m)?', summaryData: '<data2>' });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/4/entries/`,
+                query: {
+                    next: '{"rlecontinue":1,"continue":"-||"}',
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => {
+                scope.done();
+                scope2.done();
+            })
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    entries: expectedEntries.slice(1),
+                });
+            });
+        });
+
+        it('no cookie forwarding to unknown domains', function() {
+            const entries = [
+                {
+                    id: 1,
+                    listId: 1,
+                    project: 'de.wikipedia.org',
+                    title: 'Barack Obama',
+                    created: '2017-09-27T06:59:13Z',
+                    updated: '2017-10-17T07:40:50Z',
+                },
+            ];
+
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    list: 'readinglistentries',
+                    rlelists: 1,
+                    rlelimit: 'max',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglistentries: entries,
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/1/entries/`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => {
+                scope.done();
+            })
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+    });
+
+    describe('POST /lists/{id}/entries/', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'readinglists',
+                    command: 'createentry',
+                    list: '3',
+                    project: 'en.wikipedia.org',
+                    title: 'Barack Obama',
+                    token: csrfToken,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    createentry: {
+                        id: 1,
+                    },
+                });
+
+            return preq.post({
+                uri: `${config.baseURL}/data/lists/3/entries/`,
+                query: {
+                    csrf_token: csrfToken,
+                },
+                body: {
+                    project: 'en.wikipedia.org',
+                    title: 'Barack Obama',
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                    'content-type': 'application/json',
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body.id, 1);
+            });
+        });
+
+    });
+
+    describe('DELETE /lists/{id}/entries/{entry_id}', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'readinglists',
+                    command: 'deleteentry',
+                    entry: 1,
+                    token: csrfToken,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {});
+
+            return preq.delete({
+                uri: `${config.baseURL}/data/lists/3/entries/1`,
+                query: {
+                    csrf_token: csrfToken,
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+    });
+
+    describe('GET /lists/order', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglistorder',
+                    rlolistorder: 1,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglistorder: [
+                            {
+                                type: 'lists',
+                                order: [ 1, 2, 3 ],
+                            },
+                        ],
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/order`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, { order: [ 1, 2, 3 ] });
+            });
+        });
+    });
+
+    describe('PUT /lists/order', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'readinglists',
+                    command: 'order',
+                    order: '1|2|3',
+                    token: csrfToken,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {});
+
+            return preq.put({
+                uri: `${config.baseURL}/data/lists/order`,
+                query: {
+                    csrf_token: csrfToken,
+                },
+                body: [ 1, 2, 3 ],
+                headers: {
+                    'Cookie': sessionCookies,
+                    'content-type': 'application/json',
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+    });
+
+    describe('GET /lists/{id}/order', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglistorder',
+                    rlolists: 1,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglistorder: [
+                            {
+                                type: 'entries',
+                                list: 1,
+                                order: [ 1, 2, 3 ],
+                            },
+                        ],
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/1/order`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+                .finally(() => scope.done())
+                .then(function (res) {
+                    assert.deepEqual(res.status, 200);
+                    assert.deepEqual(res.body, { order: [ 1, 2, 3 ] });
+                });
+        });
+    });
+
+    describe('PUT /lists/{id}/order', function() {
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'readinglists',
+                    command: 'orderentry',
+                    list: 1,
+                    order: '1|2|3',
+                    token: csrfToken,
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {});
+
+            return preq.put({
+                uri: `${config.baseURL}/data/lists/1/order`,
+                query: {
+                    csrf_token: csrfToken,
+                },
+                body: [ 1, 2, 3 ],
+                headers: {
+                    'Cookie': sessionCookies,
+                    'content-type': 'application/json',
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+            });
+        });
+    });
+
+    describe('GET /lists/pages/{project}/{title}', function() {
+        const lists = [
+            {
+                id: 1,
+                name: 'default',
+                default: true,
+                description: '',
+                color: '',
+                image: '',
+                icon: '',
+                created: '2017-09-27T06:59:13Z',
+                updated: '2017-10-17T07:40:50Z',
+                order: [ 1, 2, 3 ],
+                listOrder: [ 1, 2 ],
+            },
+            {
+                id: 2,
+                name: 'other',
+                description: '',
+                color: '',
+                image: '',
+                icon: '',
+                created: '2017-09-27T06:59:13Z',
+                updated: '2017-10-17T07:40:50Z',
+                order: [ 5, 4 ],
+            },
+        ];
+
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglists',
+                    rlproject: 'en.wikipedia.org',
+                    rltitle: 'Foo_Bar',
+                    rllimit: 'max',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglists: lists,
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/pages/en.wikipedia.org/Foo%20Bar`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    lists: lists,
+                });
+            });
+        });
+
+        it('paging', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglists',
+                    rlproject: 'en.wikipedia.org',
+                    rltitle: 'Foo_Bar',
+                    rllimit: 'max',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglists: lists.slice(0, 1),
+                    },
+                    continue: {
+                        rlcontinue: 1,
+                        continue: '-||',
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/pages/en.wikipedia.org/Foo%20Bar`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    lists: lists.slice(0, 1),
+                    next: '{"rlcontinue":1,"continue":"-||"}',
+                });
+            });
+        });
+
+        it('paging 2', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglists',
+                    rlproject: 'en.wikipedia.org',
+                    rltitle: 'Foo_Bar',
+                    rllimit: 'max',
+                    rlcontinue: 1,
+                    continue: '-||',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglists: lists.slice(1),
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/pages/en.wikipedia.org/Foo%20Bar`,
+                query: {
+                    next: '{"rlcontinue":1,"continue":"-||"}',
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    lists: lists.slice(1),
+                });
+            });
+        });
+    });
+
+    describe('GET /lists/changes/since/{date}', function() {
+        const lists = [
+            {
+                id: 1,
+                name: 'default',
+                default: true,
+                description: '',
+                color: '',
+                image: '',
+                icon: '',
+                created: '2017-09-27T06:59:13Z',
+                updated: '2017-10-17T07:40:50Z',
+                order: [ 1, 2 ],
+                listOrder: [ 1, 2 ],
+            },
+            {
+                id: 2,
+                name: 'deleted',
+                description: '',
+                color: '',
+                image: '',
+                icon: '',
+                created: '2017-09-27T06:59:13Z',
+                updated: '2017-10-17T07:40:50Z',
+                deleted: true,
+            },
+        ];
+        const entries =  [
+            {
+                id: 1,
+                listId: 1,
+                project: 'en.wikipedia.org',
+                title: 'Foo Bar',
+                created: '2017-09-27T06:59:13Z',
+                updated: '2017-10-17T07:40:50Z',
+            },
+            {
+                id: 2,
+                listId: 1,
+                project: 'en.wikipedia.org',
+                title: 'Boom Baz',
+                created: '2017-09-27T06:59:13Z',
+                updated: '2017-10-17T07:40:50Z',
+                deleted: true,
+            },
+        ];
+
+        it('forward call', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglists',
+                    list: 'readinglistentries',
+                    rlchangedsince: '2017-10-15T00:00:00Z',
+                    rlechangedsince: '2017-10-15T00:00:00Z',
+                    rllimit: 'max',
+                    rlelimit: 'max',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglists: lists,
+                        readinglistentries: entries,
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/changes/since/2017-10-15T00%3A00%3A00Z`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    lists: lists,
+                    entries: entries,
+                });
+            });
+        });
+
+        it('paging', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglists',
+                    list: 'readinglistentries',
+                    rlchangedsince: '2017-10-15T00:00:00Z',
+                    rlechangedsince: '2017-10-15T00:00:00Z',
+                    rllimit: 'max',
+                    rlelimit: 'max',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglists: lists.slice(0, 1),
+                        readinglistentries: entries.slice(0, 1),
+                    },
+                    continue: {
+                        rlcontinue: 1,
+                        rlecontinue: 1,
+                        continue: '-||',
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/changes/since/2017-10-15T00%3A00%3A00Z`,
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    lists: lists.slice(0, 1),
+                    entries: entries.slice(0, 1),
+                    next: '{"rlcontinue":1,"rlecontinue":1,"continue":"-||"}',
+                });
+            });
+        });
+
+        it('paging 2', function() {
+            const scope = getApi()
+                .post(config.apiPath, nockDiff({
+                    action: 'query',
+                    meta: 'readinglists',
+                    list: 'readinglistentries',
+                    rlchangedsince: '2017-10-15T00:00:00Z',
+                    rlechangedsince: '2017-10-15T00:00:00Z',
+                    rllimit: 'max',
+                    rlelimit: 'max',
+                    rlcontinue: 1,
+                    rlecontinue: 1,
+                    continue: '-||',
+                    format: 'json',
+                    formatversion: '2',
+                }))
+                .reply(200, {
+                    query: {
+                        readinglists: lists.slice(1),
+                        readinglistentries: entries.slice(1),
+                    },
+                });
+
+            return preq.get({
+                uri: `${config.baseURL}/data/lists/changes/since/2017-10-15T00%3A00%3A00Z`,
+                query: {
+                    next: '{"rlcontinue":1,"rlecontinue":1,"continue":"-||"}',
+                },
+                headers: {
+                    'Cookie': sessionCookies,
+                },
+            })
+            .finally(() => scope.done())
+            .then(function (res) {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, {
+                    lists: lists.slice(1),
+                    entries: entries.slice(1),
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Work in progress; I'm hoping to get guidance on how to finish it. The problems are:
* nock and hyperswitch seem interact poorly. When there is a request to an URL that has not been mocked, nock throws an error, but instead if that bubbling up to the test runner, the whole thing breaks (there is no output, subsequent tests do not even get run). I have to step through in a debugger / litter console.log statements around (half of which mysteriously fail to work) to get some idea of what's happening, making testing a very frustrating process. Am I causing that somehow?
* nock error messages seem fairly useless (e.g. I miss the expected URL/payload by just a tiny bit and I just get something nonspecific message about an expected request not having happened. Is that just how nock is or am I using it wrong?
* How should I handle local test running in general? The existing test server config wasn't written with vagrant support in mind; I'd need some puppet-generated config file to inject the port number into. What's the best way to integrate that with the existing config? Maybe extract the whole `config` object from `server.js` into a file that can be specified via env vars? Also right now the tests seem to hardcode where they run. If I wanted tests which can be run on production, beta, local/vagrant, what would be the best way to add that capability to `server.js`? (Right now it's a theoretical question since I'm using nock so the tests have to be run locally. I was thinking of eventually adding two alternative setup phases to each test - mocking with nock vs. setting up a fixture via real requests to the API, so I can use some kind of config flag to switch the tests between unit(ish) and smoke test mode.)