### PR TITLE
Do not dynamically generate Parsoid content if TID is provided.

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -479,7 +479,7 @@ class ParsoidService {
     getFormat(format, hyper, req) {
         const rp = req.params;
         const generateContent = (storageRes) => {
-            if (storageRes.status === 404 || storageRes.status === 200) {
+            if (!rp.tid && (storageRes.status === 404 || storageRes.status === 200)) {
                 return this.generateAndSave(hyper, req, format, storageRes);
             } else {
                 // Don't generate content if there's some other error.

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -7,6 +7,7 @@ const assert = require('../../../utils/assert.js');
 const server = require('../../../utils/server.js');
 const preq   = require('preq');
 const mwUtil = require('../../../../lib/mwUtil');
+const uuid   = require('cassandra-uuid');
 
 const revA = '275843';
 const revB = '275844';
@@ -54,6 +55,18 @@ describe('on-demand generation of html and data-parsoid', function() {
             assert.localRequests(slice, false);
             assert.remoteRequests(slice, true);
             revBETag = res.headers.etag.replace(/^"(.*)"$/, '$1');
+        });
+    });
+
+    it('should not transparently create revision B via Parsoid if TID is provided', () => {
+        const slice = server.config.logStream.slice();
+        return preq.get({
+            uri: `${pageUrl}/html/${title}/${revB}/${uuid.TimeUuid.now().toString()}`,
+        })
+        .then((res) => {
+            throw new Error('404 should have been thrown');
+        }, (e) => {
+            assert.deepEqual(e.status, 404);
         });
     });
 

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -376,7 +376,7 @@ parallel('transform api', function() {
 
     it('supports reversed order of properties in TimeUuid meta', () => {
         const newHtml = testPage.html.replace(/<meta property="mw:TimeUuid" content="([^"]+)"\/?>/,
-            '<meta content="cc8ba6b3-636c-11e5-b601-24b4f65ab671" property="mw:TimeUuid" />');
+            '<meta content="$1" property="mw:TimeUuid" />');
         return preq.post({
             uri: `${server.config.labsURL
             }/transform/html/to/wikitext/${testPage.title
@@ -393,25 +393,6 @@ parallel('transform api', function() {
                 }\nSaw: ${JSON.stringify(res, null, 2)}`);
             }
             assert.contentType(res, contentTypes.wikitext);
-        });
-    });
-
-    it('returns 409 if revision was restricted while edit happened', () => {
-        const badPageName = 'User_talk:DivineAlpha%2fQ1_2015_discussions';
-        const badRevNumber = 645504917;
-        return preq.post({
-            uri: `${server.config.baseURL
-            }/transform/html/to/wikitext/${badPageName}/${badRevNumber}`,
-            body: {
-                html: '<html><head>' +
-                    '<meta property="mw:TimeUuid" content="71966eaf-62cd-11e5-8a88-952fdaad0387"/>' +
-                    '</head><body></body></html>'
-            }
-        })
-        .then(() => {
-            throw new Error('Error should be thrown');
-        }, (e) => {
-            assert.deepEqual(e.status, 409);
         });
     });
 


### PR DESCRIPTION
Unfortunately, the 409 test is now impossible and requires way more work to set it up. 

cc @wikimedia/services @wikimedia/parsing 

Bug: https://phabricator.wikimedia.org/T204880