### PR TITLE
Add application/problem+json to produces stanza for remaining endpoints

### DIFF
--- a/v1/citoid.yaml
+++ b/v1/citoid.yaml
@@ -37,6 +37,7 @@ paths:
       produces:
         - application/json; charset=utf-8;
         - application/x-bibtex; charset=utf-8
+        - application/problem+json
       parameters:
         - name: format
           in: path

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -24,6 +24,7 @@ paths:
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       produces:
         - application/json
+        - application/problem+json
       responses:
         '200':
           description: A list of page-related API end points.
@@ -47,6 +48,7 @@ paths:
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: title
           in: path
@@ -161,7 +163,7 @@ paths:
           type: string
       produces:
         - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
-        - application/json
+        - application/problem+json
       responses:
         '200':
           description: |
@@ -313,6 +315,7 @@ paths:
         - multipart/form-data
       produces:
         - application/json
+        - application/problem+json
       responses:
         '200':
           description: The content was not changed, and no new version was created.
@@ -362,6 +365,7 @@ paths:
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: title
           in: path
@@ -416,7 +420,7 @@ paths:
       operationId: getFormatRevision
       produces:
         - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
-        - application/json
+        - application/problem+json
       parameters:
         - name: title
           in: path
@@ -552,6 +556,7 @@ paths:
         Stability: [Stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       produces:
         - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.6.0"
+        - application/problem+json
       parameters:
         - name: title
           in: path
@@ -643,6 +648,7 @@ paths:
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: title
           in: path
@@ -759,6 +765,7 @@ paths:
         - multipart/form-data
       produces:
         - application/json
+        - application/problem+json
       responses:
         '200':
           description: The existing revision of the page matches the sent text

--- a/v1/content_segments.yaml
+++ b/v1/content_segments.yaml
@@ -20,6 +20,7 @@ paths:
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: title
           in: path

--- a/v1/graphoid.yaml
+++ b/v1/graphoid.yaml
@@ -13,6 +13,7 @@ paths:
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - image/png
+        - application/problem+json
       parameters:
         - name: title
           in: path

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -19,6 +19,7 @@ paths:
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: type
           in: path
@@ -82,6 +83,7 @@ paths:
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: hash
           in: path
@@ -124,6 +126,7 @@ paths:
         - image/svg+xml
         - application/mathml+xml
         - image/png
+        - application/problem+json
       parameters:
         - name: format
           in: path

--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -30,6 +30,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -123,6 +124,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -230,6 +232,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -304,6 +307,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -376,6 +380,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -454,6 +459,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -541,6 +547,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -635,6 +642,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -736,6 +744,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -827,6 +836,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -918,6 +928,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -1014,6 +1025,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -1116,6 +1128,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -1208,6 +1221,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -1300,6 +1314,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -1395,6 +1410,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -1491,6 +1507,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -1568,6 +1585,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path
@@ -1662,6 +1680,7 @@ paths:
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: project
           in: path

--- a/v1/pdf.yaml
+++ b/v1/pdf.yaml
@@ -27,6 +27,7 @@ paths:
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       produces:
         - application/pdf
+        - application/problem+json
       parameters:
         - name: title
           in: path

--- a/v1/recommend.yaml
+++ b/v1/recommend.yaml
@@ -24,6 +24,7 @@ paths:
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: from_lang
           in: path

--- a/v1/transform-global.yaml
+++ b/v1/transform-global.yaml
@@ -20,6 +20,7 @@ paths:
         - application/x-www-form-urlencoded
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: from_lang
           in: path
@@ -74,6 +75,7 @@ paths:
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: from_lang
           in: path
@@ -122,6 +124,7 @@ paths:
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: from
           in: path
@@ -157,6 +160,7 @@ paths:
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: tool
           in: path

--- a/v1/transform-lang.yaml
+++ b/v1/transform-lang.yaml
@@ -20,6 +20,7 @@ paths:
         - application/x-www-form-urlencoded
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: from
           in: path
@@ -63,6 +64,7 @@ paths:
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: from
           in: path

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -36,6 +36,7 @@ paths:
         - multipart/form-data
       produces:
         - text/plain; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/wikitext/1.0.0"
+        - application/problem+json
       parameters:
         - name: title
           in: path
@@ -125,6 +126,7 @@ paths:
         - multipart/form-data
       produces:
         - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
+        - application/problem+json
       parameters:
         - name: title
           in: path
@@ -225,6 +227,7 @@ paths:
         - application/json
       produces:
         - application/json
+        - application/problem+json
       parameters:
         - name: title
           in: path
@@ -294,6 +297,7 @@ paths:
 #        - multipart/form-data
 #      produces:
 #        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
+#        - application/problem+json
 #      parameters:
 #        - name: title
 #          in: path
@@ -367,6 +371,7 @@ paths:
         - application/json
       produces:
         - text/plain; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/wikitext/1.0.0"
+        - application/problem+json
       parameters:
         - name: title
           in: path


### PR DESCRIPTION
This covers the remaining endpoints exposed through RESTBase,
whenever the response had something like:
        default:
          description: Error
          schema:
            $ref: '#/definitions/problem'

In one case, for content.yaml, I replaced an application/json with
application/problem+json since I didn't see a reason for it to
respond with application/json.