### PR TITLE
Reuse restbase-provided cache-control when transforming html variants

### DIFF
--- a/lib/language_variants_filter.js
+++ b/lib/language_variants_filter.js
@@ -16,10 +16,13 @@ module.exports = (hyper, req, next, options, specInfo) => {
         // For now we hacky check by domain.
         .then((res) => {
             const langCode = req.params.domain.substring(0, req.params.domain.indexOf('.'));
-            if (mwUtil.canConvertLangVariant(hyper, req, langCode)) {
-                res.headers.vary = 'accept-language';
-            }
-            return res;
+            return mwUtil.canConvertLangVariant(hyper, req, langCode)
+            .then((canConvert) => {
+                if (canConvert) {
+                    res.headers.vary = 'accept-language';
+                }
+            })
+            .thenReturn(res);
         });
     }
 
@@ -36,18 +39,19 @@ module.exports = (hyper, req, next, options, specInfo) => {
                 delete req.headers['accept-language'];
                 return next(hyper, req)
                 // TODO: Eventually we want to store the Vary header we get from Parsoid!
-                .then((res) => {
-                    if (mwUtil.canConvertLangVariant(hyper, req, revision.page_language)) {
+                .then((res) => mwUtil.canConvertLangVariant(hyper, req, revision.page_language)
+                .then((canConvert) => {
+                    if (canConvert) {
                         res.headers.vary = 'accept-language';
                     }
-                    return res;
-                });
+                })
+                .thenReturn(res));
             }
 
             if (/\/page\/html\//.test(specInfo.path)) {
                 // It's HTML, hit Parsoid for conversion
                 return next(hyper, req)
-                .then(html => hyper.post({
+                .then(htmlRes => hyper.post({
                     uri: new URI([rp.domain, 'sys', 'parsoid', 'transform', 'html', 'to', 'html']),
                     headers: {
                         'content-type': 'application/json',
@@ -56,8 +60,8 @@ module.exports = (hyper, req, next, options, specInfo) => {
                     body: {
                         original: {
                             html: {
-                                headers: html.headers,
-                                body: html.body.toString()
+                                headers: htmlRes.headers,
+                                body: htmlRes.body.toString()
                             }
                         },
                         updates: {
@@ -67,13 +71,17 @@ module.exports = (hyper, req, next, options, specInfo) => {
                             }
                         }
                     }
-                }))
+                })
                 // TODO: Now we fix up the Vary header cause Parsoid
                 // sets content-type in there which is wrong.
                 .then((res) => {
+                    // Parsoid transformation doesn't know about our caching policies
+                    // or additional headers RESTBase sets, so merge headers from the original
+                    // and headers from the transformation.
+                    res.headers = Object.assign(res.headers, htmlRes.headers);
                     res.headers.vary = 'accept-language';
                     return res;
-                });
+                }));
             } else {
                 // TODO: It's something else, so just forward to MCS
                 return next(hyper, req);

--- a/lib/language_variants_filter.js
+++ b/lib/language_variants_filter.js
@@ -80,9 +80,8 @@ module.exports = (hyper, req, next, options, specInfo) => {
                     // and important headers from the transformation.
                     const resHeaders = res.headers;
                     res.headers = htmlRes.headers;
-                    res.headers.vary = resHeaders.vary || htmlRes.headers.vary;
-                    res.headers['content-language'] = resHeaders['content-language']
-                        || htmlRes.headers['content-language'];
+                    res.headers.vary = resHeaders.vary;
+                    res.headers['content-language'] = resHeaders['content-language'];
                     // TODO: T197702
                     res.headers.vary = 'accept-language';
                     return res;

--- a/lib/language_variants_filter.js
+++ b/lib/language_variants_filter.js
@@ -77,8 +77,13 @@ module.exports = (hyper, req, next, options, specInfo) => {
                 .then((res) => {
                     // Parsoid transformation doesn't know about our caching policies
                     // or additional headers RESTBase sets, so merge headers from the original
-                    // and headers from the transformation.
-                    res.headers = Object.assign(res.headers, htmlRes.headers);
+                    // and important headers from the transformation.
+                    const resHeaders = res.headers;
+                    res.headers = htmlRes.headers;
+                    res.headers.vary = resHeaders.vary || htmlRes.headers.vary;
+                    res.headers['content-language'] = resHeaders['content-language']
+                        || htmlRes.headers['content-language'];
+                    // TODO: T197702
                     res.headers.vary = 'accept-language';
                     return res;
                 }));

--- a/test/features/pagecontent/language_variants.js
+++ b/test/features/pagecontent/language_variants.js
@@ -15,11 +15,23 @@ describe('Language variants', function() {
 
     before(() => server.start());
 
+    it('should request html with impossible variants', () => {
+        return preq.get({ uri: `${server.config.labsBucketURL}/html/Main_Page`})
+        .then((res) => {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual((res.headers.vary || '').indexOf('accept-language'), -1);
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+            assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
+        });
+    });
+
     it('should request html with no variants', () => {
         return preq.get({ uri: `${server.config.variantsWikiBucketURL}/html/${variantsPageTitle}`})
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers.vary.toLowerCase(), 'accept-language');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+            assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
             assert.deepEqual(/1\. Ово је тестна страница/.test(res.body), true);
             assert.deepEqual(/2\. Ovo je testna stranica/.test(res.body), true);
         });
@@ -35,6 +47,8 @@ describe('Language variants', function() {
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers.vary.toLowerCase(), 'accept-language');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+            assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
             assert.deepEqual(/1\. Ово је тестна страница/.test(res.body), true);
             assert.deepEqual(/2\. Ovo je testna stranica/.test(res.body), true);
         });
@@ -50,6 +64,8 @@ describe('Language variants', function() {
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers.vary.toLowerCase(), 'accept-language');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+            assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
             assert.deepEqual(/1\. Ово је тестна страница/.test(res.body), true);
             assert.deepEqual(/2\. Ovo je testna stranica/.test(res.body), true);
         });
@@ -65,6 +81,9 @@ describe('Language variants', function() {
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers.vary.toLowerCase(), 'accept-language');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+            assert.deepEqual(res.headers['content-language'], 'sr-ec');
+            assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
             assert.deepEqual(/1\. Ово је тестна страница/.test(res.body), true);
             assert.deepEqual(/2\. Ово је тестна страница/.test(res.body), true);
         });
@@ -80,6 +99,9 @@ describe('Language variants', function() {
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.headers.vary.toLowerCase(), 'accept-language');
+            assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+            assert.deepEqual(res.headers['content-language'], 'sr-el');
+            assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
             assert.deepEqual(/1\. Ovo je testna stranica/.test(res.body), true);
             assert.deepEqual(/2\. Ovo je testna stranica/.test(res.body), true);
         });


### PR DESCRIPTION
cc @wikimedia/services 