### PR TITLE
Update required media item fields

### DIFF
--- a/v1/media.yaml
+++ b/v1/media.yaml
@@ -111,17 +111,8 @@ paths:
               revision: /.+/
               tid: /.+/
               items:
-                - titles:
-                    canonical: /.+/
-                    normalized: /.+/
-                    display: /.+/
-                  thumbnail:
-                    source: /.+/
-                    width: /.+/
-                    height: /.+/
-                    mime: /.+/
-                  license:
-                    type: /.+/
+                - section_id: /.+/
+                  type: /.+/
 
 # copied from MCS spec.yaml
 definitions:

--- a/v1/media.yaml
+++ b/v1/media.yaml
@@ -254,11 +254,9 @@ definitions:
         type: string
         description: description of the image from Wikimedia Commons
     required:
-      - titles
-      - file_page
+      - section_id
       - type
-      - thumbnail
-      - license
+      - original
 
   titles_set:
     type: object


### PR DESCRIPTION
As of https://gerrit.wikimedia.org/r/#/c/436360/ (adding support for
Mathoid images) media items may not have the usual set of Commons
metadata.  This updates the media spec to fix the monitoring check.