### PR TITLE
API: Include anchors in redirect targets

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -350,6 +350,12 @@ mwUtil.createRelativeTitleRedirect = (path, req, options) => {
         location = backString
             + new URI(pathPatternAfterTitle, newReqParams, true).toString().substr(1)
             + mwUtil.getQueryString(req);
+    } else if (/#/.test(newReqParams.title)) {
+        const titleFragments = encodeURIComponent(newReqParams.title).split(/%23/);
+        /* eslint-disable prefer-template */
+        location = backString + titleFragments.shift() + mwUtil.getQueryString(req)
+            + '#' + titleFragments.join('%23');
+        /* eslint-enable prefer-template */
     } else {
         location = backString + encodeURIComponent(newReqParams.title) + mwUtil.getQueryString(req);
     }
@@ -370,7 +376,7 @@ mwUtil.isCrossOrigin = (req) => {
     return req && req.headers && req.headers.origin && req.headers.origin !== req.params.domain;
 };
 
-const redirectRegEx = /<link rel="mw:PageProp\/redirect" href="\.\/([^"#]+)(?:#[^"]*)?"/;
+const redirectRegEx = /<link rel="mw:PageProp\/redirect" href="\.\/([^"]+)"/;
 mwUtil.extractRedirect = (html) => {
     const redirectMatch = redirectRegEx.exec(html);
     if (redirectMatch) {

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -383,7 +383,8 @@ class ParsoidService {
                             // This revision is actually a redirect. Pass redirect target
                             // to caller, and let it rewrite the location header.
                             resp.status = 302;
-                            resp.headers.location = encodeURIComponent(redirectTarget);
+                            resp.headers.location = encodeURIComponent(redirectTarget)
+                                .replace(/%23/, '#');
                             return hyper.post({
                                 uri: new URI([rp.domain, 'sys', 'page_revisions',
                                     'restrictions', rp.title, rp.revision]),

--- a/test/features/pagecontent/redirects.js
+++ b/test/features/pagecontent/redirects.js
@@ -208,7 +208,7 @@ describe('Redirects', function() {
         })
         .then(function(res) {
             assert.deepEqual(res.status, 302);
-            assert.deepEqual(res.headers.location, 'Main_Page');
+            assert.deepEqual(res.headers.location, 'Main_Page#Test%23123');
             assert.deepEqual(res.body.length > 0, true);
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
         });


### PR DESCRIPTION
If the redirect is explicit and it contains a URL fragment, we should honour it.

Bug: [T148645](https://phabricator.wikimedia.org/T148645)