### PR TITLE
Stabilize tests that depend on content being present

### DIFF
--- a/config.test.yaml
+++ b/config.test.yaml
@@ -20,7 +20,7 @@ default_project: &default_project
           dbname: test.db.sqlite3 # ignored in cassandra, but useful in SQLite testing
         parsoid:
           host: https://parsoid-beta.wmflabs.org
-          grace_ttl: 2
+          grace_ttl: 1000000
         action:
           apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
           baseUriTemplate: "{{'https://{domain}/api/rest_v1'}}"


### PR DESCRIPTION
Some of the tests were very unstable recently and I finally figured the reason - they rely on some content being present and with `grace_ttl=2` it just disappears from under our feet, so increase the ttl to something really big.

cc @wikimedia/services 