### PR TITLE
Do not emit a warning if the actual spec is newer then expected

### DIFF
--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -32,22 +32,6 @@ function checkContentType(hyper, req, next, expectedContentType, responsePromise
             return res;
         }
 
-        function updateSpecWarning() {
-            // Returned content type version is higher than what the
-            // spec promises.
-            if (Math.random() < 0.001) {
-                // Log a warning about the need to update the spec. Sampled 1:1000.
-                hyper.log('warn/content-type/spec_outdated', {
-                    msg: 'The Swagger spec needs updating to reflect latest content type'
-                        + ' returned by the service.',
-                    expected: expectedContentType,
-                    actual: res.headers['content-type']
-                });
-            }
-            // Don't fail the request.
-            return res;
-        }
-
         if (res.headers && res.headers === undefined) {
             delete res.headers['content-type'];
         }
@@ -61,14 +45,14 @@ function checkContentType(hyper, req, next, expectedContentType, responsePromise
 
             if (actualProfile && actualProfile !== expectedProfile) {
                 if (!expectedProfile) {
-                    return updateSpecWarning();
+                    return res;
                 }
                 // Check if actual content type is newer than the spec
                 const actualProfileParts = splitProfile(actualProfile);
                 const expectedProfileParts = splitProfile(expectedProfile);
                 if (actualProfileParts.path === expectedProfileParts.path
                         && actualProfileParts.version > expectedProfileParts.version) {
-                    return updateSpecWarning();
+                    return res;
                 }
             }
 


### PR DESCRIPTION
There's no need to spoil the logs with the useless spec update warning. The filter should be used just to force-update the content when it's required. The log warning doesn't make a lot of sence, it's just spamming.

cc @wikimedia/services @berndsi 