### PR TITLE
Experiment. Remove the feed check to try RESTBase deploy without it

### DIFF
--- a/v1/feed.yaml
+++ b/v1/feed.yaml
@@ -43,49 +43,7 @@ paths:
           schema:
             $ref: '#/definitions/problem'
       operationId: aggregatedFeed
-      x-monitor: true
-      x-amples:
-        - title: Retrieve aggregated feed content for April 29, 2016
-          request:
-            params:
-              domain: en.wikipedia.org
-              yyyy: '2016'
-              mm: '04'
-              dd: '29'
-          response:
-            status: 200
-            headers:
-              content-type: /application\/json/
-            body:
-              tfa:
-                title: /.+/
-                description: /.+/
-                extract: /.+/
-                thumbnail:
-                  source: /.+/
-                  width: /.+/
-                  height: /.+/
-              mostread:
-                date: /.+/
-                articles:
-                  - views: /.+/
-                    rank: /.+/
-                    title: /.+/
-                    pageid: /.+/
-                    normalizedtitle: /.+/
-              image:
-                title: /.+/
-                description:
-                  text: /.+/
-                  lang: /.+/
-                image:
-                  source: /.+/
-                  width: /.+/
-                  height: /.+/
-                thumbnail:
-                  source: /.+/
-                  width: /.+/
-                  height: /.+/
+      x-monitor: false
 
 definitions:
   mostread_article:


### PR DESCRIPTION
To be reverted!

We are experiencing a problem with deploying RESTBase - the MCS latency spikes for this check so the check times out. In order to encapsulate the problem more I want to try commenting ou the check to see what happens and if the issue is only with that particular endpoint or if it's generic.

cc @wikimedia/services 