### PR TITLE
Decrease the noindex severity to DEBUG

### DIFF
--- a/sys/multi_content_bucket.js
+++ b/sys/multi_content_bucket.js
@@ -379,7 +379,7 @@ class MultiContentBucket {
                     })
                     .catch({ status: 404 }, () => {
                         // Log the 404 if we don't have the timeline.
-                        hyper.log('error/noindex', {
+                        hyper.log('debug/noindex', {
                             msg: 'Empty revision timeline',
                             page_title: rp.key
                         });
@@ -431,7 +431,7 @@ class MultiContentBucket {
                     })
                     .catch({ status: 404 }, () => {
                         // Log the 404 if we don't have the timeline.
-                        hyper.log('error/noindex', {
+                        hyper.log('debug/noindex', {
                             msg: 'Empty render timeline',
                             page_title: rp.key,
                             page_revision: rev


### PR DESCRIPTION
The rate of these logs is way too high, we need to use sampled logging and sample these logs with 1% probability, so we need to decrease the log severity.

cc @wikimedia/services