### PR TITLE
Update references spec

### DIFF
--- a/v1/references.yaml
+++ b/v1/references.yaml
@@ -155,7 +155,8 @@ definitions:
     description: A single reference list
     properties:
       id:
-        type: string
+        type: ['string', 'null']
+        nullable: true
         description: Identifier for the whole reference list. May be null.
       section_heading:
         type: object
@@ -179,7 +180,6 @@ definitions:
     additionalProperties: false
     required:
       - id
-      - section_heading
       - order
 
   references_by_id:


### PR DESCRIPTION
Some minor updates, from https://gerrit.wikimedia.org/r/c/mediawiki/services/mobileapps/+/449326/3..4
which were necessary to make the spec validation work with a live example, which has a null id and no section_heading.