### PR TITLE
Tag mobile-sections resource_change events.

### DIFF
--- a/sys/mobileapps.js
+++ b/sys/mobileapps.js
@@ -87,7 +87,8 @@ class MobileApps {
                 purgeEvents = purgeEvents.concat(postfixes.map(postfix => ({
                     meta: {
                         uri: `${prefix}${postfix}/${title}`
-                    }
+                    },
+                    tags: [ `mobile-sections${postfix}` ]
                 })));
             }
 


### PR DESCRIPTION
For easier matching of mobile-sections events in ChangeProp
we should tag the events with the name of the endpoint.

For https://phabricator.wikimedia.org/T184753
cc @wikimedia/services @berndsi 