### PR TITLE
Fix namespaces issues when generating PDFs

### DIFF
--- a/v1/pdf.yaml
+++ b/v1/pdf.yaml
@@ -60,8 +60,7 @@ paths:
         - get_pdf_from_backend:
             request:
               method: get
-              # Note: The title needs to be encoded twice.
-              uri: '{{options.uri}}/pdf?accessKey={options.secret}&url={{default(options.scheme, "https")}}://{{domain}}/wiki/{_encodeURIComponent(title)}%3Fprintable=yes'
+              uri: '{{options.uri}}/pdf?accessKey={options.secret}&url={_encodeUriComponent(default(options.scheme, "https") + "://" + domain + "/wiki/" + title + "/printable=yes")}'
             return:
               status: 200
               headers:


### PR DESCRIPTION
Hello,

Don't merge this as it is not working.

I need your guidance:

- why do some parameters use one `{` and others two `{{` ?
- why doesn't my fix work?

The goal is to url encode the whole `url` parameter, otherwise it fails for wikis that use namespaces (it url-encodes the slash that is part of the title, but not the slash that is part of `http://` and the pdf electron service is confused). Also maybe it encodes the title twices?

At the moment the only fix that works is:

 ```
uri: '{{options.uri}}/pdf?accessKey={options.secret}&url={{default(options.scheme, "https")}}://{{domain}}/wiki/{title}%3Fprintable=yes'
```