### PR TITLE
No need to log the request, it duplicates root_req

### DIFF
--- a/lib/content_negotiation_filter.js
+++ b/lib/content_negotiation_filter.js
@@ -41,7 +41,6 @@ module.exports = (hyper, req, next, options, specInfo) => {
             // If it's not the sections - something is very wrong on our side.
             hyper.logger.log('error/negotiation', {
                 message: 'Failed to find out stored Parsoid version',
-                request: req,
                 requested_version: requestedVersion
             });
             return htmlRes;
@@ -65,7 +64,6 @@ module.exports = (hyper, req, next, options, specInfo) => {
                 }
                 hyper.logger.log('error/negotiation', {
                     message: 'Failed to satisfy required version',
-                    request: req,
                     requested_version: requestedVersion,
                     stored_version: storedVersion
                 });
@@ -114,7 +112,6 @@ module.exports = (hyper, req, next, options, specInfo) => {
         .catch((e) => {
             hyper.logger.log('error/negotiation', {
                 message: 'Failed to transform content',
-                request: req,
                 requested_version: requestedVersion,
                 stored_version: storedVersion,
                 error: e


### PR DESCRIPTION
This duplicates the `root_req` but includes some large fields we don't need in logstash