### PR TITLE
mobile-html: Do not anchor the ETag field in x-amples

### DIFF
--- a/v1/mobile-html.yaml
+++ b/v1/mobile-html.yaml
@@ -132,6 +132,6 @@ paths:
             status: 200
             headers:
               content-type: /^text\/html/
-              etag: /^"830543386\/[0-9a-f-]+"$/
+              etag: /830543386\/[0-9a-f-]+/
             body: /^<!DOCTYPE html><html/
 


### PR DESCRIPTION
The ETag header might have the optional `W/` portion in front of the
revision number, so do not anchor the regex testing it.

Bug: [T199491](https://phabricator.wikimedia.org/T199491)