### PR TITLE
Update pageviews top response definition

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -1772,8 +1772,18 @@ definitions:
             day:
               type: string
             articles:
-              # format for this is a json array: [{rank: 1, article: <<title>>, views: 123}, ...]
-              type: string
+              type: array
+              items:
+                properties:
+                  rank:
+                    type: integer
+                    format: int32
+                  article:
+                    type: string
+                  views:
+                    type: integer
+                    format: int64
+
 
   by-country:
     properties:


### PR DESCRIPTION
The endpoint used to send a string as a response (a json formatted
string, but a string nonetheless). When restbase-cassandra got a JSON
type, we updated the actual response but forgot to update the definition.
Here it is.

Bug: T184541