### PR TITLE
Remove useless double-checking of the stored content

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -301,7 +301,6 @@ class ParsoidService {
     generateAndSave(hyper, req, format, currentContentRes) {
         // Try to generate HTML on the fly by calling Parsoid
         const rp = req.params;
-        const reqRevision = rp.revision;
         // Helper for retrieving original content from storage & posting it to
         // the Parsoid pagebundle end point
         /* const getOrigAndPostToParsoid = (pageBundleUri, revision, contentName, updateMode) => {
@@ -324,20 +323,7 @@ class ParsoidService {
 
         return this.getRevisionInfo(hyper, req)
         .then((revInfo) => {
-            rp.revision = `${revInfo.rev}`;
-            if (reqRevision !== rp.revision) {
-                // Try to fetch the HTML corresponding to the requested revision,
-                // so that the change detection makes sense.
-                return this._getContentWithFallback(hyper, rp, format)
-                .then(
-                    (contentRes) => {
-                        currentContentRes = contentRes;
-                    },
-                    (contentRes) => {
-                        currentContentRes = contentRes;
-                    }
-                );
-            }
+            rp.revision = revInfo.rev;
         })
         .then(() => {
             const pageBundleUri = new URI([rp.domain, 'sys', 'parsoid', 'pagebundle',


### PR DESCRIPTION
NOTE: This is a bit up for discussion, because Parsoid module code is hard to follow and I might have missed the reason why we're doing this, but I'm pretty sure this code is not only useless but also harmful.

The `reqRevision !== rp.revision` can only be true if `reqRevision === undefined`, because we pass a revision id (`reqRevision`) to `getRevisionInfo` - that's exactly what we're gonna get, so they will be equal, so for requests where the revision is specified this is a no-op.

For request for latest revision, where rev id is not specified, the code before this (`getFormat`) will first try to request the existing latest HTML and pass it in here as `currentContentRes` variable - and that's exactly what we want to compare the new content with in this case - the latest render of the latest revision. So if that's a new revision - it will never be equal (html contains the revision ID), but if it's a new render, the code I'm deleting will basically simply duplicate the work that has been done before while obtaining `currentContentRes`.

Since all of the transclusions updates are requesting HTML without the revision ID, I expect this to significantly decrease the read load on the cluster.

cc @wikimedia/services 