### PR TITLE
Standardise the parsoid ttl config option name

### DIFF
--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -89,12 +89,11 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
             /parsoid_bucket:
               x-modules:
                 - path: sys/multi_content_bucket.js
                   options:
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
+                    grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
                     renew_expiring: true
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     table_name_prefix: parsoid_ng
@@ -115,7 +114,7 @@ paths:
               x-modules:
                 - path: sys/multi_content_bucket.js
                   options:
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
+                    grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     table_name_prefix: mobile
                     main_content_type:

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -58,12 +58,11 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
             /parsoid_bucket:
               x-modules:
                 - path: sys/multi_content_bucket.js
                   options:
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
+                    grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
                     renew_expiring: true
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     table_name_prefix: parsoid_ng

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -133,7 +133,7 @@ paths:
               x-modules:
                 - path: sys/multi_content_bucket.js
                   options:
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
+                    grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
                     renew_expiring: true
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     table_name_prefix: parsoid_ng
@@ -171,7 +171,6 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
                     # A list of pages that we don't currently want to re-render on
                     # each edit. Most of these are huge bot-edited pages, which are
                     # rarely viewed in any case.

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -134,6 +134,7 @@ paths:
                 - path: sys/multi_content_bucket.js
                   options:
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
+                    index_ttl: '{{default(options.parsoid.index_ttl, 846000)}}'
                     renew_expiring: true
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     table_name_prefix: parsoid_ng

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -135,7 +135,7 @@ paths:
                   options:
                     table_name_prefix: parsoid_ng
                     renew_expiring: true
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
+                    grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     main_content_type:
                       name: html
@@ -171,7 +171,6 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
                     # A list of pages that we don't currently want to re-render on
                     # each edit. Most of these are huge bot-edited pages, which are
                     # rarely viewed in any case.

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -136,6 +136,7 @@ paths:
                     table_name_prefix: parsoid_ng
                     renew_expiring: true
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
+                    index_ttl: '{{default(options.parsoid.index_ttl, 846000)}}'
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     main_content_type:
                       name: html

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -101,6 +101,7 @@ paths:
                     table_name_prefix: parsoid_ng
                     renew_expiring: true
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
+                    index_ttl: '{{default(options.parsoid.index_ttl, 846000)}}'
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     main_content_type:
                       name: html

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -100,7 +100,7 @@ paths:
                   options:
                     table_name_prefix: parsoid_ng
                     renew_expiring: true
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
+                    grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     main_content_type:
                       name: html
@@ -136,7 +136,6 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
             /events:
               x-modules:
                 - path: sys/events.js

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -124,7 +124,7 @@ paths:
                   options:
                     table_name_prefix: parsoid_ng
                     renew_expiring: true
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
+                    grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     main_content_type:
                       name: html
@@ -160,7 +160,6 @@ paths:
                     parsoidHost: '{{options.parsoid.host}}'
                     response_cache_control: '{{options.purged_cache_control}}'
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 86400)}}'
-                    time_to_live: '{{default(options.parsoid.time_to_live, 84600)}}'
             /mobileapps:
               x-modules:
                 - path: sys/mobileapps.js

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -125,6 +125,7 @@ paths:
                     table_name_prefix: parsoid_ng
                     renew_expiring: true
                     grace_ttl: '{{default(options.parsoid.grace_ttl, 84600)}}'
+                    index_ttl: '{{default(options.parsoid.index_ttl, 846000)}}'
                     delete_probability: '{{default(options.parsoid.delete_probability, 1)}}'
                     main_content_type:
                       name: html

--- a/sys/multi_content_bucket.js
+++ b/sys/multi_content_bucket.js
@@ -69,6 +69,7 @@ class MultiContentBucket {
         });
 
         this.options.grace_ttl = this.options.grace_ttl || 86400;
+        this.options.index_ttl = this.options.index_ttl || this.options.grace_ttl * 10;
         this.options.delete_probability = this.options.delete_probability || 1;
     }
 
@@ -183,7 +184,7 @@ class MultiContentBucket {
                         { attribute: 'ts', type: 'range', order: 'desc' },
                     ],
                     options: {
-                        default_time_to_live: this.options.grace_ttl * 10
+                        default_time_to_live: this.options.index_ttl
                     }
                 }
             },
@@ -204,7 +205,7 @@ class MultiContentBucket {
                         { attribute: 'ts', type: 'range', order: 'desc' },
                     ],
                     options: {
-                        default_time_to_live: this.options.grace_ttl * 10
+                        default_time_to_live: this.options.index_ttl
                     }
                 }
             }

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -236,7 +236,7 @@ class ParsoidService {
         .then((res) => {
             // Now check the result ETag and see if the content is close to expiration
             const contentTid = uuid.fromString(mwUtil.parseETag(res.headers.etag).tid);
-            const expirationTime =  new Date(Date.now() + this.options.time_to_live * 1000 / 2);
+            const expirationTime =  new Date(Date.now() + this.options.grace_ttl * 1000 / 2);
             if (format === 'html' && contentTid.getDate() > expirationTime) {
                 // Content is half-expired. Regenerate.
                 throw new HTTPError({


### PR DESCRIPTION
We've had 2 different options for the same config, `time_to_live` wasn't really used almost anywhere. 

Also introduced the `index_ttl` config option for more fine-grained control on indexes TTLs.

cc @wikimedia/services 