### PR TITLE
Try old bucket in case original content TID was not matching with the received TID

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -883,7 +883,7 @@ class ParsoidService {
         })
         .then((res) => {
             const parsedTid = mwUtil.parseETag(res.html.headers.etag).tid;
-            if (parsedTid !== tid) {
+            if (tid && parsedTid !== tid) {
                 const storedContentUri = [rp.domain, 'sys',
                     'parsoid_old', 'stored_pagebundle', rp.title];
                 if (rp.revision) {

--- a/sys/parsoid.yaml
+++ b/sys/parsoid.yaml
@@ -15,6 +15,11 @@ paths:
       summary: Retrieve a JSON bundle containing html and data-parsoid
       operationId: getPageBundle
 
+  /stored_pagebundle/{title}{/revision}{/tid}:
+    get:
+      summary: Retrieve a JSON bundle containing html and data-parsoid
+      operationId: getStoredPageBundle
+
   /wikitext/{title}/:
     get:
       summary: List Wikitext revisions.

--- a/sys/parsoid_old.js
+++ b/sys/parsoid_old.js
@@ -196,6 +196,7 @@ class ParsoidService {
         // Set up operations
         this.operations = {
             getPageBundle: this.pagebundle.bind(this),
+            getStoredPageBundle: this.getStoredPageBundle.bind(this),
             // Revision retrieval per format
             getWikitext: this.getFormat.bind(this, 'wikitext'),
             getHtml: this.getFormat.bind(this, 'html'),
@@ -244,6 +245,20 @@ class ParsoidService {
         newReq.uri = `${this.parsoidHost}/${domain}/v3/${path}/pagebundle/`
             + `${encodeURIComponent(rp.title)}/${rp.revision}`;
         return hyper.request(newReq);
+    }
+
+    getStoredPageBundle(hyper, req) {
+        const rp = req.params;
+        return P.props({
+            html: hyper.get(this.getBucketURI(rp, 'html', rp.tid)),
+            'data-parsoid': hyper.get(this.getBucketURI(rp, 'data-parsoid', rp.tid))
+        })
+        .then((results) => {
+            return {
+                status: 200,
+                body: results
+            };
+        });
     }
 
     saveParsoidResult(hyper, req, format, tid, parsoidResp) {

--- a/sys/parsoid_proxy.js
+++ b/sys/parsoid_proxy.js
@@ -22,6 +22,14 @@ class ParsoidProxy {
         // Set up operations
         this.operations = {
             getPageBundle: this.pagebundle.bind(this),
+            getStoredPageBundle: (hyper, req) => {
+                throw new HTTPError({
+                    status: 500,
+                    body: {
+                        message: 'getStoredPageBundle must not be called on new parsoid proxy'
+                    }
+                });
+            },
             // Revision retrieval per format
             getWikitext: this.getFormat.bind(this, 'wikitext'),
             getHtml: this.getFormat.bind(this, 'html'),


### PR DESCRIPTION
Seems like we don't need this after all.

Bug: https://phabricator.wikimedia.org/T182728

cc @wikimedia/services @subbuss 