### PR TITLE
Allow http URLs in example config

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -96,11 +96,11 @@ spec_root: &spec_root
       name: http
       options:
         allow:
-          - pattern: /^https:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
+          - pattern: /^https?:\/\/[a-zA-Z0-9\.]+\/w\/api\.php/
             forward_headers: true
-          - pattern: /^https:\/\/parsoid-beta.wmflabs.org.+/
+          - pattern: /^https?:\/\/parsoid-beta.wmflabs.org.+/
             forward_headers: true
-          - pattern: /^https:\/\//
+          - pattern: /^https?:\/\//
   paths:
     /{domain:en.wikipedia.org}: *en.wikipedia.org
     /{domain:fr.wikipedia.org}: *wikipedia_project


### PR DESCRIPTION
The x-sub-request-filters patterns used to allow http in the past.
A couple of weeks ago this was change to only allow https. The problem
with this is that developers need to manually change these patterns
when using a local backend instead of the public ones.

This patch bring back the ability to use http://localhost for backend
services, like MCS or Parsoid, without an extra step needed to get the
configuration right.

Bug: https://phabricator.wikimedia.org/T202425