### PR TITLE
Add ability to select domain HTTP scheme for PDF exports

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -55,6 +55,7 @@ default_project: &default_project
           cache_control: s-maxage=600, max-age=600
           uri: https://pdfrender-beta.wmflabs.org
           secret: secret
+          scheme: https
         transform:
           cx_host: https://cxserver-beta.wmflabs.org
         skip_updates: false

--- a/v1/pdf.yaml
+++ b/v1/pdf.yaml
@@ -61,7 +61,7 @@ paths:
             request:
               method: get
               # Note: The title needs to be encoded twice.
-              uri: '{{options.uri}}/pdf?accessKey={options.secret}&url=https://{{domain}}/wiki/{_encodeURIComponent(title)}%3Fprintable=yes'
+              uri: '{{options.uri}}/pdf?accessKey={options.secret}&url={{default(options.scheme, "https")}}://{{domain}}/wiki/{_encodeURIComponent(title)}%3Fprintable=yes'
             return:
               status: 200
               headers:


### PR DESCRIPTION
My wiki server runs on HTTP, not HTTPS.

There is probably a better way to do this, but since issues are closed on this repository I'm forced to create a pull request.