### PR TITLE
Revert bumping Parsoid content-type filter

### DIFF
--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -162,7 +162,7 @@ paths:
           required: false
           type: string
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
         - application/json
         - application/problem+json
       responses:
@@ -420,7 +420,7 @@ paths:
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       operationId: getFormatRevision
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
         - application/json
         - application/problem+json
       parameters:
@@ -557,7 +557,7 @@ paths:
 
         Stability: [Stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       produces:
-        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.7.0"
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.6.0"
         - application/problem+json
       parameters:
         - name: title

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -125,7 +125,7 @@ paths:
       consumes:
         - multipart/form-data
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
         - application/problem+json
       parameters:
         - name: title
@@ -296,7 +296,7 @@ paths:
 #      consumes:
 #        - multipart/form-data
 #      produces:
-#        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
+#        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.6.0"
 #        - application/problem+json
 #      parameters:
 #        - name: title


### PR DESCRIPTION
This is an ASAP temporary fix for https://phabricator.wikimedia.org/T194190#4564170

cc @wikimedia/services @wikimedia/parsing 