### PR TITLE
Deduplicate most-read results

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -566,12 +566,19 @@ mwUtil.constructRegex = (list) => {
 /**
  * Remove entries with duplicate 'title' values from an array of objects
  * @param {?Array} arr Array of page/article objects
+ * @param {?Function} upd Optional function to update the original item based on the duplicate.
+ *   Takes two parameters (orig, dupe): orig - the original object, dupe - the duplicate
  * @return {?Array} arr deduplicated by 'title'
  */
-mwUtil.removeDuplicateTitles = (arr) => {
+mwUtil.removeDuplicateTitles = (arr, upd) => {
     const titles = {};
-    return arr.filter((item) => {
+    return arr.filter((item, idx, init) => {
         if (titles[item.title]) {
+            if (upd) {
+                // eslint-disable-next-line no-unused-vars
+                let orig = init[init.findIndex(el => el.title === item.title)];
+                orig = upd(orig, item);
+            }
             return false;
         }
         titles[item.title] = true;

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -563,4 +563,20 @@ mwUtil.constructRegex = (list) => {
     return regex;
 };
 
+/**
+ * Remove entries with duplicate 'title' values from an array of objects
+ * @param {?Array} arr Array of page/article objects
+ * @return {?Array} arr deduplicated by 'title'
+ */
+mwUtil.removeDuplicateTitles = (arr) => {
+    const titles = {};
+    return arr.filter((item) => {
+        if (titles[item.title]) {
+            return false;
+        }
+        titles[item.title] = true;
+        return true;
+    });
+};
+
 module.exports = mwUtil;

--- a/test/features/mwutils.js
+++ b/test/features/mwutils.js
@@ -61,3 +61,16 @@ describe('Utils.hydrateResponse', () => {
         });
     });
 });
+
+describe('Utils.removeDuplicateTitles', () => {
+    it('deduplicates and applies update function', () => {
+        const data = [ { title: 'Foo', count: 1 }, { title: 'Foo', count: 1 } ];
+        const update = (orig, dupe) => {
+            orig.count += dupe.count;
+            return orig;
+        };
+        const result = mwUtil.removeDuplicateTitles(data, update);
+        assert.deepEqual(result.length, 1);
+        assert.deepEqual(result[0].count, 2);
+    });
+});

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -57,6 +57,15 @@ class Feed extends BaseFeed {
     // TODO: this is temporary code to increase the size of the TFA thumbnail
     _hydrateResponse(hyper, req, res) {
         const rp = req.params;
+        const updateForDupes = (orig, dupe) => {
+            orig.views += dupe.views;
+            orig.view_history.forEach((toViewsForDate) => {
+                toViewsForDate.views += dupe.view_history.filter((fromViewsForDate) => {
+                    return toViewsForDate.date === fromViewsForDate.date;
+                })[0].views;
+            });
+            return orig;
+        };
         if (res.body.tfa && res.body.tfa.$merge && res.body.tfa.$merge.length) {
             const summaryURI = res.body.tfa.$merge[0];
             const title = decodeURIComponent(
@@ -89,7 +98,8 @@ class Feed extends BaseFeed {
                 }
                 if (result[0].body.mostread && result[0].body.mostread.articles) {
                     result[0].body.mostread.articles =
-                        mwUtil.removeDuplicateTitles(result[0].body.mostread.articles);
+                        mwUtil.removeDuplicateTitles(result[0].body.mostread.articles,
+                            updateForDupes);
                 }
                 return result[0];
             });
@@ -98,7 +108,8 @@ class Feed extends BaseFeed {
             .then((response) => {
                 if (response.body.mostread && response.body.mostread.articles) {
                     response.body.mostread.articles =
-                        mwUtil.removeDuplicateTitles(response.body.mostread.articles);
+                        mwUtil.removeDuplicateTitles(response.body.mostread.articles,
+                            updateForDupes);
                 }
                 return response;
             });

--- a/v1/feed.js
+++ b/v1/feed.js
@@ -87,10 +87,21 @@ class Feed extends BaseFeed {
                         result[0].body.tfa.originalimage = newOriginal;
                     }
                 }
+                if (result[0].body.mostread && result[0].body.mostread.articles) {
+                    result[0].body.mostread.articles =
+                        mwUtil.removeDuplicateTitles(result[0].body.mostread.articles);
+                }
                 return result[0];
             });
         } else {
-            return super._hydrateResponse(hyper, req, res);
+            return super._hydrateResponse(hyper, req, res)
+            .then((response) => {
+                if (response.body.mostread && response.body.mostread.articles) {
+                    response.body.mostread.articles =
+                        mwUtil.removeDuplicateTitles(response.body.mostread.articles);
+                }
+                return response;
+            });
         }
     }
 


### PR DESCRIPTION
Builds on some deduplication functionality added earlier for on-this-day by generalizing it and adding an optional updater function to update original items based on their duplicates.  This fixes a situation in which pages can appear more than once in the most-read/trending list if they are moved at the height of their popularity. 

Alternate solution to the mobileapps-only patch in https://gerrit.wikimedia.org/r/#/c/mediawiki/services/mobileapps/+/434806/. 

Bug: https://phabricator.wikimedia.org/T195390