### PR TITLE
Expose /page/metadata and /page/references endpoints via RESTBase

### DIFF
--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -33,6 +33,10 @@ paths:
                   options:
                     response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
+                - path: v1/references.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
             /transform:
               x-modules:
                 - path: v1/transform.yaml

--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -29,6 +29,10 @@ paths:
                   options:
                     response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
+                - path: v1/metadata.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
             /transform:
               x-modules:
                 - path: v1/transform.yaml

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -77,6 +77,10 @@ paths:
                   options:
                     response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
+                - path: v1/metadata.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
                 - path: v1/related.js
                   options: '{{options.related}}'
                 - path: v1/random.yaml

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -81,6 +81,10 @@ paths:
                   options:
                     response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
+                - path: v1/references.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
                 - path: v1/related.js
                   options: '{{options.related}}'
                 - path: v1/random.yaml

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -77,6 +77,10 @@ paths:
                   options:
                     response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
+                - path: v1/metadata.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
                 - path: v1/related.js
                   options: '{{options.related}}'
                 - path: v1/random.yaml

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -81,6 +81,10 @@ paths:
                   options:
                     response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
+                - path: v1/references.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
                 - path: v1/related.js
                   options: '{{options.related}}'
                 - path: v1/random.yaml

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -79,6 +79,10 @@ paths:
                   options:
                     response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
+                - path: v1/references.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
                 - path: v1/graphoid.yaml
                   options: '{{options.graphoid}}'
                 - path: v1/definition.yaml

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -75,6 +75,10 @@ paths:
                   options:
                     response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
+                - path: v1/metadata.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
                 - path: v1/graphoid.yaml
                   options: '{{options.graphoid}}'
                 - path: v1/definition.yaml

--- a/test/features/metadata.js
+++ b/test/features/metadata.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const assert = require('../utils/assert.js');
+const server = require('../utils/server.js');
+const preq   = require('preq');
+
+describe('Page Content Service: /page/metadata', () => {
+    before(() => server.start());
+
+    const pageTitle = 'Foobar';
+    const pageRev = 757550077;
+
+    const commonChecks = (res) => {
+        assert.deepEqual(res.status, 200);
+        assert.deepEqual(/^application\/json/.test(res.headers['content-type']), true);
+        assert.deepEqual(!!res.body.revision, true);
+        assert.deepEqual(!!res.body.tid, true);
+        assert.deepEqual(!!res.body.toc, true);
+        assert.deepEqual(!!res.body.language_links, true);
+        assert.deepEqual(!!res.body.categories, true);
+        assert.deepEqual(!!res.body.protection, true);
+    };
+
+    it('Should fetch latest metadata', () => {
+        return preq.get({
+            uri: `${server.config.bucketURL}/metadata/${pageTitle}`
+        })
+        .then((res) => {
+            commonChecks(res);
+            assert.deepEqual(!!res.headers.etag, true);
+        });
+    });
+
+    it('Should fetch older metadata', () => {
+        return preq.get({
+            uri: `${server.config.bucketURL}/metadata/${pageTitle}/${pageRev}`
+        })
+        .then((res) => {
+            commonChecks(res);
+            assert.deepEqual(new RegExp(`^"${pageRev}\/.+"$`).test(res.headers.etag), true);
+        });
+    });
+});
+

