### PR TITLE
Remove old hack we reusing TID.

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -343,13 +343,8 @@ class ParsoidService {
 
             return P.join(parsoidReq, mwUtil.decodeBody(currentContentRes))
             .spread((res, currentContentRes) => {
-                // If the content is coming from old storage - tid will already be there
-                // so reuse it.
-                let tid = extractTidMeta(res.body.html.body);
-                if (!tid) {
-                    tid = uuid.now().toString();
-                    res.body.html.body = insertTidMeta(res.body.html.body, tid);
-                }
+                const tid  = uuid.now().toString();
+                res.body.html.body = insertTidMeta(res.body.html.body, tid);
 
                 if (format === 'html'
                         && currentContentRes


### PR DESCRIPTION
During the switch from the old storage to the new storage we've used
to use old storage instead of actually running Parsoid, so we've
needed to reuse the TID of the old content before storing the new
content. The hack was removed, but the reusing code remained. It's not
needed any more without the hack.

cc @wikimedia/services 