### PR TITLE
Add pageviews by country endpoint

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -283,6 +283,72 @@ paths:
                 x-client-ip: '{{x-client-ip}}'
       x-monitor: false
 
+  /pageviews/top-by-country/{project}/{access}/{year}/{month}:
+    get:
+      tags:
+        - Pageviews data
+      summary: Get pageviews by country and access method.
+      description: |
+        Lists the pageviews to this project, split by country of origin for a given month.
+        Because of privacy reasons, pageviews are given in a bucketed format, and countries
+        with less than 100 views do not get reported.
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 100 req/s
+        - License: Data accessible via this endpoint is available under the
+          [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
+      produces:
+        - application/json
+      parameters:
+        - name: project
+          in: path
+          description: |
+            If you want to filter by project, use the domain of any Wikimedia project,
+            for example 'en.wikipedia.org', 'www.mediawiki.org' or 'commons.wikimedia.org'.
+          type: string
+          required: true
+        - name: access
+          in: path
+          description: |
+            If you want to filter by access method, use one of desktop, mobile-app or mobile-web.
+            If you are interested in pageviews regardless of access method, use all-access.
+          type: string
+          enum: ['all-access', 'desktop', 'mobile-app', 'mobile-web']
+          required: true
+        - name: year
+          in: path
+          description: The year of the date for which to retrieve top countries, in YYYY format.
+          type: string
+          required: true
+        - name: month
+          in: path
+          description: |
+            The month of the date for which to retrieve top countries, in MM format.
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of top countries by pageviews in the project
+          schema:
+            $ref: '#/definitions/by-country'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 100
+              external: 100
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/pageviews/top-by-country/{project}/{access}/{year}/{month}'
+              headers:
+                x-client-ip: '{{x-client-ip}}'
+      x-monitor: false
+
   ########################################
   # Unique Devices
   ########################################
@@ -1707,6 +1773,24 @@ definitions:
               type: string
             articles:
               # format for this is a json array: [{rank: 1, article: <<title>>, views: 123}, ...]
+              type: string
+
+  by-country:
+    properties:
+      items:
+        type: array
+        items:
+          properties:
+            project:
+              type: string
+            access:
+              type : string
+            year:
+              type: string
+            month:
+              type: string
+            countries:
+              # format for this is a json array: [{rank: 1, country: <<name>>, views: 123}, ...]
               type: string
 
   unique-devices:

--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -1790,8 +1790,17 @@ definitions:
             month:
               type: string
             countries:
-              # format for this is a json array: [{rank: 1, country: <<name>>, views: 123}, ...]
-              type: string
+              type: array
+              items:
+                properties:
+                  rank:
+                    type: integer
+                    format: int32
+                  country:
+                    type: string
+                  views:
+                    type: integer
+                    format: int64
 
   unique-devices:
     properties:


### PR DESCRIPTION
This PR adds the endpoint for top by country pageviews metric. Analytics Query Service backend for it is already deployed.

Phab task: https://phabricator.wikimedia.org/T181520

cc @jobar @d00rman @Pchelolo :)