### PR TITLE
Bump summary to stable endpoint

### DIFF
--- a/v1/summary_new.yaml
+++ b/v1/summary_new.yaml
@@ -28,7 +28,7 @@ paths:
         sentences, as well as information about a thumbnail that represents
         the page.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       produces:
         - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.3.7"
         - application/problem+json


### PR DESCRIPTION
Since the summary is used for page previews on all wikis now, I think it's time to bump it to `stable`

cc @wikimedia/services