### PR TITLE
Add notloggedin to list of known errors

### DIFF
--- a/sys/action.js
+++ b/sys/action.js
@@ -73,6 +73,7 @@ const errCodes = {
     confirmemail: errDefs['401'],
     'noedit-anon': errDefs['401'],
     'noimageredirect-anon': errDefs['401'],
+    notloggedin: errDefs['401'],
     protectedpage: errDefs['401'],
     readapidenied: errDefs['401'],
     /* 403 - access denied */


### PR DESCRIPTION
This happens a lot with reading lists and causes bogus 500 errors.