### PR TITLE
Include `page_language` into the title_revision table.

### DIFF
--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -113,6 +113,7 @@ paths:
                   rev: /\d+/
                   tid: /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
                   comment: /.*/
+                  page_language: 'en'
 
   /html/{title}:
     x-route-filters:
@@ -868,6 +869,8 @@ definitions:
         format: date-time
       redirect:
         type: boolean
+      page_language:
+        type: string
 
   revisionIdentifier:
     description: Unique revision identifier


### PR DESCRIPTION
For language variants support it's not enough to look
whether the domain language supports multiple variants,
since on every wiki each page can actually have it's own
lang, and since LanguageConverter is enabled universally,
the individual pages could be transformed even on wikis
where we generically don't support variants.

Thus, we need to include `pagelanguage` property into
the title_revision table in order to be able to check,
whether to try the transformtion, or just to skip it.
Also will be useful to do Varnish cache splitting more
intelegently.

Bug: https://phabricator.wikimedia.org/T190689