### PR TITLE
Remove falling back to old storage for non-found pagebundle

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -176,7 +176,6 @@ class ParsoidService {
         // Set up operations
         this.operations = {
             getPageBundle: this.pagebundle.bind(this),
-            getStoredPageBundle: this.getStoredPageBundle.bind(this),
             // Revision retrieval per format
             getWikitext: this.getFormat.bind(this, 'wikitext'),
             getHtml: this.getFormat.bind(this, 'html'),
@@ -244,30 +243,12 @@ class ParsoidService {
     pagebundle(hyper, req) {
         const rp = req.params;
         const domain = rp.domain;
-        const storedContentUri = [domain, 'sys', 'parsoid_old', 'stored_pagebundle', rp.title];
-        if (rp.revision) {
-            storedContentUri.push(rp.revision);
-        }
-        return hyper.get(new URI(storedContentUri))
-        .catch({ status: 404 }, (e) => {
-            // Don't have it in old storage. Generate.
-            const newReq = Object.assign({}, req);
-            if (!newReq.method) { newReq.method = 'get'; }
-            const path = (newReq.method === 'get') ? 'page' : 'transform/wikitext/to';
-            newReq.uri = `${this.parsoidHost}/${domain}/v3/${path}/pagebundle/`
-                + `${encodeURIComponent(rp.title)}/${rp.revision}`;
-            return hyper.request(newReq);
-        });
-
-    }
-
-    getStoredPageBundle(hyper, req) {
-        throw new HTTPError({
-            status: 500,
-            body: {
-                message: 'getStoredPageBundle must not be called on new parsoid module'
-            }
-        });
+        const newReq = Object.assign({}, req);
+        if (!newReq.method) { newReq.method = 'get'; }
+        const path = (newReq.method === 'get') ? 'page' : 'transform/wikitext/to';
+        newReq.uri = `${this.parsoidHost}/${domain}/v3/${path}/pagebundle/`
+            + `${encodeURIComponent(rp.title)}/${rp.revision}`;
+        return hyper.request(newReq);
     }
 
     saveParsoidResultToLatest(hyper, req, tid, parsoidResp) {

--- a/sys/parsoid.yaml
+++ b/sys/parsoid.yaml
@@ -15,11 +15,6 @@ paths:
       summary: Retrieve a JSON bundle containing html and data-parsoid
       operationId: getPageBundle
 
-  /stored_pagebundle/{title}{/revision}:
-    get:
-      summary: Retrieve a JSON bundle containing html and data-parsoid
-      operationId: getStoredPageBundle
-
   /wikitext/{title}/:
     get:
       summary: List Wikitext revisions.

--- a/sys/parsoid_old.js
+++ b/sys/parsoid_old.js
@@ -196,7 +196,6 @@ class ParsoidService {
         // Set up operations
         this.operations = {
             getPageBundle: this.pagebundle.bind(this),
-            getStoredPageBundle: this.getStoredPageBundle.bind(this),
             // Revision retrieval per format
             getWikitext: this.getFormat.bind(this, 'wikitext'),
             getHtml: this.getFormat.bind(this, 'html'),
@@ -245,20 +244,6 @@ class ParsoidService {
         newReq.uri = `${this.parsoidHost}/${domain}/v3/${path}/pagebundle/`
             + `${encodeURIComponent(rp.title)}/${rp.revision}`;
         return hyper.request(newReq);
-    }
-
-    getStoredPageBundle(hyper, req) {
-        const rp = req.params;
-        return P.props({
-            html: hyper.get(this.getBucketURI(rp, 'html')),
-            'data-parsoid': hyper.get(this.getBucketURI(rp, 'data-parsoid'))
-        })
-        .then((results) => {
-            return {
-                status: 200,
-                body: results
-            };
-        });
     }
 
     saveParsoidResult(hyper, req, format, tid, parsoidResp) {

--- a/sys/parsoid_proxy.js
+++ b/sys/parsoid_proxy.js
@@ -22,14 +22,6 @@ class ParsoidProxy {
         // Set up operations
         this.operations = {
             getPageBundle: this.pagebundle.bind(this),
-            getStoredPageBundle: (hyper, req) => {
-                throw new HTTPError({
-                    status: 500,
-                    body: {
-                        message: 'getStoredPageBundle must not be called on new parsoid proxy'
-                    }
-                });
-            },
             // Revision retrieval per format
             getWikitext: this.getFormat.bind(this, 'wikitext'),
             getHtml: this.getFormat.bind(this, 'html'),


### PR DESCRIPTION
When switching to the new storage before we've implemented a way to avoid reparsing the content, because we've already had it in the Cassandra 2 storage - in case a GET request to Parsoid had to be issues we've just checked the old storage (without no-cache header) to see whether we can reuse the content. That worked perfectly without Parsed version bump, but it actually prevents reparising with the pretense of the version bump.

cc @wikimedia/services @subbuss @arlolra 