### PR TITLE
Use regexes to generalize content-type expectations in tests

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -89,9 +89,9 @@ wiktionary_project: &wiktionary_project
 # Hacky way to parametrize RESTBase tests. TODO: Move to config?
 test:
   content_types:
-    html: '/text\/html; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/HTML\/[\d.]+"$/'
-    data-parsoid: '/application\/json; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/data-parsoid/[\d.]+"/'
-    wikitext: '/text\/plain; charset=utf-8; profile="https:\/\/www.mediawiki.org\/wiki\/Specs\/wikitext\/[\d.]+"/'
+    html: '/^text\/html; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/HTML\/[\d.]+"$/'
+    data-parsoid: '/^application\/json; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/data-parsoid/[\d.]+"$/'
+    wikitext: '/^text\/plain; charset=utf-8; profile="https:\/\/www.mediawiki.org\/wiki\/Specs\/wikitext\/[\d.]+"$/'
 
 
 # The root of the spec tree. Domains tend to share specs by referencing them

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -89,9 +89,9 @@ wiktionary_project: &wiktionary_project
 # Hacky way to parametrize RESTBase tests. TODO: Move to config?
 test:
   content_types:
-    html: text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
-    data-parsoid: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.6.0"
-    wikitext: text/plain; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/wikitext/1.0.0"
+    html: '/text\/html; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/HTML\/[\d.]+"$/'
+    data-parsoid: '/application\/json; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/data-parsoid/[\d.]+"/'
+    wikitext: '/text\/plain; charset=utf-8; profile="https:\/\/www.mediawiki.org\/wiki\/Specs\/wikitext\/[\d.]+"/'
 
 
 # The root of the spec tree. Domains tend to share specs by referencing them

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -181,7 +181,7 @@ describe('Redirects', function() {
                 assert.deepEqual(res.status, 302);
                 assert.deepEqual(res.headers.location, '../../User%3APchelolo%2FRedirect_Target_%25');
                 assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
-                assert.deepEqual(res.headers['content-type'], server.config.conf.test.content_types['data-parsoid']);
+                assert.contentType(res, server.config.conf.test.content_types['data-parsoid']);
                 assert.deepEqual(Object.keys(res.body).length > 0, true);
             });
         });

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -1,15 +1,19 @@
 'use strict';
 
-var assert = require('assert');
-
+const assert = require('assert');
+const mwUtil = require('../../lib/mwUtil');
 
 /**
  * Asserts whether content type was as expected
  */
 function contentType(res, expected) {
-    var actual = res.headers['content-type'];
-    deepEqual(actual, expected,
-        'Expected content-type to be ' + expected + ', but was ' + actual);
+    const actual = res.headers['content-type'];
+    if (/^\/.+\/$/.test(expected)) {
+        const expectedRegex = mwUtil.constructRegex([ expected ]);
+        assert.ok(expectedRegex.test(actual), `Expected content type should match ${expected}`);
+    } else {
+        deepEqual(actual, expected, `Expected content-type to be ${expected} , but was ${actual}`);
+    }
 }
 
 /**


### PR DESCRIPTION
From time to time Parsoid bumps the content-type version which breaks RESTBase tests that expect a specific content-type version to be served. I don't think that expecting the exact version number in tests provides any value and is kinda painful cause we need to update RESTBase every time the version in PArsoid is bumped. Let's use less restrictive regexes to match the version.

cc @wikimedia/services @subbuss @arlolra 