### PR TITLE
Bump Parsoid html version to 1.6.0

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -107,8 +107,8 @@ wiktionary_project: &wiktionary_project
 # Hacky way to parametrize RESTBase tests. TODO: Move to config?
 test:
   content_types:
-    html: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.5.0"
-    data-parsoid: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.5.0"
+    html: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
+    data-parsoid: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.6.0"
     wikitext: text/plain; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/wikitext/1.0.0"
 
 

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -508,7 +508,7 @@ describe('storage-backed transform api', function() {
             headers: { 'content-type': 'application/json' },
             body: {
                 headers: {
-                  'content-type': 'text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.5.0"'
+                  'content-type': 'text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"'
                 },
                 body: '<html>The modified HTML</html>'
             }

--- a/test/features/specification/swagger.yaml
+++ b/test/features/specification/swagger.yaml
@@ -96,7 +96,7 @@ paths:
           response:
             status: 200
             headers:
-              content-type: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.5.0"
+              content-type: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
 
   /{domain}/v1/page/html/{title}/{revision}:
     get:
@@ -147,7 +147,7 @@ paths:
           response:
             status: 200
             headers:
-              content-type: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.5.0"
+              content-type: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
 
 definitions:
   defaultError:

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -151,7 +151,7 @@ paths:
           type: boolean
           required: false
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.5.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
       responses:
         '200':
           description: |
@@ -404,7 +404,7 @@ paths:
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       operationId: getFormatRevision
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.5.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
       parameters:
         - name: title
           in: path
@@ -532,7 +532,7 @@ paths:
 
         Stability: [Stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       produces:
-        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.5.0"
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.6.0"
       parameters:
         - name: title
           in: path

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -124,7 +124,7 @@ paths:
       consumes:
         - multipart/form-data
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.5.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
       parameters:
         - name: title
           in: path
@@ -293,7 +293,7 @@ paths:
 #      consumes:
 #        - multipart/form-data
 #      produces:
-#        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.5.0"
+#        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
 #      parameters:
 #        - name: title
 #          in: path


### PR DESCRIPTION
In preparation for deploy.

The tests will fail right now cause Parsoid is not deployed. To make the tests pass we need to
1. Deploy version bump to beta
2. Merge #919 
3. Rebase this one

cc @wikimedia/services @subbuss 