### PR TITLE
Fix duplicate pages in on this day results.

### DIFF
--- a/v1/onthisday.js
+++ b/v1/onthisday.js
@@ -26,18 +26,18 @@ class Feed extends BaseFeed {
                 [req.params.type]: res.body[req.params.type]
             };
         }
-        let hydratedResponse = super._hydrateResponse(hyper, req, res);
+        const hydratedResponse = super._hydrateResponse(hyper, req, res);
 
         // Hydration resolves re-directs so we need to de-dupe titles here *after* hydration.
         const removeDuplicateTitlesFromHydratedResponsePages = (response) => {
-          Object.keys(response.body).forEach(key => {
-            response.body[key].forEach(event => {
-              event.pages = event.pages.filter(
-                (item1, index, self) =>
-                  self.findIndex(item2 => item2.title === item1.title) === index
-              )
+            Object.keys(response.body).forEach((key) => {
+                response.body[key].forEach((event) => {
+                    event.pages = event.pages.filter(
+                        (item1, index, self) =>
+                            self.findIndex(item2 => item2.title === item1.title) === index
+                    );
+                });
             });
-          });
         };
 
         return hydratedResponse

--- a/v1/onthisday.js
+++ b/v1/onthisday.js
@@ -47,7 +47,7 @@ class Feed extends BaseFeed {
                 });
             });
             return response;
-        }
+        };
         return super._hydrateResponse(hyper, req, res)
         .then(removeDuplicateTitlesFromHydratedResponsePages);
     }


### PR DESCRIPTION
The `events` for the following days are examples having dupe pages:

`onthisday/events/09/14`
"Telecommunications companies MCI Communications and WorldCom complete their $37 billion merger to form MCI WorldCom."

`onthisday/events/09/01`
"St. Petersburg, Russia, changes its name to Petrograd."

Bug: T175974