### PR TITLE
Normalize namings of cache-control options.

### DIFF
--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -15,10 +15,11 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
-                  options: '{{options}}'
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/content_segments.yaml
                   options:
-                      purged_cache_control: '{{options.purged_cache_control}}'
+                      response_cache_control: '{{options.purged_cache_control}}'
                       cx_host: '{{options.transform.cx_host}}'
                 - path: v1/common_schemas.yaml # Doesn't really matter where to mount it.
                 - path: v1/mobileapps.yaml

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -15,7 +15,8 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
-                  options: '{{options}}'
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/common_schemas.yaml # Doesn't really matter where to mount it.
             /transform:
               x-modules:

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -59,10 +59,11 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
-                  options: '{{options}}'
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/content_segments.yaml
                   options:
-                    purged_cache_control: '{{options.purged_cache_control}}'
+                    response_cache_control: '{{options.purged_cache_control}}'
                     cx_host: '{{options.transform.cx_host}}'
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -59,10 +59,11 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
-                  options: '{{options}}'
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/content_segments.yaml
                   options:
-                    purged_cache_control: '{{options.purged_cache_control}}'
+                    response_cache_control: '{{options.purged_cache_control}}'
                     cx_host: '{{options.transform.cx_host}}'
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -59,10 +59,11 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
-                  options: '{{options}}'
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/content_segments.yaml
                   options:
-                    purged_cache_control: '{{options.purged_cache_control}}'
+                    response_cache_control: '{{options.purged_cache_control}}'
                     cx_host: '{{options.transform.cx_host}}'
                 - path: v1/graphoid.yaml
                   options: '{{options.graphoid}}'

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -62,10 +62,11 @@ paths:
             /page:
               x-modules:
                 - path: v1/content.yaml
-                  options: '{{options}}'
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
                 - path: v1/content_segments.yaml
                   options:
-                    purged_cache_control: '{{options.purged_cache_control}}'
+                    response_cache_control: '{{options.purged_cache_control}}'
                     cx_host: '{{options.transform.cx_host}}'
                 - path: v1/mobileapps.yaml
                   options: '{{merge({"response_cache_control": options.purged_cache_control},

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -7,7 +7,6 @@ var mwUtil = require('../../../lib/mwUtil');
 var assert = require('../../utils/assert.js');
 var preq   = require('preq');
 var server = require('../../utils/server.js');
-var nock = require('nock');
 
 describe('Redirects', function() {
     before(function() { return server.start(); });
@@ -21,6 +20,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 301);
             assert.deepEqual(res.headers['location'], 'Main_Page?test=mwAQ');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
         });
     });
 
@@ -32,6 +32,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 301);
             assert.deepEqual(res.headers['location'], '../Main_Page/1234?test=mwAQ');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
         });
     });
 
@@ -43,6 +44,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 301);
             assert.deepEqual(res.headers['location'], '../Main_Page/');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
         });
     });
 
@@ -58,6 +60,7 @@ describe('Redirects', function() {
             assert.deepEqual(res.status, 200);
         });
     });
+
     it('should redirect to commons for missing file pages', function() {
         return preq.get({
             uri: server.config.bucketURL + '/html/File:ThinkingMan_Rodin.jpg',
@@ -67,6 +70,7 @@ describe('Redirects', function() {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers['location'],
                 'https://commons.wikimedia.org/api/rest_v1/page/html/File%3AThinkingMan_Rodin.jpg');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
         });
     });
 
@@ -79,6 +83,7 @@ describe('Redirects', function() {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers['location'],
                 'https://commons.wikimedia.org/api/rest_v1/page/html/File%3AName.jpg');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
         });
     });
 
@@ -286,6 +291,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.body.length, 0);
         });
     });
@@ -298,6 +304,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.body.length, 0);
         });
     });
@@ -310,6 +317,7 @@ describe('Redirects', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 302);
             assert.deepEqual(res.headers.location, 'User%3APchelolo%2FRedirect_Target_%25');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.body.length, 0);
         });
     });

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -118,7 +118,7 @@ paths:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
         options:
-          redirect_cache_control: '{{options.purged_cache_control}}'
+          redirect_cache_control: '{{options.response_cache_control}}'
           attach_body_to_redirect: true
       - path: lib/security_response_header_filter.js
         options:
@@ -390,7 +390,7 @@ paths:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
         options:
-          redirect_cache_control: '{{options.purged_cache_control}}'
+          redirect_cache_control: '{{options.response_cache_control}}'
           attach_body_to_redirect: true
       - path: lib/security_response_header_filter.js
         options:
@@ -515,7 +515,7 @@ paths:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
         options:
-          redirect_cache_control: '{{options.purged_cache_control}}'
+          redirect_cache_control: '{{options.response_cache_control}}'
           attach_body_to_redirect: true
     get:
       tags:

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -7,7 +7,7 @@ paths:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
         options:
-          redirect_cache_control: '{{options.purged_cache_control}}'
+          redirect_cache_control: '{{options.response_cache_control}}'
     get:
       tags:
         - Mobile
@@ -106,7 +106,7 @@ paths:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
         options:
-          redirect_cache_control: '{{options.purged_cache_control}}'
+          redirect_cache_control: '{{options.response_cache_control}}'
     get:
       tags:
         - Mobile
@@ -190,7 +190,7 @@ paths:
     x-route-filters:
       - path: ./lib/revision_table_access_check_filter.js
         options:
-          redirect_cache_control: '{{options.purged_cache_control}}'
+          redirect_cache_control: '{{options.response_cache_control}}'
     get:
       tags:
         - Mobile


### PR DESCRIPTION
Due to non-normalized namings of the options parameters
related to cache-control response headers we didn't really specify
the parameter for mobile-related content for redirect responses
and fallback on default value `no-cache`.

Now all the `v1/*` and `sys/*` components use only `response_cache_control`
name, while the `projects/*` set the params to values appropriate
for a particular module.

Bug: T184833