### PR TITLE
Update section tests to match new parsoid output

### DIFF
--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const cType = require('content-type');
+const P = require('bluebird');
 const mwUtil = require('./mwUtil');
 
 // Utility function to split path & version suffix from a profile parameter.
@@ -95,12 +96,22 @@ function checkContentType(hyper, req, next, expectedContentType, responsePromise
 
 module.exports = (hyper, req, next, options, specInfo) => {
     const produces = specInfo.spec.produces;
-    const expectedContentType = Array.isArray(produces) && produces[0];
-    const responsePromise = next(hyper, req);
-    if (expectedContentType) {
-        // Found a content type. Ensure that we return the latest profile.
-        return checkContentType(hyper, req, next, expectedContentType, responsePromise);
-    } else {
-        return responsePromise;
-    }
+    return next(hyper, req)
+    .then((res) => {
+        // Most likely it's application/json for sections,
+        // check if it exactly matches one of the list
+        if (Array.isArray(produces)
+            && produces.some(expected =>
+                res.headers && res.headers['content-type'] === expected)) {
+            return res;
+        } else {
+            const expectedContentType = Array.isArray(produces) && produces[0];
+            if (expectedContentType) {
+                // Found a content type. Ensure that we return the latest profile.
+                return checkContentType(hyper, req, next, expectedContentType, P.resolve(res));
+            } else {
+                return res;
+            }
+        }
+    });
 };

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -111,7 +111,7 @@ describe('item requests', function() {
         return preq.get({
             uri: server.config.labsBucketURL + '/html/Main_Page/262492',
             query: {
-                sections: 'mwAQ,mwCw'
+                sections: 'mwAQ,mwDA'
             },
             headers: {
                 'cache-control': 'no-cache'
@@ -123,7 +123,7 @@ describe('item requests', function() {
             assert.deepEqual(res.headers['cache-control'], 'no-cache');
             var body = res.body;
             if (!body['mwAQ'] || typeof body['mwAQ'] !== 'string'
-                    || !body['mwCw']) {
+                    || !body['mwDA']) {
                 throw new Error('Missing section content!');
             }
             return preq.get({
@@ -148,7 +148,7 @@ describe('item requests', function() {
         return preq.get({
             uri: server.config.labsBucketURL + '/html/Main_Page',
             query: {
-                sections: 'mwAQ,mwCw'
+                sections: 'mwAQ,mwDA'
             },
             headers: {
                 'cache-control': 'no-cache'
@@ -159,7 +159,7 @@ describe('item requests', function() {
             assert.contentType(res, 'application/json');
             assert.deepEqual(res.headers['cache-control'], 'no-cache');
             var body = res.body;
-            if (!body['mwAQ'] || typeof body['mwAQ'] !== 'string' || !body['mwCw']) {
+            if (!body['mwAQ'] || typeof body['mwAQ'] !== 'string' || !body['mwDA']) {
                 throw new Error('Missing section content!');
             }
         });

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -111,7 +111,7 @@ describe('item requests', function() {
         return preq.get({
             uri: server.config.labsBucketURL + '/html/Main_Page/262492',
             query: {
-                sections: 'mp-sister,mp-lang'
+                sections: 'mwAQ,mwCw'
             },
             headers: {
                 'cache-control': 'no-cache'
@@ -122,14 +122,14 @@ describe('item requests', function() {
             assert.contentType(res, 'application/json');
             assert.deepEqual(res.headers['cache-control'], 'no-cache');
             var body = res.body;
-            if (!body['mp-sister'] || typeof body['mp-sister'] !== 'string'
-                    || !body['mp-lang']) {
+            if (!body['mwAQ'] || typeof body['mwAQ'] !== 'string'
+                    || !body['mwCw']) {
                 throw new Error('Missing section content!');
             }
             return preq.get({
                 uri: server.config.labsBucketURL + '/html/Main_Page',
                 query: {
-                    sections: 'mp-sister'
+                    sections: 'mwAQ'
                 },
             });
         })
@@ -138,7 +138,7 @@ describe('item requests', function() {
             assert.contentType(res, 'application/json');
             assert.deepEqual(res.headers['cache-control'], 'no-cache');
             var body = res.body;
-            if (!body['mp-sister'] || typeof body['mp-sister'] !== 'string') {
+            if (!body['mwAQ'] || typeof body['mwAQ'] !== 'string') {
                 throw new Error('Missing section content!');
             }
         });
@@ -148,7 +148,7 @@ describe('item requests', function() {
         return preq.get({
             uri: server.config.labsBucketURL + '/html/Main_Page',
             query: {
-                sections: 'mp-sister,mp-lang'
+                sections: 'mwAQ,mwCw'
             },
             headers: {
                 'cache-control': 'no-cache'
@@ -159,8 +159,7 @@ describe('item requests', function() {
             assert.contentType(res, 'application/json');
             assert.deepEqual(res.headers['cache-control'], 'no-cache');
             var body = res.body;
-            if (!body['mp-sister'] || typeof body['mp-sister'] !== 'string'
-            || !body['mp-lang']) {
+            if (!body['mwAQ'] || typeof body['mwAQ'] !== 'string' || !body['mwCw']) {
                 throw new Error('Missing section content!');
             }
         });

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -111,7 +111,7 @@ parallel('transform api', function() {
         .then(function (res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, contentTypes.html);
-            var pattern = /^<h2.*> Heading <\/h2>$/;
+            var pattern = /^<section data-mw-section-id="[^"]+" id="[^"]+"><h2 id="Heading"> Heading <\/h2><\/section>$/;
             if (!pattern.test(res.body)) {
                 throw new Error('Expected pattern in response: ' + pattern
                         + '\nSaw: ' + res.body);
@@ -203,8 +203,8 @@ parallel('transform api', function() {
             body: {
                 changes: {
                     mwAQ: [],
-                    First_Section: [{ html: "<h2>First Section replaced</h2>" }],
-                    Second_Section: [{ html: "<h2>Second Section replaced</h2>" }]
+                    mwAw: [{ html: "<h2>First Section replaced</h2>" }],
+                    mwBA: [{ html: "<h2>Second Section replaced</h2>" }]
                 }
             }
         })
@@ -227,8 +227,8 @@ parallel('transform api', function() {
             body: {
                 changes: JSON.stringify({
                     mwAQ: [],
-                    First_Section: [{ html: "<h2>First Section replaced</h2>" }],
-                    Second_Section: [{ html: "<h2>Second Section replaced</h2>" }]
+                    mwAw: [{ html: "<h2>First Section replaced</h2>" }],
+                    mwBA: [{ html: "<h2>Second Section replaced</h2>" }]
                 }),
                 scrub_wikitext: 'true'
             }
@@ -255,8 +255,8 @@ parallel('transform api', function() {
             body: {
                 changes: {
                     mwAQ: [],
-                    First_Section: [{ html: "<h2></h2>" }],
-                    Second_Section: [{ html: "<h2>Second Section replaced</h2>" }]
+                    mwAw: [{ html: "<h2></h2>" }],
+                    mwBA: [{ html: "<h2>Second Section replaced</h2>" }]
                 },
                 scrub_wikitext: true
             }
@@ -282,8 +282,8 @@ parallel('transform api', function() {
             body: {
                 changes: {
                     mwAQ: [],
-                    First_Section: [{ id: 'First_Section' }, { html: '<h2>Appended Section</h2>' }],
-                    Second_Section: [{ html: '<h2>Prepended section</h2>' }, { id: 'Second_Section'}]
+                    mwAw: [{ id: 'mwAw' }, { html: '<h2>Appended Section</h2>' }],
+                    mwBA: [{ html: '<h2>Prepended section</h2>' }, { id: 'mwBA'}]
                 }
             }
         })
@@ -309,8 +309,8 @@ parallel('transform api', function() {
             body: {
                 changes: {
                     mwAQ: [],
-                    First_Section: [{ id: 'Second_Section' }, { id: 'First_Section' }],
-                    Second_Section: []
+                    mwAw: [{ id: 'mwBA' }, { id: 'mwAw' }],
+                    mwBA: []
                 }
             },
             headers: {
@@ -361,7 +361,7 @@ parallel('transform api', function() {
             + '/' + pageWithSectionsRev,
             body: {
                 changes: {
-                    First_Section:[ { id: 'mwAASDC'}, { id: 'First_Section'} ]
+                    mwAw:[ { id: 'mwAASDC'}, { id: 'mwAw'} ]
                 }
             },
             headers: {

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -111,7 +111,7 @@ parallel('transform api', function() {
         .then(function (res) {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, contentTypes.html);
-            var pattern = /^<section data-mw-section-id="[^"]+" id="[^"]+"><h2 id="Heading"> Heading <\/h2><\/section>$/;
+            var pattern = /^<h2.*> Heading <\/h2>$/;
             if (!pattern.test(res.body)) {
                 throw new Error('Expected pattern in response: ' + pattern
                         + '\nSaw: ' + res.body);
@@ -151,6 +151,7 @@ parallel('transform api', function() {
             body: {
                 html: '<body>The modified HTML</body>'
             }
+
         })
         .then(function (res) {
             assert.deepEqual(res.status, 200);

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -152,6 +152,7 @@ paths:
           required: false
       produces:
         - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
+        - application/json
       responses:
         '200':
           description: |
@@ -405,6 +406,7 @@ paths:
       operationId: getFormatRevision
       produces:
         - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
+        - application/json
       parameters:
         - name: title
           in: path


### PR DESCRIPTION
1. Update section tests expectations
2. In case we're using the content-type upgrade filter with sections it didn't really play well - we were expecting HTML content-type but instead got application/json and tried to upgrade. Fixed that.

cc @wikimedia/services @subbuss 