### PR TITLE
Delete revisions on a new render creation

### DIFF
--- a/sys/multi_content_bucket.js
+++ b/sys/multi_content_bucket.js
@@ -428,7 +428,10 @@ class MultiContentBucket {
                         })
                         .then((res) => {
                             if (res.body.items.length) {
-                                return this._deleteRenders(hyper, req, rev, res.body.items[0].tid);
+                                return P.all(
+                                    this._deleteRenders(hyper, req, rev, res.body.items[0].tid),
+                                    this._deleteRevisions(hyper, req, rev - 1)
+                                );
                             }
                         });
                     })


### PR DESCRIPTION
Removing revisions olny when the new revision is created can end up in a very significant overstoring, so delete the old revisions when the new render arrives as well. Rerenders are far more frequent then revisions.

this is safe as we only update the latest revision renders, so if we are capable of deleting renders, that means all the previous revisions were replaced > 24h ago.

cc @d00rman @eevans 
