### PR TITLE
Upgrade cassandra driver to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "cassandra-uuid": "^0.0.2",
-    "restbase-mod-table-cassandra": "^1.1.0",
+    "restbase-mod-table-cassandra": "^1.1.1",
     "service-runner": "^2.6.3",
     "json-stable-stringify": "^1.0.1",
     "content-type": "git+https://github.com/wikimedia/content-type#master",


### PR DESCRIPTION
No-op, but just in case.

cc @wikimedia/services 