### PR TITLE
Drop nullable property in references.yaml

### DIFF
--- a/v1/references.yaml
+++ b/v1/references.yaml
@@ -156,7 +156,6 @@ definitions:
     properties:
       id:
         type: ['string', 'null']
-        nullable: true
         description: Identifier for the whole reference list. May be null.
       section_heading:
         type: object


### PR DESCRIPTION
Removed it in MCS, which cause `npm run swagger` to have an additional
error message.

See comments for
https://gerrit.wikimedia.org/r/c/mediawiki/services/mobileapps/+/449326/4..5