### PR TITLE
Only use fallback storage if the specific revision is requested.

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -223,8 +223,14 @@ class ParsoidService {
         return hyper.get({
             uri: this.getNGBucketURI(rp, format, tid)
         })
-        .catch({ status: 404 }, () => hyper.get({
-            uri: this.getFallbackBucketURI(rp, format, tid)
+        .catch({ status: 404 }, (e) => {
+            if (rp.revision) {
+                return hyper.get({
+                    uri: this.getFallbackBucketURI(rp, format, tid)
+                });
+            } else {
+                throw e;
+            }
         })
         .then((res) => {
             // Now check the result ETag and see if the content is close to expiration

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -243,7 +243,7 @@ class ParsoidService {
                 });
             }
             return res;
-        }));
+        });
     }
 
     pagebundle(hyper, req) {


### PR DESCRIPTION
The fallback storage exists for VE edits of non-latest revisions,
so it doesn't really make sence to check there if the revision is
not specified - we will unlikely return what we inteded to - the
latest revision. We can retun something old or even previously stashed
content.

Bug: T179417
cc @wikimedia/services 