### PR TITLE
Bump expected Parsoid version to 1.7.0

### DIFF
--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -506,7 +506,7 @@ describe('storage-backed transform api', () => {
             headers: { 'content-type': 'application/json' },
             body: {
                 headers: {
-                  'content-type': 'text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"'
+                  'content-type': 'text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"'
                 },
                 body: '<html>The modified HTML</html>'
             }

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -162,7 +162,7 @@ paths:
           required: false
           type: string
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
         - application/json
         - application/problem+json
       responses:
@@ -420,7 +420,7 @@ paths:
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       operationId: getFormatRevision
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
         - application/json
         - application/problem+json
       parameters:
@@ -557,7 +557,7 @@ paths:
 
         Stability: [Stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       produces:
-        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.6.0"
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.7.0"
         - application/problem+json
       parameters:
         - name: title

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -125,7 +125,7 @@ paths:
       consumes:
         - multipart/form-data
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
         - application/problem+json
       parameters:
         - name: title
@@ -296,7 +296,7 @@ paths:
 #      consumes:
 #        - multipart/form-data
 #      produces:
-#        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
+#        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
 #        - application/problem+json
 #      parameters:
 #        - name: title


### PR DESCRIPTION
90% of traffic is already service 1.7.0, so it's safe to upgrade the minimal content-type version.

cc @wikimedia/services @subbuss @arlolra 