### PR TITLE
Don't store the feed results

### DIFF
--- a/lib/base_feed.js
+++ b/lib/base_feed.js
@@ -69,7 +69,7 @@ class BaseFeed {
                 body: res.body
             });
         };
-        const requesCurrentContentFromMCS = () => this._makeFeedRequests(hyper, req, false)
+        const requestCurrentContentFromMCS = () => this._makeFeedRequests(hyper, req, false)
         .then(result => this._assembleResult(result, dateKey))
         .tap((res) => {
             if (this.options.storeHistory) {
@@ -118,8 +118,10 @@ class BaseFeed {
 
         if (this.options.storeHistory && mwUtil.isHistoric(date)) {
             return getHistoricContent().then(populateSummaries);
+        } else if (mwUtil.isHistoric(date)) {
+            return requestHistoricContentFromMCS().then(populateSummaries);
         } else {
-            return requesCurrentContentFromMCS().then(populateSummaries);
+            return requestCurrentContentFromMCS().then(populateSummaries);
         }
     }
 

--- a/test/features/feed.js
+++ b/test/features/feed.js
@@ -46,8 +46,8 @@ describe('Featured feed', () => {
         .then(() => {
             slice.halt();
             const requests = slice.get().map(JSON.parse);
-            assertStorageRequest(requests, 'get', 'feed.aggregated', true);
-            assertStorageRequest(requests, 'put', 'feed.aggregated', true);
+            assertStorageRequest(requests, 'get', 'feed.aggregated', false);
+            assertStorageRequest(requests, 'put', 'feed.aggregated', false);
             assertMCSRequest(requests, 'page/featured', date, true);
             assertMCSRequest(requests, 'page/most-read', date, true);
             assertMCSRequest(requests, 'media/image/featured', date, true);
@@ -55,7 +55,7 @@ describe('Featured feed', () => {
         });
     });
 
-    it('Should not rerender available historic content', () => {
+    it.skip('Should not rerender available historic content', () => {
         const date = '2016/10/01';
         const slice = server.config.logStream.slice();
         return preq.get({
@@ -65,7 +65,7 @@ describe('Featured feed', () => {
         .then(() => {
             slice.halt();
             const requests = slice.get().map(JSON.parse);
-            assertStorageRequest(requests, 'get', 'feed.aggregated', true);
+            assertStorageRequest(requests, 'get', 'feed.aggregated', false);
             assertStorageRequest(requests, 'put', 'feed.aggregated', false);
             assertMCSRequest(requests, 'page/featured', date, false);
             assertMCSRequest(requests, 'page/most-read', date, false);
@@ -74,7 +74,7 @@ describe('Featured feed', () => {
         });
     });
 
-    it('Should partially rerender available historic content, no-cache', () => {
+    it.skip('Should partially rerender available historic content, no-cache', () => {
         const date = '2016/10/01';
         const slice = server.config.logStream.slice();
         return preq.get({
@@ -87,8 +87,8 @@ describe('Featured feed', () => {
         .then(() => {
             slice.halt();
             const requests = slice.get().map(JSON.parse);
-            assertStorageRequest(requests, 'get', 'feed.aggregated', true);
-            assertStorageRequest(requests, 'put', 'feed.aggregated', true);
+            assertStorageRequest(requests, 'get', 'feed.aggregated', false);
+            assertStorageRequest(requests, 'put', 'feed.aggregated', false);
             assertMCSRequest(requests, 'page/featured', date, true);
             assertMCSRequest(requests, 'page/most-read', date, true);
             assertMCSRequest(requests, 'media/image/featured', date, true);
@@ -107,7 +107,7 @@ describe('Featured feed', () => {
         .then(() => {
             slice.halt();
             const requests = slice.get().map(JSON.parse);
-            assertStorageRequest(requests, 'put', 'feed.aggregated', true);
+            assertStorageRequest(requests, 'put', 'feed.aggregated', false);
             assertMCSRequest(requests, 'page/featured', date, true);
             assertMCSRequest(requests, 'page/most-read', date, true);
             assertMCSRequest(requests, 'media/image/featured', date, true);
@@ -147,7 +147,7 @@ describe('Featured feed', () => {
         .then(() => {
             slice.halt();
             const requests = slice.get().map(JSON.parse);
-            assertStorageRequest(requests, 'put', 'feed.aggregated', true);
+            assertStorageRequest(requests, 'put', 'feed.aggregated', false);
             assertMCSRequest(requests, 'page/featured', date, true);
             assertMCSRequest(requests, 'page/most-read', date, true);
             assertMCSRequest(requests, 'media/image/featured', date, true);

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -145,7 +145,7 @@ module.exports = (options) => {
     options.content_type = 'application/json; charset=utf-8; ' +
         'profile="https://www.mediawiki.org/wiki/Specs/aggregated-feed/0.5.0"';
     options.spec = spec;
-    options.storeHistory = true;
+    options.storeHistory = false;
 
     return new Feed(options).getModuleDeclaration();
 };


### PR DESCRIPTION
We've reached the consensus that we will not store the results for the feed in Cassandra. This will eventually allow to simplify the code a lot, but right now I wanted to make the first experiment with `storeHistory === false` - it's equivalent to having no buckets at all - to access the latency increase and see if we eventually really want that.

Bug: https://phabricator.wikimedia.org/T179412

cc @wikimedia/services @coreyfloyd @berndsi 