### PR TITLE
Parsoid: Add the time_to_live config option to projects

### DIFF
--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -83,6 +83,8 @@ paths:
                   options:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
+                    grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
+                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
             /parsoid_bucket:
               x-modules:
                 - path: sys/multi_content_bucket.js

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -57,6 +57,7 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
+                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
             /parsoid_bucket:
               x-modules:
                 - path: sys/multi_content_bucket.js

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -166,6 +166,7 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
+                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
                     # A list of pages that we don't currently want to re-render on
                     # each edit. Most of these are huge bot-edited pages, which are
                     # rarely viewed in any case.

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -166,6 +166,7 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
+                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
                     # A list of pages that we don't currently want to re-render on
                     # each edit. Most of these are huge bot-edited pages, which are
                     # rarely viewed in any case.

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -143,6 +143,7 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
+                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
             /events:
               x-modules:
                 - path: sys/events.js

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -155,6 +155,7 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
+                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.js


### PR DESCRIPTION
The Parsoid module uses the time_to_live configuration option to determine whether content has half-expired and thus needs to be re-rendered. Alas, this config option if not passed to it by the projects. This PR fixes that.