### PR TITLE
Update and add metrics endpoints

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -1119,8 +1119,8 @@ paths:
         Given a Mediawiki project and a date range, returns a timeseries of the top 100 editors by
         edits count. You can filter by editor-type (all-editor-types, anonymous, group-bot,
         name-bot, user) or page-type (all-page-types, content or non-content). You can choose
-        between daily and monthly granularity as well. The user_id returned is either the
-        mediawiki user_id if user is registered, or his/her IP if the user is anonymous.
+        between daily and monthly granularity as well. The user_text returned is either the
+        mediawiki user_name if user is registered, or his/her IP if the user is anonymous.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
         - Rate limit: 25 req/s
@@ -1212,8 +1212,8 @@ paths:
         Given a Mediawiki project and a date range, returns a timeseries of the top 100 editors by
         net bytes-difference. You can filter by editor-type (all-editor-types, anonymous, group-bot,
         name-bot, user) or page-type (all-page-types, content or non-content). You can choose
-        between daily and monthly granularity as well. The user_id returned is either the mediawiki
-        user_id if user is registered, or his/her IP if the user is anonymous.
+        between daily and monthly granularity as well. The user_text returned is either the mediawiki
+        user_name if user is registered, or his/her IP if the user is anonymous.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
         - Rate limit: 25 req/s
@@ -1305,8 +1305,8 @@ paths:
         Given a Mediawiki project and a date range, returns a timeseries of the top 100 editors by
         absolute bytes-difference. You can filter by editor-type (all-editor-types, anonymous,
         group-bot, name-bot, user) or page-type (all-page-types, content or non-content). You can
-        choose between daily and monthly granularity as well. The user_id returned is either the
-        mediawiki user_id if user is registered, or his/her IP if the user is anonymous.
+        choose between daily and monthly granularity as well. The user_text returned is either the
+        mediawiki user_name if user is registered, or his/her IP if the user is anonymous.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
         - Rate limit: 25 req/s
@@ -1487,6 +1487,183 @@ paths:
                 keepAlive: true
       x-monitor: false
 
