### PR TITLE
Remove attempting to renew the TTL

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -232,18 +232,6 @@ class ParsoidService {
             } else {
                 throw e;
             }
-        })
-        .then((res) => {
-            // Now check the result ETag and see if the content is close to expiration
-            const contentTid = uuid.fromString(mwUtil.parseETag(res.headers.etag).tid);
-            const expirationTime =  new Date(Date.now() + this.options.grace_ttl * 1000 / 2);
-            if (format === 'html' && contentTid.getDate() > expirationTime) {
-                // Content is half-expired. Regenerate.
-                throw new HTTPError({
-                    status: 404
-                });
-            }
-            return res;
         });
     }
 


### PR DESCRIPTION
That piece of code was intended to avoid serving the content that is about to expire and renew it. But, if you look closer - it never actually worked - the `contentTid` will always be in the past, and the `expirationDate` is actually always in the future. 

Actually, finding the real expiration date for the content at this point is kinda impossible, and, more then that, we already have the logic inside the `multi-content-bucket` that serves exactly the same purpose. So, remove useless code!

cc @wikimedia/services 