### PR TITLE
Expose CSS endpoints

### DIFF
--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -52,6 +52,10 @@ paths:
                   options: '{{options.citoid}}'
                 - path: v1/lists.js
                   options: '{{options.lists}}'
+                - path: v1/css.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -54,7 +54,6 @@ paths:
                   options: '{{options.lists}}'
                 - path: v1/css.yaml
                   options:
-                    response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -118,6 +118,10 @@ paths:
                   options: '{{options.lists}}'
                 - path: v1/recommend.yaml
                   options: '{{options.recommendation}}'
+                - path: v1/css.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -120,7 +120,6 @@ paths:
                   options: '{{options.recommendation}}'
                 - path: v1/css.yaml
                   options:
-                    response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -118,6 +118,10 @@ paths:
                   options: '{{options.lists}}'
                 - path: v1/recommend.yaml
                   options: '{{options.recommendation}}'
+                - path: v1/css.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -120,7 +120,6 @@ paths:
                   options: '{{options.recommendation}}'
                 - path: v1/css.yaml
                   options:
-                    response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -107,6 +107,10 @@ paths:
                   options: '{{options.citoid}}'
                 - path: v1/lists.js
                   options: '{{options.lists}}'
+                - path: v1/css.yaml
+                  options:
+                    response_cache_control: '{{options.purged_cache_control}}'
+                    host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -109,7 +109,6 @@ paths:
                   options: '{{options.lists}}'
                 - path: v1/css.yaml
                   options:
-                    response_cache_control: '{{options.purged_cache_control}}'
                     host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 

--- a/test/features/css.js
+++ b/test/features/css.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const assert = require('../utils/assert.js');
+const server = require('../utils/server.js');
+const preq   = require('preq');
+
+describe('Page Content Service: /data/css/mobile', () => {
+    before(() => server.start());
+
+    const commonChecks = (res) => {
+        assert.deepEqual(res.status, 200);
+        assert.deepEqual(/^text\/css; charset=utf-8/.test(res.headers['content-type']), true);
+        assert.deepEqual(!!res.headers.etag, true);
+    };
+
+    it('Should get base CSS successfully', () => {
+        return preq.get({
+            uri: `${server.config.baseURL}/data/css/mobile/base`
+        })
+        .then((res) => {
+            commonChecks(res);
+        });
+    });
+
+    it('Should get site CSS successfully', () => {
+        return preq.get({
+            uri: `${server.config.baseURL}/data/css/mobile/site`
+        })
+        .then((res) => {
+            commonChecks(res);
+        });
+    });
+});
+

--- a/test/features/css.js
+++ b/test/features/css.js
@@ -17,18 +17,14 @@ describe('Page Content Service: /data/css/mobile', () => {
         return preq.get({
             uri: `${server.config.baseURL}/data/css/mobile/base`
         })
-        .then((res) => {
-            commonChecks(res);
-        });
+        .then(res => commonChecks(res));
     });
 
     it('Should get site CSS successfully', () => {
         return preq.get({
             uri: `${server.config.baseURL}/data/css/mobile/site`
         })
-        .then((res) => {
-            commonChecks(res);
-        });
+        .then(res => commonChecks(res));
     });
 });
 

--- a/v1/css.yaml
+++ b/v1/css.yaml
@@ -12,12 +12,14 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /css/mobile/base:
+    x-route-filters:
+      - path: lib/security_response_header_filter.js
     get:
       tags:
         - Mobile
       summary: Get base CSS for mobile apps.
       description: |
-        Gets common CSS for mobile apps need to properly display pages using Page Content Service.
+        Gets common CSS mobile apps need to properly display pages using Page Content Service.
 
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       produces:
@@ -36,8 +38,6 @@ paths:
         - get_from_pcs:
             request:
               method: get
-              headers:
-                cache-control: '{{cache-control}}'
               uri: '{{options.host}}/{domain}/v1/data/css/mobile/base'
             return:
               status: 200
@@ -54,6 +54,8 @@ paths:
             body: /.+/
 
   /css/mobile/site:
+    x-route-filters:
+      - path: lib/security_response_header_filter.js
     get:
       tags:
         - Mobile
@@ -78,8 +80,6 @@ paths:
         - get_from_pcs:
             request:
               method: get
-              headers:
-                cache-control: '{{cache-control}}'
               uri: '{{options.host}}/{domain}/v1/data/css/mobile/site'
             return:
               status: 200

--- a/v1/css.yaml
+++ b/v1/css.yaml
@@ -1,0 +1,96 @@
+swagger: '2.0'
+info:
+  version: '1.0.0-beta'
+  title: CSS for mobile apps
+  description: API for retrieving CSS for mobile apps
+  termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
+  contact:
+    name: Reading Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+  license:
+    name: Apache licence, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /css/mobile/base:
+    get:
+      tags:
+        - Mobile
+      summary: Get base CSS for mobile apps.
+      description: |
+        Gets common CSS for mobile apps need to properly display pages using Page Content Service.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/CSS/1.0.0"
+      responses:
+        '200':
+          description: Success
+          headers:
+            ETag:
+              description: Different values indicate that the content has changed
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_pcs:
+            request:
+              method: get
+              headers:
+                cache-control: '{{cache-control}}'
+              uri: '{{options.host}}/{domain}/v1/data/css/mobile/base'
+            return:
+              status: 200
+              headers: '{{ merge({"cache-control": options.response_cache_control},
+                                 get_from_pcs.headers) }}'
+              body: '{{get_from_pcs.body}}'
+      x-monitor: true
+      x-amples:
+        - title: Get base CSS
+          response:
+            status: 200
+            headers:
+              content-type: /^text\/css; charset=utf-8/
+            body: /.+/
+
+  /css/mobile/site:
+    get:
+      tags:
+        - Mobile
+      summary: Get site-specific CSS for mobile apps.
+      description: |
+        Gets wiki specific CSS mobile apps need to properly display pages using Page Content Service.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/CSS/1.0.0"
+      responses:
+        '200':
+          description: Success
+          headers:
+            ETag:
+              description: Different values indicate that the content has changed
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_pcs:
+            request:
+              method: get
+              headers:
+                cache-control: '{{cache-control}}'
+              uri: '{{options.host}}/{domain}/v1/data/css/mobile/site'
+            return:
+              status: 200
+              headers: '{{ merge({"cache-control": options.response_cache_control},
+                                 get_from_pcs.headers) }}'
+              body: '{{get_from_pcs.body}}'
+      x-monitor: true
+      x-amples:
+        - title: Get site-specific CSS
+          response:
+            status: 200
+            headers:
+              content-type: /^text\/css; charset=utf-8/
+            body: /.+/


### PR DESCRIPTION
Another Page Content Service endpoint. This patch provides two
page-independent CSS responses under /data/css/mobile/:
* /data/css/mobile/base
* /data/css/mobile/site

Bug: T190846