### PR TITLE
Recommendation API: Expand the route with article/creation/

### DIFF
--- a/v1/recommend.yaml
+++ b/v1/recommend.yaml
@@ -7,7 +7,7 @@ info:
     name: Apache license, v2
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
-  /recommendation/translation/{from_lang}{/seed_article}:
+  /recommendation/article/creation/translation/{from_lang}{/seed_article}:
     get:
       tags:
         - Recommendation


### PR DESCRIPTION
Originally, the recommendation API route supposed that the recommendation is about article creation. However, since other types of recommendation might be possible in the future, put that explicitly in the route's path.

Bug: [T170877](https://phabricator.wikimedia.org/T170877)