### PR TITLE
Mathoid test failure

### DIFF
--- a/test/features/mathoid.js
+++ b/test/features/mathoid.js
@@ -87,7 +87,7 @@ describe('Mathoid', function() {
     });
 
     for (let i = 0; i < formats.length; i++) {
-        var format = formats[i];
+        const format = formats[i];
         it(`gets the render in ${format}`, () => { // eslint-disable-line no-loop-func
             return preq.get({
                 uri: `${uri}/render/${format}/${hash}`


### PR DESCRIPTION
Changed the test code to be as it was probably intended, iterating over
all values in format. Before this simple change it was just testing the
last value in formats, `png`.
There is no `mml` in the following string:
`application/mathml+xml; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/MathML/1.0.0"`

Found by eslint warning "mutable variable is accessible inside closure".