### PR TITLE
Rewrite URIs to HTTPS in summary thumbnails.

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -46,6 +46,8 @@ default_project: &default_project
           cache-control: s-maxage=864000, max-age=86400
         mobileapps:
           host: https://appservice.wmflabs.org
+        summary:
+          host: https://appservice.wmflabs.org
         citoid:
           host: https://citoid-beta.wmflabs.org
         recommendation:

--- a/v1/summary.js
+++ b/v1/summary.js
@@ -17,55 +17,61 @@ const entities = require('entities');
  */
 const TAGS_MATCH = /<\/?[a-zA-Z][\w-]*(?:\s+[a-zA-Z_\-:]+(?:=\\?(?:"[^"]*"|'[^']*'))?)*\s*\/?>/g;
 
+const functions = {
+    // Add a utility function to the global scope, so that it can be
+    // called in the response template.
+    httpsSource(thumb) {
+        if (!thumb) {
+            return thumb;
+        }
+        if (thumb.source) {
+            thumb.source = thumb.source.replace(/^http:/, 'https:');
+        }
+        if (thumb.original) {
+            thumb.original = thumb.original.replace(/^http:/, 'https:');
+        }
+        return thumb;
+    },
+    httpsSourceAll(summary) {
+        summary.thumbnail = functions.httpsSource(summary.thumbnail);
+        summary.originalimage = functions.httpsSource(summary.originalimage);
+        return summary;
+    },
+    getRevision(revItems) {
+        if (Array.isArray(revItems) && revItems.length) {
+            return revItems[0];
+        }
+        return {};
+    },
+    extractDescription(terms) {
+        if (terms && terms.description && terms.description.length) {
+            return terms.description[0];
+        }
+    },
+    processCoords(coords) {
+        if (!coords || !coords.length) {
+            return undefined;
+        }
+
+        const coord = coords[0];
+        delete coord.primary;
+        delete coord.globe;
+        if (coord.lat === undefined || coord.lon === undefined) {
+            // These properties are required, so double check they exist
+            return undefined;
+        }
+        return coord;
+    },
+    stripTags(extract) {
+        if (!extract) {
+            return "";
+        }
+
+        return entities.decodeHTML(extract.replace(TAGS_MATCH, ''));
+    }
+};
+
 module.exports = options => ({
     spec: options.implementation === 'mcs' ? newSpec : spec,
-    globals: {
-        options,
-        // Add a utility function to the global scope, so that it can be
-        // called in the response template.
-        httpsSource(thumb) {
-            if (!thumb) {
-                return thumb;
-            }
-            if (thumb.source) {
-                thumb.source = thumb.source.replace(/^http:/, 'https:');
-            }
-            if (thumb.original) {
-                thumb.original = thumb.original.replace(/^http:/, 'https:');
-            }
-            return thumb;
-        },
-        getRevision(revItems) {
-            if (Array.isArray(revItems) && revItems.length) {
-                return revItems[0];
-            }
-            return {};
-        },
-        extractDescription(terms) {
-            if (terms && terms.description && terms.description.length) {
-                return terms.description[0];
-            }
-        },
-        processCoords(coords) {
-            if (!coords || !coords.length) {
-                return undefined;
-            }
-
-            const coord = coords[0];
-            delete coord.primary;
-            delete coord.globe;
-            if (coord.lat === undefined || coord.lon === undefined) {
-                // These properties are required, so double check they exist
-                return undefined;
-            }
-            return coord;
-        },
-        stripTags(extract) {
-            if (!extract) {
-                return "";
-            }
-
-            return entities.decodeHTML(extract.replace(TAGS_MATCH, ''));
-        }
-    }
+    globals: Object.assign({ options }, functions)
 });

--- a/v1/summary_new.yaml
+++ b/v1/summary_new.yaml
@@ -113,6 +113,10 @@ paths:
             request:
               method: get
               uri: '{{options.host}}/{domain}/v1/page/summary/{title}'
+            return:
+              status: '{{extract.status}}'
+              headers: '{{extract.headers}}'
+              body: '{{httpsSourceAll(extract.body)}}'
         - store_and_return:
             request:
               method: put


### PR DESCRIPTION
The thumbnails are coming from the PageImages extension,
which emits URIs with the same protocol as the request.

PageImages are contacted by MCS inside the production cluster,
so the request uses HTTP, not HTTPS - so when service to the clients,
the protocol should be rewritten.

Bug: T179875

cc @wikimedia/services 