### PR TITLE
Revert "Update defaults for new storage strategies"

### DIFF
--- a/sys/key_rev_value.js
+++ b/sys/key_rev_value.js
@@ -62,8 +62,8 @@ class KRVBucket {
             options: {
                 compression: opts.compression || [
                     {
-                        algorithm: 'lz4',
-                        block_size: 64
+                        algorithm: 'deflate',
+                        block_size: 256
                     }
                 ],
                 updates: opts.updates || {

--- a/sys/key_value.js
+++ b/sys/key_value.js
@@ -66,8 +66,8 @@ class KVBucket {
             options: {
                 compression: opts.compression || [
                     {
-                        algorithm: 'lz4',
-                        block_size: 64
+                        algorithm: 'deflate',
+                        block_size: 256
                     }
                 ],
                 updates: opts.updates || {

--- a/sys/multi_content_bucket.js
+++ b/sys/multi_content_bucket.js
@@ -228,8 +228,8 @@ class MultiContentBucket {
             options: {
                 compression: opts.compression || [
                     {
-                        algorithm: 'lz4',
-                        block_size: 64
+                        algorithm: 'deflate',
+                        block_size: 256
                     }
                 ],
                 updates: opts.updates || {


### PR DESCRIPTION
Reverts wikimedia/restbase#911

As discussed in the [corresponding issue](https://phabricator.wikimedia.org/T179105), this requires a schema version increment, which in turn will kick off (unwanted) schema migrations in WMF production, so we should refrain for now.