### PR TITLE
Stop sending response vary headers with empty string values

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -170,7 +170,7 @@ function stripAcceptFromVary(res) {
     if (res && res.headers && res.headers.vary) {
         res.headers.vary = res.headers.vary.split(',')
         .map(header => header.trim())
-        .filter(header => !/^accept$/i.test(header))
+        .filter(header => header && !/^accept$/i.test(header))
         .join(',');
     }
     if (!res.headers.vary) {

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -173,6 +173,9 @@ function stripAcceptFromVary(res) {
         .filter(header => !/^accept$/i.test(header))
         .join(',');
     }
+    if (!res.headers.vary) {
+        delete res.headers.vary;
+    }
     return res;
 }
 

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -51,6 +51,7 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.varyNotContains(res, 'accept');
+            assert.varyNotContains(res, '');
             return preq.get({
                 uri: server.config.labsBucketURL + '/html/Main_Page/'
             });
@@ -68,6 +69,7 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.varyNotContains(res, 'accept');
+            assert.varyNotContains(res, '');
         });
     });
 
@@ -99,6 +101,7 @@ describe('item requests', function() {
         .then(function(res) {
             assert.deepEqual(res.status, 200);
             assert.varyNotContains(res, 'accept');
+            assert.varyNotContains(res, '');
             rev2Etag = res.headers.etag.replace(/^"(.*)"$/, '$1');
         });
     });
@@ -111,6 +114,7 @@ describe('item requests', function() {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, contentTypes.html);
             assert.varyNotContains(res, 'accept');
+            assert.varyNotContains(res, '');
             return preq.get({
                 uri: server.config.labsBucketURL + '/data-parsoid/Foobar/'
                     + res.headers.etag.replace(/^"(.*)"$/, '$1')

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -166,8 +166,13 @@ function varyNotContains(res, header) {
             message: `Empty headers verifying vary doesn't contain ${header}`
         });
     }
-    if (!res.headers.vary) {
+    if (!Object.prototype.hasOwnProperty.call(res.headers, 'vary')) {
         return;
+    }
+    if (res.headers.vary === '') {
+        throw new assert.AssertionError({
+            message: `Vary header should not be an empty string ('')`
+        });
     }
     const varyAsList = res.headers.vary.split(',')
     .map(header => header.trim().toLowerCase());


### PR DESCRIPTION
Since the most recent RESTBase deployment, a "Vary: ''" header has been
sent with /page/html responses.  This is an invalid Vary header value and
has caused various mobileapps tests to begin failing.[1]

This patch removes the Vary header if it's empty after stripping 'Accept'.

[1] https://integration.wikimedia.org/ci/job/npm-node-6-docker/2153/console