### PR TITLE
MCS: Remove tests that directly call the service

### DIFF
--- a/v1/availability.yaml
+++ b/v1/availability.yaml
@@ -41,22 +41,7 @@ paths:
               status: '{{get_feed_content_availability.status}}'
               headers: '{{get_feed_content_availability.headers}}'
               body: '{{get_feed_content_availability.body}}'
-      x-monitor: true
-      x-amples:
-        - title: Retrieve feed content availability
-          request:
-            params:
-              domain: wikimedia.org
-          response:
-            status: 200
-            headers:
-              content-type: application/json
-            body:
-              todays_featured_article: [ /.+/ ]
-              most_read: [ '*' ]
-              picture_of_the_day: [ '*' ]
-              in_the_news: [ /.+/ ]
-              on_this_day: [ /.+/ ]
+      x-monitor: false
 
 # copied from MCS spec.yaml
 definitions:

--- a/v1/css.yaml
+++ b/v1/css.yaml
@@ -62,32 +62,4 @@ paths:
               headers: '{{ merge({"cache-control": options.response_cache_control},
                                  get_from_pcs.headers) }}'
               body: '{{get_from_pcs.body}}'
-      x-monitor: true
-      x-amples:
-        - title: Get base CSS
-          request:
-            params:
-              type: base
-          response:
-            status: 200
-            headers:
-              content-type: /^text\/css; charset=utf-8/
-            body: /.+/
-        - title: Get pagelib CSS
-          request:
-            params:
-              type: pagelib
-          response:
-            status: 200
-            headers:
-              content-type: /^text\/css; charset=utf-8/
-            body: /.+/
-        - title: Get site CSS
-          request:
-            params:
-              type: site
-          response:
-            status: 200
-            headers:
-              content-type: /^text\/css; charset=utf-8/
-            body: /.+/
+      x-monitor: false

--- a/v1/javascript.yaml
+++ b/v1/javascript.yaml
@@ -50,11 +50,4 @@ paths:
               headers: '{{ merge({"cache-control": options.response_cache_control},
                                  get_from_pcs.headers) }}'
               body: '{{get_from_pcs.body}}'
-      x-monitor: true
-      x-amples:
-        - title: Get the wikimedia-page-library JavaScript bundle
-          response:
-            status: 200
-            headers:
-              content-type: /^text\/javascript; charset=utf-8/
-            body: /.+/
+      x-monitor: false

--- a/v1/media.yaml
+++ b/v1/media.yaml
@@ -97,24 +97,7 @@ paths:
               headers: '{{ merge({"cache-control": options.response_cache_control},
                                  get_from_pcs.headers) }}'
               body: '{{get_from_pcs.body}}'
-      x-monitor: true
-      x-amples:
-        - title: Get media in test page
-          request:
-            params:
-              domain: en.wikipedia.org
-              title: User:BSitzmann_(WMF)/MCS/Test/Frankenstein
-              revision: 803891963
-          response:
-            status: 200
-            headers:
-              content-type: /application\/json/
-            body:
-              revision: /.+/
-              tid: /.+/
-              items:
-                - section_id: /.+/
-                  type: /.+/
+      x-monitor: false
 
 # copied from MCS spec.yaml
 definitions:

--- a/v1/metadata.yaml
+++ b/v1/metadata.yaml
@@ -96,52 +96,7 @@ paths:
               headers: '{{ merge({"cache-control": options.response_cache_control},
                                  get_from_pcs.headers) }}'
               body: '{{get_from_pcs.body}}'
-      x-monitor: true
-      x-amples:
-        - title: Get extended metadata of a test page
-          request:
-            params:
-              domain: en.wikipedia.org
-              title: Video
-              revision: 830543386
-          response:
-            status: 200
-            headers:
-              content-type: /application\/json/
-            body:
-              revision: /.+/
-              tid: /.+/
-              hatnotes:
-                - section: /.+/
-                  html: /.+/
-              issues:
-                - section: /.+/
-                  html: /.+/
-              toc:
-                title: /.+/
-                entries:
-                  - level: /.+/
-                    section: /.+/
-                    number: /.+/
-                    anchor: /.+/
-                    html: /.+/
-              language_links:
-                - lang: /.+/
-                  titles:
-                    canonical: /.+/
-                    normalized: /.+/
-                  summary_url: /.+/
-              categories:
-                - titles:
-                    canonical: /.+/
-                    normalized: /.+/
-                    display: /.+/
-                  hidden: /.+/
-                  ns: /.+/
-                  summary_url: /.+/
-              protection:
-                edit: [ /.+/ ]
-                move: [ /.+/ ]
+      x-monitor: false
 
 # copied from MCS spec.yaml
 definitions:

--- a/v1/mobile-html.yaml
+++ b/v1/mobile-html.yaml
@@ -122,18 +122,5 @@ paths:
               headers: '{{ merge({"cache-control": options.response_cache_control},
                                  get_from_pcs.headers) }}'
               body: '{{get_from_pcs.body}}'
-      x-monitor: true
-      x-amples:
-        - title: Get mobile-html of a test page
-          request:
-            params:
-              domain: en.wikipedia.org
-              title: Video
-              revision: 830543386
-          response:
-            status: 200
-            headers:
-              content-type: /^text\/html/
-              etag: /830543386\/[0-9a-f-]+/
-            body: /^<!DOCTYPE html><html/
+      x-monitor: false
 

--- a/v1/random.yaml
+++ b/v1/random.yaml
@@ -41,15 +41,5 @@ paths:
               headers:
                 cache_control: '{{options.random_cache_control}}'
                 location: '../{request.params.format}/{title_from_mobileapps.body.items[0].title}'
-      x-monitor: true
-      x-amples:
-        - title: Random title redirect
-          request:
-            params:
-              format: title
-          response:
-            status: 303
-            headers:
-              cache-control: /.+/
-              location: /^..\/title\/[^\/]+$/
-        
+      x-monitor: false
+

--- a/v1/references.yaml
+++ b/v1/references.yaml
@@ -97,28 +97,7 @@ paths:
               headers: '{{ merge({"cache-control": options.response_cache_control},
                                  get_from_pcs.headers) }}'
               body: '{{get_from_pcs.body}}'
-      x-monitor: true
-      x-amples:
-        - title: Get references of a test page
-          request:
-            params:
-              domain: en.wikipedia.org
-              title: Video
-              revision: 830543386
-          response:
-            status: 200
-            headers:
-              content-type: /application\/json/
-            body:
-              revision: /.+/
-              tid: /.+/
-              reference_lists:
-                - id: /.*/
-                  section_heading:
-                    id: /.+/
-                    html: /.+/
-                  order: [ /.*/ ]
-              references_by_id: /.+/
+      x-monitor: false
 
 # copied from MCS spec.yaml
 definitions:


### PR DESCRIPTION
Over time we have accumulated numerous x-amples that bypass all RB features and directly call the Mobile Content Service. Since all of these are directly tested in MCS' x-amples, there is no need to do that in RB as well.

Nevertheless, the announcement x-ample has been left to assert that MCS is reachable to RB.