### PR TITLE
Expose lint errors for a page/revision via a GET request.

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -778,7 +778,7 @@ class ParsoidService {
         let path = `${this.parsoidHost}/${rp.domain}/v3/transform/`
             + `wikitext/to/lint/${encodeURIComponent(rp.title)}`;
         if (rp.revision) {
-            path += `/${rp.revision}`
+            path += `/${rp.revision}`;
         }
         return hyper.post({ uri: path });
     }

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -180,6 +180,7 @@ class ParsoidService {
             getWikitext: this.getFormat.bind(this, 'wikitext'),
             getHtml: this.getFormat.bind(this, 'html'),
             getDataParsoid: this.getFormat.bind(this, 'data-parsoid'),
+            getLintErrors: this.getLintErrors.bind(this),
             // Listings
             listWikitextRevisions: this.listRevisions.bind(this, 'wikitext'),
             listHtmlRevisions: this.listRevisions.bind(this, 'html'),
@@ -770,6 +771,15 @@ class ParsoidService {
         }
         return transformPromise;
 
+    }
+
+    getLintErrors(hyper, req) {
+        const rp = req.params;
+        let path = `${this.parsoidHost}/${rp.domain}/v3/transform/wikitext/to/lint/${rp.title}`;
+        if (rp.revision) {
+            path += `/${rp.revision}`
+        }
+        return hyper.post({ uri: path });
     }
 
     makeTransform(from, to) {

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -775,7 +775,8 @@ class ParsoidService {
 
     getLintErrors(hyper, req) {
         const rp = req.params;
-        let path = `${this.parsoidHost}/${rp.domain}/v3/transform/wikitext/to/lint/${rp.title}`;
+        let path = `${this.parsoidHost}/${rp.domain}/v3/transform/`
+            + `wikitext/to/lint/${encodeURIComponent(rp.title)}`;
         if (rp.revision) {
             path += `/${rp.revision}`
         }

--- a/sys/parsoid.yaml
+++ b/sys/parsoid.yaml
@@ -63,6 +63,11 @@ paths:
       summary: Retrieve the data-parsoid JSON for title & revision.
       operationId: getDataParsoid
 
+  /lint/{title}{/revision}:
+    get:
+      summary: Retreive the lint errors for a specific page revision
+      operationId: getLintErrors
+
   /transform/html/to/html{/title}{/revision}:
     post:
       summary: Update HTML, while optionally passing in title & revision.

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -68,6 +68,26 @@ describe('item requests', function() {
         });
     });
 
+    it('should request page lints. no revision', () => {
+        return preq.get({
+            uri: `${server.config.bucketURL}/lint/User%3APchelolo%2FLintTest`
+        })
+        .then((res) => {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.length > 0, true);
+        })
+    });
+
+    it('should request page lints. with revision', () => {
+        return preq.get({
+            uri: `${server.config.bucketURL}/lint/User%3APchelolo%2FLintTest/830278619`
+        })
+        .then((res) => {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.body.length > 0, true);
+        })
+    });
+
     var rev2Etag;
     it('should transparently create data-parsoid with id 241155, rev 2', function() {
         return preq.get({

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -624,7 +624,6 @@ paths:
       summary: Get the linter errors for a specific title/revision.
       description: |
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-      operationId: getFormatRevision
       produces:
         - application/json
       parameters:

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -612,6 +612,80 @@ paths:
                 x-restbase-parentrevision: '{{x-restbase-parentrevision}}'
       x-monitor: false
 
+  /lint/{title}{/revision}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
+        options:
+          redirect_cache_control: '{{options.response_cache_control}}'
+      - path: lib/security_response_header_filter.js
+    get:
+      tags:
+        - Page content
+      summary: Get the linter errors for a specific title/revision.
+      description: |
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      operationId: getFormatRevision
+      produces:
+        - application/json
+      parameters:
+        - name: title
+          in: path
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: The revision
+          type: integer
+          required: false
+      responses:
+        '200':
+          description: |
+            The lint errors for the given page and optionally revision.
+
+            See [the Linter extension docs](https://www.mediawiki.org/wiki/Extension:Linter) for more
+            details.
+          schema:
+            - type: object
+          headers:
+        '301':
+          description: |
+            A permanent redirect is returned if the supplied article title was not in the normalized form.
+            To avoid this kind of redirect, you can use the [mediawiki-title](https://github.com/wikimedia/mediawiki-title) library to perform
+            title normalization client-side.
+
+            Beware that redirected pre-flighted cross-origin requests (such as those sending custom request headers like `Api-User-Agent`)
+            will fail in most current browsers [due to a spec bug](https://github.com/whatwg/fetch/issues/204).
+        '302':
+          description: |
+            The page is a [redirect page](https://www.mediawiki.org/wiki/Help:Redirects).
+            The `location` header points to the redirect target, and the body contains the actual page revision contents as HTML.
+            If you would like to avoid automatically following redirect pages, set the `redirect=false` query parameter.
+
+            Beware that redirected pre-flighted cross-origin requests (such as those sending custom request headers like `Api-User-Agent`)
+            will fail in most current browsers [due to a spec bug](https://github.com/whatwg/fetch/issues/204).
+        '400':
+          description: Invalid revision or tid
+          schema:
+            $ref: '#/definitions/problem'
+        '403':
+          description: Access to the specific revision is restricted
+          schema:
+            $ref: '#/definitions/problem'
+        '404':
+          description: Unknown page, revision or tid
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: /{domain}/sys/parsoid/lint/{title}{/revision}
+      x-monitor: false
+
   /wikitext/{title}:
     post:
       tags:


### PR DESCRIPTION
Bug: T164006

cc @wikimedia/services @subbuss @arlolra 