### PR TITLE
Allow specifying expected content type in the ensure_content_type filter

### DIFF
--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -89,7 +89,8 @@ module.exports = (hyper, req, next, options, specInfo) => {
                 res.headers && res.headers['content-type'] === expected)) {
             return res;
         } else {
-            const expectedContentType = Array.isArray(produces) && produces[0];
+            const expectedContentType = options.expected
+                || (Array.isArray(produces) && produces[0]);
             if (expectedContentType) {
                 // Found a content type. Ensure that we return the latest profile.
                 return checkContentType(hyper, req, next, expectedContentType, P.resolve(res));


### PR DESCRIPTION
Bug: T189733

cc @wikimedia/services @berndsi 