--- a/test/features/pagecontent/access_checks.js
+++ b/test/features/pagecontent/access_checks.js
@@ -179,6 +179,7 @@ describe('Access checks', () => {
         testAccess('summary', 'deleted', deletedPageTitle);
         testAccess('media', 'deleted', deletedPageTitle);
         testAccess('metadata', 'deleted', deletedPageTitle);
+        testAccess('references', 'deleted', deletedPageTitle);
     });
 
     describe('Undeleting', () => {

--- a/test/features/pagecontent/access_checks.js
+++ b/test/features/pagecontent/access_checks.js
@@ -178,6 +178,7 @@ describe('Access checks', () => {
         testAccess('mobile-sections-remaining', 'deleted', deletedPageTitle);
         testAccess('summary', 'deleted', deletedPageTitle);
         testAccess('media', 'deleted', deletedPageTitle);
+        testAccess('metadata', 'deleted', deletedPageTitle);
     });
 
     describe('Undeleting', () => {

--- a/test/features/references.js
+++ b/test/features/references.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const assert = require('../utils/assert.js');
+const server = require('../utils/server.js');
+const preq   = require('preq');
+
+describe('Page Content Service: /page/references', () => {
+    before(() => server.start());
+
+    const pageTitle = 'Foobar';
+    const pageRev = 757550077;
+
+    const commonChecks = (res) => {
+        assert.deepEqual(res.status, 200);
+        assert.deepEqual(/^application\/json/.test(res.headers['content-type']), true);
+        assert.deepEqual(!!res.body.revision, true);
+        assert.deepEqual(!!res.body.tid, true);
+        assert.deepEqual(!!res.body.reference_lists, true);
+        assert.deepEqual(!!res.body.references_by_id, true);
+    };
+
+    it('Should fetch latest references', () => {
+        return preq.get({
+            uri: `${server.config.bucketURL}/references/${pageTitle}`
+        })
+        .then((res) => {
+            commonChecks(res);
+            assert.deepEqual(!!res.headers.etag, true);
+        });
+    });
+
+    it('Should fetch older references', () => {
+        return preq.get({
+            uri: `${server.config.bucketURL}/references/${pageTitle}/${pageRev}`
+        })
+        .then((res) => {
+            commonChecks(res);
+            assert.deepEqual(new RegExp(`^"${pageRev}\/.+"$`).test(res.headers.etag), true);
+        });
+    });
+});
+

--- a/v1/metadata.yaml
+++ b/v1/metadata.yaml
@@ -1,0 +1,224 @@
+swagger: '2.0'
+info:
+  version: '1.0.0-beta'
+  title: MediaWiki page metadata API
+  description: API for retrieving additional metadata of a given page
+  termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
+  contact:
+    name: Reading Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+  license:
+    name: Apache licence, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /metadata/{title}{/revision}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
+        options:
+          redirect_cache_control: '{{options.response_cache_control}}'
+      - path: lib/security_response_header_filter.js
+    get:
+      tags:
+        - Page content
+      summary: Get additional metadata of a page.
+      description: |
+        Gets metadata of a page that's not already covered by the summary endpoint.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Metadata/1.0.0"
+      parameters:
+        - name: title
+          in: path
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: >
+            Optional page revision. Note that older revisions are not stored, so
+            request latency with the revision would be higher.
+          required: false
+        - name: redirect
+          in: query
+          description: >
+            Requests for [redirect pages](https://www.mediawiki.org/wiki/Help:Redirects)
+            return HTTP 302 with a redirect target in `Location` header and content in the body.
+
+            To get a 200 response instead, supply `false` to the `redirect` parameter.
+          type: boolean
+          required: false
+      responses:
+        '200':
+          description: JSON containing metadata of metadata items appearing on the given page.
+          schema:
+            $ref: '#/definitions/metadata'
+          headers:
+            ETag:
+              description: >
+                Syntax: "{revision}/{tid}".
+                Example: "701384379/154d7bca-c264-11e5-8c2f-1b51b33b59fc"
+        '301':
+          description: |
+            A permanent redirect is returned if the supplied article title was not in the normalized form.
+            To avoid this kind of redirect, you can use the [mediawiki-title](https://github.com/wikimedia/mediawiki-title) library to perform
+            title normalization client-side.
+
+            Beware that redirected pre-flighted cross-origin requests (such as those sending custom request headers like `Api-User-Agent`)
+            will fail in most current browsers [due to a spec bug](https://github.com/whatwg/fetch/issues/204).
+        '302':
+          description: |
+            The page is a [redirect page](https://www.mediawiki.org/wiki/Help:Redirects).
+            The `location` header points to the redirect target.
+            If you would like to avoid automatically following redirect pages, set the `redirect=false` query parameter.
+
+            Beware that redirected pre-flighted cross-origin requests (such as those sending custom request headers like `Api-User-Agent`)
+            will fail in most current browsers [due to a spec bug](https://github.com/whatwg/fetch/issues/204).
+        '404':
+          description: Unknown page title
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_pcs:
+            request:
+              method: get
+              headers:
+                cache-control: '{{cache-control}}'
+              uri: '{{options.host}}/{domain}/v1/page/metadata/{title}/{revision}'
+            return:
+              status: 200
+              headers: '{{ merge({"cache-control": options.response_cache_control},
+                                 get_from_pcs.headers) }}'
+              body: '{{get_from_pcs.body}}'
+      x-monitor: true
+      x-amples:
+        - title: Get extended metadata of a test page
+          request:
+            params:
+              domain: en.wikipedia.org
+              title: Video
+              revision: 830543386
+          response:
+            status: 200
+            headers:
+              content-type: /application\/json/
+            body:
+              revision: /.+/
+              tid: /.+/
+              hatnotes:
+                - section: /.+/
+                  html: /.+/
+              issues:
+                - section: /.+/
+                  html: /.+/
+              toc:
+                title: /.+/
+                entries:
+                  - level: /.+/
+                    section: /.+/
+                    number: /.+/
+                    anchor: /.+/
+                    html: /.+/
+              language_links:
+                - lang: /.+/
+                  titles:
+                    canonical: /.+/
+                    normalized: /.+/
+                  summary_url: /.+/
+              categories:
+                - titles:
+                    canonical: /.+/
+                    normalized: /.+/
+                    display: /.+/
+                  hidden: /.+/
+                  ns: /.+/
+                  summary_url: /.+/
+              protection:
+                edit: [ /.+/ ]
+                move: [ /.+/ ]
+
+# copied from MCS spec.yaml
+definitions:
+
+  hatnote_or_page_issue:
+    type: object
+    properties:
+      section:
+        type: integer
+        description: section ID containing the hatnote or page issue
+      html:
+        type: string
+        description: the hatnote or page issue HTML
+    required: [ section, html ]
+    additionalProperties: false
+
+  toc_entry:
+    type: object
+    properties:
+      level:
+        type: integer
+        description: the depth of the heading in the TOC hierarchy
+      section:
+        type: integer
+        description: the position of the section in the order of appearance of all sections on the page
+      number:
+        type: string
+        description: a numeric representation of the section's position in the page hierarhcy (e.g., '1', '1.3', '1.3.2')
+      anchor:
+        type: string
+        description: the heading text to be used in constracting a page anchor for linking
+      html:
+        type: string
+        description: the heading display text (may contain HTML markup)
+    required: [ level, section, number, anchor, html ]
+    additionalProperties: false
+
+  category:
+    type: object
+    properties:
+      titles:
+        type: object
+        description: titles dictionary
+        properties:
+          canonical:
+            type: string
+            description: canonical title
+          normalized:
+            type: string
+            description: normalized title
+          display:
+            type: string
+            description: display title (omitting the "Category:" namespace prefix)
+        required:
+          - canonical
+          - normalized
+          - display
+      summary_url:
+        type: string
+        description: link to REST API summary
+      hidden:
+        type: boolean
+        description: whether the category is hidden or not
+      ns:
+        type: integer
+        description: the numeric namespace id for the category page
+    required: [ titles, hidden, summary_url, ns ]
+    additionalProperties: false
+
+  protection:
+    type: object
+    properties:
+      edit:
+        type: array
+        description: list of groups with the 'edit' permission
+        items:
+          type: string
+      move:
+        type: array
+        description: list of groups with the 'move' permission
+        items:
+          type: string

--- a/v1/metadata.yaml
+++ b/v1/metadata.yaml
@@ -50,7 +50,7 @@ paths:
           required: false
       responses:
         '200':
-          description: JSON containing metadata of metadata items appearing on the given page.
+          description: JSON containing additional metadata of the given page.
           schema:
             $ref: '#/definitions/metadata'
           headers:

--- a/v1/references.yaml
+++ b/v1/references.yaml
@@ -1,0 +1,226 @@
+swagger: '2.0'
+info:
+  version: '1.0.0-beta'
+  title: MediaWiki page references API
+  description: API for retrieving references of a given page
+  termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
+  contact:
+    name: Reading Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+  license:
+    name: Apache licence, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /references/{title}{/revision}:
+    x-route-filters:
+      - path: ./lib/revision_table_access_check_filter.js
+        options:
+          redirect_cache_control: '{{options.response_cache_control}}'
+      - path: lib/security_response_header_filter.js
+    get:
+      tags:
+        - Page content
+      summary: Get references of a page.
+      description: |
+        Gets references of a page in a way that makes it easy to look up the details of a reference by id
+        and allow some reference lists to be rebuild.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/References/1.0.0"
+      parameters:
+        - name: title
+          in: path
+          description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
+          type: string
+          required: true
+        - name: revision
+          in: path
+          description: >
+            Optional page revision. Note that older revisions are not stored, so
+            request latency with the revision would be higher.
+          required: false
+        - name: redirect
+          in: query
+          description: >
+            Requests for [redirect pages](https://www.mediawiki.org/wiki/Help:Redirects)
+            return HTTP 302 with a redirect target in `Location` header and content in the body.
+
+            To get a 200 response instead, supply `false` to the `redirect` parameter.
+          type: boolean
+          required: false
+      responses:
+        '200':
+          description: JSON containing a structure of references on the given page.
+          schema:
+            $ref: '#/definitions/references_response'
+          headers:
+            ETag:
+              description: >
+                Syntax: "{revision}/{tid}".
+                Example: "701384379/154d7bca-c264-11e5-8c2f-1b51b33b59fc"
+        '301':
+          description: |
+            A permanent redirect is returned if the supplied article title was not in the normalized form.
+            To avoid this kind of redirect, you can use the [mediawiki-title](https://github.com/wikimedia/mediawiki-title) library to perform
+            title normalization client-side.
+
+            Beware that redirected pre-flighted cross-origin requests (such as those sending custom request headers like `Api-User-Agent`)
+            will fail in most current browsers [due to a spec bug](https://github.com/whatwg/fetch/issues/204).
+        '302':
+          description: |
+            The page is a [redirect page](https://www.mediawiki.org/wiki/Help:Redirects).
+            The `location` header points to the redirect target.
+            If you would like to avoid automatically following redirect pages, set the `redirect=false` query parameter.
+
+            Beware that redirected pre-flighted cross-origin requests (such as those sending custom request headers like `Api-User-Agent`)
+            will fail in most current browsers [due to a spec bug](https://github.com/whatwg/fetch/issues/204).
+        '404':
+          description: Unknown page title
+          schema:
+            $ref: '#/definitions/problem'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_pcs:
+            request:
+              method: get
+              headers:
+                cache-control: '{{cache-control}}'
+              uri: '{{options.host}}/{domain}/v1/page/references/{title}/{revision}'
+            return:
+              status: 200
+              headers: '{{ merge({"cache-control": options.response_cache_control},
+                                 get_from_pcs.headers) }}'
+              body: '{{get_from_pcs.body}}'
+      x-monitor: true
+      x-amples:
+        - title: Get references of a test page
+          request:
+            params:
+              domain: en.wikipedia.org
+              title: Video
+              revision: 830543386
+          response:
+            status: 200
+            headers:
+              content-type: /application\/json/
+            body:
+              revision: /.+/
+              tid: /.+/
+              reference_lists:
+                - id: /.*/
+                  section_heading:
+                    id: /.+/
+                    html: /.+/
+                  order: [ /.*/ ]
+              references_by_id: /.+/
+
+# copied from MCS spec.yaml
+definitions:
+
+  references_response:
+    type: object
+    description: Reference lists and references
+    properties:
+      revision:
+        type: string
+        description: revision ID for the page
+      tid:
+        type: string
+        description: time UUID for the page/revision
+      reference_lists:
+        $ref: '#/definitions/reference_lists'
+      references_by_id:
+        $ref: '#/definitions/references_by_id'
+    additionalProperties: false
+    required:
+      - revision
+      - tid
+      - reference_lists
+      - references_by_id
+
+  reference_lists:
+    type: array
+    description: A list of reference lists
+    properties:
+      id:
+        type: string
+        description: Identifier for the whole reference list. May be null.
+      section_heading:
+        type: object
+        description: |
+          Object containing information about the section heading this reference list
+          is shown in.
+        properties:
+          id:
+            type: string
+            description: Identifier for the section, which can be used to link to it
+          html:
+            type: string
+            description: HTML content of section heading
+      order:
+        type: array
+        description: |
+          List of identifiers for individual references, which can be used to lookup
+          the reference details in references_by_id.
+        items:
+          type: string
+    additionalProperties: false
+    required:
+      - id
+      - section_heading
+      - order
+
+  references_by_id:
+    type: object
+    description: A map of reference ids to reference details
+    properties:
+      default:
+        $ref: '#/definitions/reference_detail_item'
+
+  reference_detail_item:
+    type: object
+    description: Information about one reference
+    properties:
+      back_links:
+        type: array
+        description: A list of back links, can be empty in rare cases
+        items:
+          $ref: '#/definitions/reference_detail_item_back_link'
+      content:
+        type: object
+        properties:
+          html:
+            type: string
+            description: HTML representation of the reference content
+          type:
+            type: string
+            enum:
+              - generic
+              - book
+              - journal
+              - news
+              - web
+            description: Known citation type if there is exactly one cite tag, else 'generic'
+    additionalProperties: false
+
+  reference_detail_item_back_link:
+    type: object
+    description: Information about one link back to where on the page a given reference was used
+    properties:
+      href:
+        type: string
+        description: Relative URL pointing to anchor on same page
+      text:
+        type: string
+        description: |
+          Either an arrow for a single back link or another (usually single) chararacter
+          to distinguish multiple back links.
+    additionalProperties: false
+    required:
+      - href
+      - text
+


### PR DESCRIPTION
This is pretty much the same as was done for /page/media. Going to do references later.

Bug: T190198
Bug: T189750