### PR TITLE
Run tests with SQLite by default

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -8,7 +8,7 @@ default_project: &default_project
     - path: projects/wmf_default.yaml
       options: &default_options
         table:
-          backend: cassandra
+          backend: sqlite
           hosts: [localhost]
           keyspace: system
           username: cassandra

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -5,11 +5,7 @@ mocha="$mod_dir"/mocha/bin/mocha
 istanbul="$mod_dir"/istanbul/lib/cli.js
 
 runTest ( ) {
-    if [ "$1" = "sqlite" ]; then
-        echo "Running with SQLite backend"
-        export RB_TEST_BACKEND=sqlite
-        rm -f test.db.sqlite3
-    else
+    if [ "$1" = "cassandra" ]; then
         echo "Running with Cassandra backend"
         if [ `nc -z localhost 9042 < /dev/null; echo $?` != 0 ]; then
           echo "Waiting for Cassandra to start..."
@@ -20,6 +16,10 @@ runTest ( ) {
         fi
         export RB_TEST_BACKEND=cassandra
         sh ./test/utils/cleandb.sh local_group_test
+    else
+        echo "Running with SQLite backend"
+        export RB_TEST_BACKEND=sqlite
+        rm -f test.db.sqlite3
     fi
 
     if [ "$2" = "test" ]; then

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -26,8 +26,8 @@ function loadConfig(path) {
         if (backendImpl !== 'cassandra' && backendImpl !== 'sqlite') {
             throw new Error('Invalid RB_TEST_BACKEND env variable value. Allowed values: "cassandra", "sqlite"');
         }
-        if (backendImpl === 'sqlite') {
-            confString = confString.replace(/backend: cassandra/, "backend: sqlite");
+        if (backendImpl === 'cassandra') {
+            confString = confString.replace(/backend: sqlite/, "backend: cassandra");
         }
     }
     return yaml.safeLoad(confString);


### PR DESCRIPTION
It's easier for third-party to run tests with sqlite by default, CI runs them with cassandra anyway.

cc @wikimedia/services @berndsi 