### PR TITLE
Reading lists: add sorting

### DIFF
--- a/v1/lists.js
+++ b/v1/lists.js
@@ -70,18 +70,34 @@ class ReadingLists {
     }
 
     /**
+     * Get the sort parameters for the action API.
+     * @param {!String} sort Sort mode ('name' or 'updated').
+     * @return {!Object} { sort: <rlsort/rlesort parameter>, dir: <rldir/rledir parameter> }
+     */
+    getSortParameters(sort) {
+        sort = sort || 'updated';
+        return {
+            sort,
+            dir: (sort === 'updated') ? 'descending' : 'ascending',
+        };
+    }
+
+    /**
      * Handle the /list/{id}/entries endpoint (get entries of a list).
      * @param {!HyperSwitch} hyper
      * @param {!Object} req The request object as provided by HyperSwitch.
      * @return {!Promise<Object>} A response promise.
      */
     getListEntries(hyper, req) {
+        const sortParameters = this.getSortParameters(req.query.sort);
         return hyper.post({
             uri: new URI([req.params.domain, 'sys', 'action', 'rawquery']),
             body: {
                 action: 'query',
                 list: 'readinglistentries',
                 rlelists: req.params.id,
+                rlesort: sortParameters.sort,
+                rledir: sortParameters.dir,
                 rlelimit: 'max',
                 continue: this.unflattenContinuation(req.query.next).continue,
                 rlecontinue: this.unflattenContinuation(req.query.next).rlecontinue,
@@ -138,6 +154,7 @@ module.exports = (options) => {
             flattenContinuation: rl.flattenContinuation.bind(rl),
             unflattenContinuation: rl.unflattenContinuation.bind(rl),
             flattenMultivalue: rl.flattenMultivalue.bind(rl),
+            getSortParameters: rl.getSortParameters.bind(rl),
         },
         operations: {
             getListEntries: rl.getListEntries.bind(rl),

--- a/v1/lists.yaml
+++ b/v1/lists.yaml
@@ -139,6 +139,16 @@ paths:
           description: Continuation parameter from previous request
           type: string
           required: false
+        - name: sort
+          in: query
+          description: |
+            Sort order
+            - `name`: by name, ascending;
+            - `updated`: by last modification date, descending.
+          type: string
+          default: updated
+          enum: [ name, updated ]
+          required: false
       produces:
         - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
       responses:
@@ -167,6 +177,8 @@ paths:
               body:
                 action: query
                 meta: readinglists
+                rlsort: '{{getSortParameters(request.query.sort).sort}}'
+                rldir: '{{getSortParameters(request.query.sort).dir}}'
                 rllimit: max
                 continue: '{{unflattenContinuation(request.query.next).continue}}'
                 rlcontinue: '{{unflattenContinuation(request.query.next).rlcontinue}}'
@@ -345,6 +357,16 @@ paths:
           in: query
           description: Continuation parameter from previous request
           type: string
+          required: false
+        - name: sort
+          in: query
+          description: |
+            Sort order
+            - `name`: by page title, ascending;
+            - `updated`: by last modification date, descending.
+          type: string
+          default: updated
+          enum: [ name, updated ]
           required: false
       produces:
         - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Lists/0.1"
@@ -529,7 +551,6 @@ paths:
                 rllimit: max
                 rlproject: '{{request.params.project}}'
                 rltitle: '{{request.params.title}}'
-                # FIXME there should be a nicer way to do this
                 continue: '{{unflattenContinuation(request.query.next).continue}}'
                 rlcontinue: '{{unflattenContinuation(request.query.next).rlcontinue}}'
             return:
@@ -593,11 +614,14 @@ paths:
                 action: query
                 meta: readinglists
                 list: readinglistentries
-                rllimit: max
-                rlelimit: max
                 rlchangedsince: '{{request.params.date}}'
                 rlechangedsince: '{{request.params.date}}'
-                # FIXME there should be a nicer way to do this
+                rlsort: updated
+                rlesort: updated
+                rldir: ascending
+                rledir: ascending
+                rllimit: max
+                rlelimit: max
                 continue: '{{unflattenContinuation(request.query.next).continue}}'
                 rlcontinue: '{{unflattenContinuation(request.query.next).rlcontinue}}'
                 rlecontinue: '{{unflattenContinuation(request.query.next).rlecontinue}}'


### PR DESCRIPTION
Add `sort` parameter to `/lists/` and `/lists/{id}/entries/`, set sort/dir for MW API accordingly.

Also add sort parameters to `/lists/changes/since/{date}` (has no effect since those are the default settings, but good for self-documentation).

(Also get rid of a bunch of old FIXME comments. I wanted to see if it's possible to just return an object with multiple keys from a helper method and merge that with the rest of the query parameters, but I'm getting used to the current syntax.)

Bug: [T180402](https://phabricator.wikimedia.org/T180402)