+  /edits/per-page/{project}/{page-title}/{editor-type}/{granularity}/{start}/{end}:
+    get:
+      tags:
+        - Edits data
+      summary: Get edit counts for a page in a project.
+      description: |
+        Given a Mediawiki project, a page-title prefixed with its canonical namespace (for
+        instance 'User:Jimbo_Wales') and a date range, returns a timeseries of edit counts.
+        You can filter by editors-type (all-editor-types, anonymous, group-bot, name-bot, user).
+        You can choose between daily and monthly granularity as well.
+
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 25 req/s
+        - License: Data accessible via this endpoint is available under the
+          [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
+      produces:
+        - application/json
+        - application/problem+json
+      parameters:
+        - name: project
+          in: path
+          description: |
+            The name of any Wikimedia project formatted like {language code}.{project name},
+            for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped
+            off. For projects like commons without language codes, use commons.wikimedia. For
+            projects like www.mediawiki.org, you can use that full string, or just use mediawiki
+            or mediawiki.org.
+          type: string
+          required: true
+        - name: page-title
+          in: path
+          description: |
+            The page-title to request edits for. It should be prefixed with canonical namespace.
+            Spaces will be converted to underscores.
+          type: string
+          required: true
+        - name: editor-type
+          in: path
+          description: |
+            If you want to filter by editor-type, use one of anonymous, group-bot (registered
+            accounts belonging to the bot group), name-bot (registered accounts not belonging to
+            the bot group but having bot-like names) or user (registered account not in bot group
+            nor having bot-like name). If you are interested in edits regardless of their
+            editor-type, use all-editor-types.
+          type: string
+          enum: ['all-editor-types', 'anonymous', 'group-bot', 'name-bot', 'user']
+          required: true
+        - name: granularity
+          in: path
+          description: |
+            Time unit for the response data. As of today, supported values are daily and monthly
+          type: string
+          enum: ['daily', 'monthly']
+          required: true
+        - name: start
+          in: path
+          description: The date of the first day to include, in YYYYMMDD format
+          type: string
+          required: true
+        - name: end
+          in: path
+          description: The date of the last day to include, in YYYYMMDD format
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of values
+          schema:
+            $ref: '#/definitions/edits-per-page'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 25
+              external: 25
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/edits/per-page/{project}/{page-title}/{editor-type}/{granularity}/{start}/{end}'
+              headers:
+                x-client-ip: '{{x-client-ip}}'
+              agentOptions:
+                keepAlive: true
+      x-monitor: false
+
+  /edits/per-editor/{project}/{user-text}/{page-type}/{granularity}/{start}/{end}:
+    get:
+      tags:
+        - Edits data
+      summary: Get the edits counts for an editor in a project.
+      description: |
+        Given a Mediawiki project, a user-text and a date range, returns a timeseries of edits
+        counts. You can filter by page type (all-page-types, content or non-content). You can
+        choose between daily and monthly granularity as well.
+
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 25 req/s
+        - License: Data accessible via this endpoint is available under the
+          [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
+      produces:
+        - application/json
+        - application/problem+json
+      parameters:
+        - name: project
+          in: path
+          description: |
+            The name of any Wikimedia project formatted like {language code}.{project name},
+            for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped
+            off. For projects like commons without language codes, use commons.wikimedia. For
+            projects like www.mediawiki.org, you can use that full string, or just use mediawiki
+            or mediawiki.org.
+          type: string
+          required: true
+        - name: user-text
+          in: path
+          description: |
+            The user you want to get edits for. Can be either a registered user-name, or an
+            anonymous user IP.
+          type: string
+          required: true
+        - name: page-type
+          in: path
+          description: |
+            If you want to filter by page-type, use one of content (edits on pages in content
+            namespaces) or non-content (edits on pages in non-content namespaces). If you are
+            interested in edits regardless of their page-type, use all-page-types.
+          type: string
+          enum: ['all-page-types', 'content', 'non-content']
+          required: true
+        - name: granularity
+          in: path
+          description: |
+            Time unit for the response data. As of today, supported values are daily and monthly
+          type: string
+          enum: ['daily', 'monthly']
+          required: true
+        - name: start
+          in: path
+          description: The date of the first day to include, in YYYYMMDD format
+          type: string
+          required: true
+        - name: end
+          in: path
+          description: The date of the last day to include, in YYYYMMDD format
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of values
+          schema:
+            $ref: '#/definitions/edits-per-editor'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 25
+              external: 25
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/edits/per-editor/{project}/{user-text}/{page-type}/{granularity}/{start}/{end}'
+              headers:
+                x-client-ip: '{{x-client-ip}}'
+              agentOptions:
+                keepAlive: true
+      x-monitor: false
+
 
   ########################################
   # Registered Users
@@ -1566,7 +1743,7 @@ paths:
 
 
   ########################################
-  # Bytes difference
+  # Net Bytes difference
   ########################################
   /bytes-difference/net/aggregate/{project}/{editor-type}/{page-type}/{granularity}/{start}/{end}:
     get:
@@ -1661,6 +1838,187 @@ paths:
                 keepAlive: true
       x-monitor: false
 
+  /bytes-difference/net/per-page/{project}/{page-title}/{editor-type}/{granularity}/{start}/{end}:
+    get:
+      tags:
+        - Bytes difference data
+      summary: Get the sum of net text bytes difference per page.
+      description: |
+        Given a Mediawiki project, a page-title prefixed with canonical namespace (for
+        instance 'User:Jimbo_Wales') and a date range, returns a timeseries of bytes
+        difference net sums. You can filter by editors-type (all-editor-types, anonymous,
+        group-bot, name-bot, user). You can choose between daily and monthly granularity as well.
+
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 25 req/s
+        - License: Data accessible via this endpoint is available under the
+          [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
+      produces:
+        - application/json
+        - application/problem+json
+      parameters:
+        - name: project
+          in: path
+          description: |
+            The name of any Wikimedia project formatted like {language code}.{project name},
+            for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped
+            off. For projects like commons without language codes, use commons.wikimedia. For
+            projects like www.mediawiki.org, you can use that full string, or just use mediawiki
+            or mediawiki.org.
+          type: string
+          required: true
+        - name: page-title
+          in: path
+          description: |
+            The page-title to request net bytes-difference for. Should be prefixed with the
+            page canonical namespace.
+          type: string
+          required: true
+        - name: editor-type
+          in: path
+          description: |
+            If you want to filter by editor-type, use one of anonymous, group-bot (registered
+            accounts belonging to the bot group), name-bot (registered accounts not belonging to
+            the bot group but having bot-like names) or user (registered account not in bot group
+            nor having bot-like name). If you are interested in edits regardless of their
+            editor-type, use all-editor-types.
+          type: string
+          enum: ['all-editor-types', 'anonymous', 'group-bot', 'name-bot', 'user']
+          required: true
+        - name: granularity
+          in: path
+          description: |
+            Time unit for the response data. As of today, supported values are daily and monthly
+          type: string
+          enum: ['daily', 'monthly']
+          required: true
+        - name: start
+          in: path
+          description: The date of the first day to include, in YYYYMMDD format
+          type: string
+          required: true
+        - name: end
+          in: path
+          description: The date of the last day to include, in YYYYMMDD format
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of values
+          schema:
+            $ref: '#/definitions/net-bytes-difference-per-page'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 25
+              external: 25
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/bytes-difference/net/per-page/{project}/{page-title}/{editor-type}/{granularity}/{start}/{end}'
+              headers:
+                x-client-ip: '{{x-client-ip}}'
+              agentOptions:
+                keepAlive: true
+      x-monitor: false
+
+  /bytes-difference/net/per-editor/{project}/{user-text}/{page-type}/{granularity}/{start}/{end}:
+    get:
+      tags:
+        - Bytes difference data
+      summary: Get the sum of net text bytes difference per editor.
+      description: |
+        Given a Mediawiki project, an user-text and a date range, returns a timeseries of bytes
+        difference net sums. You can filter by page-type (all-page-types, content, non-content).
+        You can choose between daily and monthly granularity as well.
+
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 25 req/s
+        - License: Data accessible via this endpoint is available under the
+          [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
+      produces:
+        - application/json
+        - application/problem+json
+      parameters:
+        - name: project
+          in: path
+          description: |
+            The name of any Wikimedia project formatted like {language code}.{project name},
+            for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped
+            off. For projects like commons without language codes, use commons.wikimedia. For
+            projects like www.mediawiki.org, you can use that full string, or just use mediawiki
+            or mediawiki.org.
+          type: string
+          required: true
+        - name: user-text
+          in: path
+          description: |
+            The user-text to request net bytes-difference for. Can be either a registered
+            user-name or an anonymous user IP.
+          type: string
+          required: true
+        - name: page-type
+          in: path
+          description: |
+            If you want to filter by page-type, use one of content (edits on pages in content
+            namespaces) or non-content (edits on pages in non-content namespaces). If you are
+            interested in edits regardless of their page-type, use all-page-types.
+          type: string
+          enum: ['all-page-types', 'content', 'non-content']
+          required: true
+        - name: granularity
+          in: path
+          description: |
+            Time unit for the response data. As of today, supported values are daily and monthly
+          type: string
+          enum: ['daily', 'monthly']
+          required: true
+        - name: start
+          in: path
+          description: The date of the first day to include, in YYYYMMDD format
+          type: string
+          required: true
+        - name: end
+          in: path
+          description: The date of the last day to include, in YYYYMMDD format
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of values
+          schema:
+            $ref: '#/definitions/net-bytes-difference-per-editor'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 25
+              external: 25
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/bytes-difference/net/per-editor/{project}/{user-text}/{page-type}/{granularity}/{start}/{end}'
+              headers:
+                x-client-ip: '{{x-client-ip}}'
+              agentOptions:
+                keepAlive: true
+      x-monitor: false
+
+
+  ########################################
+  # Absolute Bytes difference
+  ########################################
   /bytes-difference/absolute/aggregate/{project}/{editor-type}/{page-type}/{granularity}/{start}/{end}:
     get:
       tags:
@@ -1756,7 +2114,187 @@ paths:
                 keepAlive: true
       x-monitor: false
 
+  /bytes-difference/absolute/per-page/{project}/{page-title}/{editor-type}/{granularity}/{start}/{end}:
+    get:
+      tags:
+        - Bytes difference data
+      summary: Get the sum of absolute text bytes difference per page.
+      description: |
+        Given a Mediawiki project, a page-title prefixed with canonical namespace (for
+        instance 'User:Jimbo_Wales') and a date range, returns a timeseries of bytes
+        difference absolute sums. You can filter by editors-type (all-editor-types, anonymous,
+        group-bot, name-bot, user). You can choose between daily and monthly granularity as well.
 
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 25 req/s
+        - License: Data accessible via this endpoint is available under the
+          [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
+      produces:
+        - application/json
+        - application/problem+json
+      parameters:
+        - name: project
+          in: path
+          description: |
+            The name of any Wikimedia project formatted like {language code}.{project name},
+            for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped
+            off. For projects like commons without language codes, use commons.wikimedia. For
+            projects like www.mediawiki.org, you can use that full string, or just use mediawiki
+            or mediawiki.org.
+          type: string
+          required: true
+        - name: page-title
+          in: path
+          description: |
+            The page-title to request absolute bytes-difference for. Should be prefixed with the
+            page canonical namespace.
+          type: string
+          required: true
+        - name: editor-type
+          in: path
+          description: |
+            If you want to filter by editor-type, use one of anonymous, group-bot (registered
+            accounts belonging to the bot group), name-bot (registered accounts not belonging to
+            the bot group but having bot-like names) or user (registered account not in bot group
+            nor having bot-like name). If you are interested in edits regardless of their
+            editor-type, use all-editor-types.
+          type: string
+          enum: ['all-editor-types', 'anonymous', 'group-bot', 'name-bot', 'user']
+          required: true
+        - name: granularity
+          in: path
+          description: |
+            Time unit for the response data. As of today, supported values are daily and monthly
+          type: string
+          enum: ['daily', 'monthly']
+          required: true
+        - name: start
+          in: path
+          description: The date of the first day to include, in YYYYMMDD format
+          type: string
+          required: true
+        - name: end
+          in: path
+          description: The date of the last day to include, in YYYYMMDD format
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of values
+          schema:
+            $ref: '#/definitions/absolute-bytes-difference-per-page'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 25
+              external: 25
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/bytes-difference/absolute/per-page/{project}/{page-title}/{editor-type}/{granularity}/{start}/{end}'
+              headers:
+                x-client-ip: '{{x-client-ip}}'
+              agentOptions:
+                keepAlive: true
+      x-monitor: false
+
+  /bytes-difference/absolute/per-editor/{project}/{user-text}/{page-type}/{granularity}/{start}/{end}:
+    get:
+      tags:
+        - Bytes difference data
+      summary: Get the sum of absolute text bytes difference per editor.
+      description: |
+        Given a Mediawiki project, an user_text and a date range, returns a timeseries of bytes
+        difference absolute sums. You can filter by page-type (all-page-types, content,
+        non-content). You can choose between daily and monthly granularity as well.
+
+        - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        - Rate limit: 25 req/s
+        - License: Data accessible via this endpoint is available under the
+          [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
+      produces:
+        - application/json
+        - application/problem+json
+      parameters:
+        - name: project
+          in: path
+          description: |
+            The name of any Wikimedia project formatted like {language code}.{project name},
+            for example en.wikipedia. You may pass en.wikipedia.org and the .org will be stripped
+            off. For projects like commons without language codes, use commons.wikimedia. For
+            projects like www.mediawiki.org, you can use that full string, or just use mediawiki
+            or mediawiki.org.
+          type: string
+          required: true
+        - name: user-text
+          in: path
+          description: |
+            The user-text to request absolute bytes-difference for. Can be either a registered
+            user-name or an anonymous user IP.
+          type: string
+          required: true
+        - name: page-type
+          in: path
+          description: |
+            If you want to filter by page-type, use one of content (edits on pages in content
+            namespaces) or non-content (edits on pages in non-content namespaces). If you are
+            interested in edits regardless of their page-type, use all-page-types.
+          type: string
+          enum: ['all-page-types', 'content', 'non-content']
+          required: true
+        - name: granularity
+          in: path
+          description: |
+            Time unit for the response data. As of today, supported values are daily and monthly
+          type: string
+          enum: ['daily', 'monthly']
+          required: true
+        - name: start
+          in: path
+          description: The date of the first day to include, in YYYYMMDD format
+          type: string
+          required: true
+        - name: end
+          in: path
+          description: The date of the last day to include, in YYYYMMDD format
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The list of values
+          schema:
+            $ref: '#/definitions/absolute-bytes-difference-per-editor'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-route-filters:
+        - type: default
+          name: ratelimit_route
+          options:
+            limits:
+              internal: 25
+              external: 25
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/bytes-difference/absolute/per-editor/{project}/{user-text}/{page-type}/{granularity}/{start}/{end}'
+              headers:
+                x-client-ip: '{{x-client-ip}}'
+              agentOptions:
+                keepAlive: true
+      x-monitor: false
+
+
+########################################
+# Definitions
+########################################
 definitions:
   listing:
     description: The result format for listings
@@ -1981,7 +2519,7 @@ definitions:
                     type: array
                     items:
                       properties:
-                        page_id:
+                        page_title:
                           type: string
                         edits:
                           type: integer
@@ -2011,7 +2549,7 @@ definitions:
                     type: array
                     items:
                       properties:
-                        page_id:
+                        page_title:
                           type: string
                         net_bytes_diff:
                           type: integer
@@ -2041,7 +2579,7 @@ definitions:
                     type: array
                     items:
                       properties:
-                        page_id:
+                        page_title:
                           type: string
                         abs_bytes_diff:
                           type: integer
@@ -2098,7 +2636,7 @@ definitions:
                     type: array
                     items:
                       properties:
-                        user_id:
+                        user_text:
                           type: string
                         edits:
                           type: integer
@@ -2128,7 +2666,7 @@ definitions:
                     type: array
                     items:
                       properties:
-                        user_id:
+                        user_text:
                           type: string
                         net_bytes_diff:
                           type: integer
@@ -2158,7 +2696,7 @@ definitions:
                     type: array
                     items:
                       properties:
-                        user_id:
+                        user_text:
                           type: string
                         abs_bytes_diff:
                           type: integer
@@ -2175,6 +2713,54 @@ definitions:
               type : string
             editor-type:
               type : string
+            page-type:
+              type: string
+            granularity:
+              type: string
+            results:
+              type: array
+              items:
+                properties:
+                  timestamp:
+                    type: string
+                  edits:
+                    type: integer
+                    format: int64
+
+  edits-per-page:
+    properties:
+      items:
+        type: array
+        items:
+          properties:
+            project:
+              type : string
+            page-title:
+              type: string
+            editor-type:
+              type : string
+            granularity:
+              type: string
+            results:
+              type: array
+              items:
+                properties:
+                  timestamp:
+                    type: string
+                  edits:
+                    type: integer
+                    format: int64
+
+  edits-per-editor:
+    properties:
+      items:
+        type: array
+        items:
+          properties:
+            project:
+              type : string
+            user-text:
+              type: string
             page-type:
               type: string
             granularity:
@@ -2210,7 +2796,7 @@ definitions:
                     type: integer
                     format: int32
 
-  ## Bytes Difference
+  ## Net Bytes Difference
   net-bytes-difference:
     properties:
       items:
@@ -2235,6 +2821,55 @@ definitions:
                     type: integer
                     format: int64
 
+  net-bytes-difference-per-page:
+    properties:
+      items:
+        type: array
+        items:
+          properties:
+            project:
+              type : string
+            page-title:
+              type: string
+            editor-type:
+              type : string
+            granularity:
+              type: string
+            results:
+              type: array
+              items:
+                properties:
+                  timestamp:
+                    type: string
+                  net_bytes_diff:
+                    type: integer
+                    format: int64
+
+  net-bytes-difference-per-editor:
+    properties:
+      items:
+        type: array
+        items:
+          properties:
+            project:
+              type : string
+            user-text:
+              type: string
+            page-type:
+              type: string
+            granularity:
+              type: string
+            results:
+              type: array
+              items:
+                properties:
+                  timestamp:
+                    type: string
+                  net_bytes_diff:
+                    type: integer
+                    format: int64
+
+  ## Net Bytes Difference
   absolute-bytes-difference:
     properties:
       items:
@@ -2245,6 +2880,53 @@ definitions:
               type : string
             editor-type:
               type : string
+            page-type:
+              type: string
+            granularity:
+              type: string
+            results:
+              type: array
+              items:
+                properties:
+                  timestamp:
+                    type: string
+                  abs_bytes_diff:
+                    type: integer
+                    format: int64
+  absolute-bytes-difference-per-page:
+    properties:
+      items:
+        type: array
+        items:
+          properties:
+            project:
+              type : string
+            page-title:
+              type: string
+            editor-type:
+              type : string
+            granularity:
+              type: string
+            results:
+              type: array
+              items:
+                properties:
+                  timestamp:
+                    type: string
+                  abs_bytes_diff:
+                    type: integer
+                    format: int64
+
+  absolute-bytes-difference-per-editor:
+    properties:
+      items:
+        type: array
+        items:
+          properties:
+            project:
+              type : string
+            user-text:
+              type: string
             page-type:
               type: string
             granularity:


### PR DESCRIPTION
AQS have been updated to serve endpoints using page-title and
user-text instead of IDs. This patch updates the existing
endpoints that used ids and adds new endpoints by-user and
by-page.