### PR TITLE
recommendation API: fix typo in content-type

### DIFF
--- a/v1/recommend.yaml
+++ b/v1/recommend.yaml
@@ -23,7 +23,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
-        - applicaiton/json
+        - application/json
       parameters:
         - name: from_lang
           in: path


### PR DESCRIPTION
Typo was found in https://en.wikipedia.org/api/rest_v1/?spec. Not sure why these things don't get detected when checking the Swagger spec.