### PR TITLE
Correctly indent http filer allow options

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -34,12 +34,12 @@ services:
           - type: default
             name: http
             options:
-            allow:
-              - pattern: http://localhost/w/api.php
-                forward_headers: true
-              - pattern: http://localhost:8142
-                forward_headers: true
-              - pattern: /^https?:\/\//
+              allow:
+                - pattern: http://localhost/w/api.php
+                  forward_headers: true
+                - pattern: http://localhost:8142
+                  forward_headers: true
+                - pattern: /^https?:\/\//
         paths:
           /{domain:localhost}:
             x-modules:


### PR DESCRIPTION
This took me several hours to find this little difference in the three provided config files. The allow array of the http sub-request filter needs to be part of the options object, which it isn't for the example config. This results in a functional setup, as long as no login is required for a service. If a login is required (e.g. the lists service), it will always fail with the "badtoken" error message as the user seems to be not logged in. This is because of the missing Cookie header, where the session ID is saved in.

Correctly indenting the options for the http filter is the solution for that problem. As the example config yaml looks like the suggested file to start with, this error should be fixed.