### PR TITLE
Expose Javascript endpoint

### DIFF
--- a/projects/dev.yaml
+++ b/projects/dev.yaml
@@ -55,6 +55,9 @@ paths:
                 - path: v1/css.yaml
                   options:
                     host: '{{options.mobileapps.host}}'
+                - path: v1/javascript.yaml
+                  options:
+                    host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -121,6 +121,9 @@ paths:
                 - path: v1/css.yaml
                   options:
                     host: '{{options.mobileapps.host}}'
+                - path: v1/javascript.yaml
+                  options:
+                    host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -121,6 +121,9 @@ paths:
                 - path: v1/css.yaml
                   options:
                     host: '{{options.mobileapps.host}}'
+                - path: v1/javascript.yaml
+                  options:
+                    host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -110,6 +110,9 @@ paths:
                 - path: v1/css.yaml
                   options:
                     host: '{{options.mobileapps.host}}'
+                - path: v1/javascript.yaml
+                  options:
+                    host: '{{options.mobileapps.host}}'
         options: '{{options}}'
 
   /{api:sys}:

--- a/v1/javascript.yaml
+++ b/v1/javascript.yaml
@@ -1,0 +1,59 @@
+swagger: '2.0'
+info:
+  version: '1.0.0-beta'
+  title: JavaScript bundle from the wikimedia-page-library
+  description: API for retrieving JavaScript for mobile apps
+  termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
+  contact:
+    name: Reading Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+  license:
+    name: Apache licence, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /javascript/mobile/pagelib:
+    x-route-filters:
+      - path: lib/security_response_header_filter.js
+    get:
+      tags:
+        - Mobile
+      summary: Get JavaScript bundle from the wikimedia-page-library
+      description: |
+        Gets the javascript bundle from the wikimedia-page-library so that clients can have
+        convenient access to that for consuming the content-html HTML.
+        Amongst other things,
+        * it allows to detect the platform and through that enable platform specific CSS rules,
+        * has code to lazy load images on the page,
+        * code for collapsing and expanding tables.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      produces:
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/JavaScript/1.0.0"
+      responses:
+        '200':
+          description: Success
+          headers:
+            ETag:
+              description: Different values indicate that the content has changed
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - get_from_pcs:
+            request:
+              method: get
+              uri: '{{options.host}}/{domain}/v1/data/javascript/mobile/pagelib'
+            return:
+              status: 200
+              headers: '{{ merge({"cache-control": options.response_cache_control},
+                                 get_from_pcs.headers) }}'
+              body: '{{get_from_pcs.body}}'
+      x-monitor: true
+      x-amples:
+        - title: Get the wikimedia-page-library JavaScript bundle
+          response:
+            status: 200
+            headers:
+              content-type: /^text\/javascript; charset=utf-8/
+            body: /.+/


### PR DESCRIPTION
Another Page Content Service endpoint. This patch provides one
page-independent JavaScript response under /data/javascript/mobile/:
* /data/javascript/mobile/pagelib

This is somewhat similar to the CSS endpoints.