### PR TITLE
Downgrade major-greater to minor-greater if no-cache is required

### DIFF
--- a/lib/content_negotiation_filter.js
+++ b/lib/content_negotiation_filter.js
@@ -6,8 +6,51 @@ const HTTPError = HyperSwitch.HTTPError;
 const URI = HyperSwitch.URI;
 const mwUtil = require('./mwUtil');
 
-module.exports = (hyper, req, next, options, specInfo) => {
+function downgrade(hyper, req, html, existingVersion, requestedVersion) {
     const rp = req.params;
+    const start = Date.now();
+    // The version is less then we expected - downgrade.
+    return hyper.post({
+        uri: new URI([rp.domain, 'sys', 'parsoid', 'transform', 'html', 'to', 'html']),
+        headers: {
+            'content-type': 'application/json',
+            'accept': req.headers.accept
+        },
+        body: {
+            original: {
+                html: {
+                    headers: html.headers,
+                    body: html.body.toString()
+                },
+                'data-parsoid': {
+                    body: { ids: {} }
+                }
+            }
+        }
+    })
+    .then((res) => {
+        hyper.metrics.endTiming('negotiation', start, 0.1);
+        // Parsoid transformation doesn't know about our caching policies
+        // or additional headers RESTBase sets, so merge headers from the original
+        // and important headers from the transformation.
+        const resHeaders = res.headers;
+        res.headers = html.headers;
+        res.headers.vary = resHeaders.vary;
+        res.headers['content-type'] = resHeaders['content-type'];
+        return res;
+    })
+    .catch((e) => {
+        hyper.logger.log('error/negotiation', {
+            message: 'Failed to transform content',
+            requested_version: requestedVersion,
+            existing_version: existingVersion,
+            error: e
+        });
+        throw e;
+    });
+}
+
+module.exports = (hyper, req, next, options, specInfo) => {
     if (!mwUtil.isHTMLRoute(specInfo.path)) {
         // The filter is  only supported on HTML routes,
         // but don't punish the client for our own mistake, just log an error.
@@ -61,6 +104,10 @@ module.exports = (hyper, req, next, options, specInfo) => {
                     mwUtil.extractHTMLProfileVersion(newRes.headers['content-type']);
                 if (semver.satisfies(newVersion, `^${requestedVersion}`)) {
                     return newRes;
+                } else if (semver.gt(newVersion, requestedVersion)) {
+                    // This means no-cache request upgraded the version to major-greater,
+                    // then requested, try to downgrade to get the minor-greater then requested.
+                    return downgrade(hyper, req, newRes, newVersion, requestedVersion);
                 }
                 hyper.logger.log('error/negotiation', {
                     message: 'Failed to satisfy required version',
@@ -78,46 +125,7 @@ module.exports = (hyper, req, next, options, specInfo) => {
             });
         }
 
-        const start = Date.now();
-        // The version is less then we expected - downgrade.
-        return hyper.post({
-            uri: new URI([rp.domain, 'sys', 'parsoid', 'transform', 'html', 'to', 'html']),
-            headers: {
-                'content-type': 'application/json',
-                'accept': req.headers.accept
-            },
-            body: {
-                original: {
-                    html: {
-                        headers: htmlRes.headers,
-                        body: htmlRes.body.toString()
-                    },
-                    'data-parsoid': {
-                        body: { ids: {} }
-                    }
-                }
-            }
-        })
-        .then((res) => {
-            hyper.metrics.endTiming('negotiation', start, 0.1);
-            // Parsoid transformation doesn't know about our caching policies
-            // or additional headers RESTBase sets, so merge headers from the original
-            // and important headers from the transformation.
-            const resHeaders = res.headers;
-            res.headers = htmlRes.headers;
-            res.headers.vary = resHeaders.vary;
-            res.headers['content-type'] = resHeaders['content-type'];
-            return res;
-        })
-        .catch((e) => {
-            hyper.logger.log('error/negotiation', {
-                message: 'Failed to transform content',
-                requested_version: requestedVersion,
-                stored_version: storedVersion,
-                error: e
-            });
-            throw e;
-        });
+        return downgrade(hyper, req, htmlRes, storedVersion, requestedVersion);
     });
 
 };

--- a/test/features/errors/invalid_request.js
+++ b/test/features/errors/invalid_request.js
@@ -12,6 +12,9 @@ parallel('400 handling', function() {
     let siteInfo;
     let revisionInfo;
     before(() => {
+        if (!nock.isActive()) {
+            nock.activate();
+        }
         return server.start()
         .then(() => {
             // Fetch real siteInfo to return from a mock

--- a/test/features/lists.js
+++ b/test/features/lists.js
@@ -57,6 +57,9 @@ describe('reading lists', function() {
     }
 
     before(() => {
+        if (!nock.isActive()) {
+            nock.activate();
+        }
         return server.start()
         // Do a preparation request to force siteinfo fetch so that we don't need to mock it
         .then(() => preq.get({

--- a/test/features/pagecontent/access_checks.js
+++ b/test/features/pagecontent/access_checks.js
@@ -46,6 +46,9 @@ describe('Access checks', () => {
     }
 
     before(() => {
+        if (!nock.isActive()) {
+            nock.activate();
+        }
         return server.start()
         // Do a preparation request to force siteinfo fetch so that we don't need to mock it
         .then(() => P.join(

--- a/test/features/pagecontent/content_negotiation.js
+++ b/test/features/pagecontent/content_negotiation.js
@@ -3,7 +3,10 @@
 const assert = require('../../utils/assert.js');
 const preq = require('preq');
 const server = require('../../utils/server.js');
+const nock = require('nock');
 
+const PARSOID_VERSION_BEFORE_DOWNGRADE = '1.7.0';
+const PARSOID_VERSION_BEFORE_DOWNGRADE_PAGE = 'User%3APchelolo%2FContent_Negotiation_Test';
 const PARSOID_SUPPORTED_DOWNGRADE = '1.8.0';
 
 describe('Content negotiation', function() {
@@ -11,13 +14,30 @@ describe('Content negotiation', function() {
     this.timeout(20000);
 
     let currentParsoidContentType;
-    before(() =>
-        server.start()
-        .then(() => preq.get({ uri: `${server.config.labsBucketURL}/html/Main_Page`}))
+    let parsoidNock;
+    before(() => {
+        if (!nock.isActive()) {
+            nock.activate();
+        }
+        return server.start()
+        .then(() => preq.get({uri: `${server.config.parsoidURI}/en.wikipedia.org/v3/page/pagebundle/User%3aPchelolo%2fContent_Negotiation_Test`}))
         .then((res) => {
-            currentParsoidContentType = res.headers['content-type'];
+            currentParsoidContentType = res.body.html.headers['content-type'];
+            res.body.html.headers['content-type'] = res.body.html.headers['content-type']
+            .replace(/\d+\.\d+\.\d+"$/, `${PARSOID_VERSION_BEFORE_DOWNGRADE}"`);
+            parsoidNock = nock(server.config.parsoidURI)
+            // Content-Location is absolute but for nock we need to transform it to relative.
+            .get(res.headers['content-location'].replace(server.config.parsoidURI, ''))
+            .reply(200, res.body, res.headers);
         })
-    );
+        // Just request it to store pre-supported-downgrade version
+        .then(() => preq.get({uri: `${server.config.bucketURL}/html/${PARSOID_VERSION_BEFORE_DOWNGRADE_PAGE}`}))
+        .then(() => parsoidNock.done())
+        .finally(() => {
+            nock.cleanAll();
+            nock.restore();
+        })
+    });
 
     const assertCorrectResponse = (expectedContentType) => (res) => {
         assert.deepEqual(res.status, 200);
@@ -160,8 +180,6 @@ describe('Content negotiation', function() {
         const supportedMinorVersion = parseInt(/\d+\.(\d+)\.\d+$/.exec(PARSOID_SUPPORTED_DOWNGRADE)[1], 10);
         const higherMinorDowngradeVersion = PARSOID_SUPPORTED_DOWNGRADE
         .replace(/(\d+\.)\d+(.\d+$)/, `$1${supportedMinorVersion + 1}$2`);
-        const supportedDowngradeContentType = currentParsoidContentType
-        .replace(/\d+\.\d+\.\d+"$/, `${PARSOID_SUPPORTED_DOWNGRADE}"`);
         const higherDowngradeContentType = currentParsoidContentType
         .replace(/\d+\.\d+\.\d+"$/, `${higherMinorDowngradeVersion}"`);
         return preq.get({
@@ -175,5 +193,34 @@ describe('Content negotiation', function() {
         }, (e) => {
             assert.deepEqual(e.status, 406);
         });
+    });
+
+    it('should return stored if it satisfied ^ of requested', () => {
+        const beforeDowngradeMinor = /\d\.(\d)\.\d/.exec(PARSOID_VERSION_BEFORE_DOWNGRADE)[1];
+        const evenOlderMinorVersion = PARSOID_VERSION_BEFORE_DOWNGRADE
+        .replace(beforeDowngradeMinor, parseInt(beforeDowngradeMinor, 10) - 1);
+        const evenOlderParsoidContentType = currentParsoidContentType
+        .replace(/\d+\.\d+\.\d+"$/, `${evenOlderMinorVersion}"`);
+        const beforeDowngradeContentType = currentParsoidContentType
+        .replace(/\d+\.\d+\.\d+"$/, `${PARSOID_VERSION_BEFORE_DOWNGRADE}"`);
+        return preq.get({
+            uri: `${server.config.bucketURL}/html/${PARSOID_VERSION_BEFORE_DOWNGRADE_PAGE}`,
+            headers: {
+                accept: evenOlderParsoidContentType
+            }
+        })
+        .then(assertCorrectResponse(beforeDowngradeContentType));
+    });
+
+    it('should downgrade after upgrading major version', () => {
+        const supportedDowngradeContentType = currentParsoidContentType
+        .replace(/\d+\.\d+\.\d+"$/, `${PARSOID_SUPPORTED_DOWNGRADE}"`);
+        return preq.get({
+            uri: `${server.config.bucketURL}/html/${PARSOID_VERSION_BEFORE_DOWNGRADE_PAGE}`,
+            headers: {
+                accept: supportedDowngradeContentType
+            }
+        })
+        .then(assertCorrectResponse(supportedDowngradeContentType));
     });
 });

--- a/test/features/pagecontent/save_api.js
+++ b/test/features/pagecontent/save_api.js
@@ -28,6 +28,9 @@ describe('page save api', function() {
     this.timeout(20000);
 
     before(() => {
+        if (!nock.isActive()) {
+            nock.activate();
+        }
         return server.start().then(() => {
             return P.all([
                 preq.get({

--- a/test/features/security/security.js
+++ b/test/features/security/security.js
@@ -10,6 +10,9 @@ describe('router - security', function() {
     this.timeout(20000);
 
     before(() => {
+        if (!nock.isActive()) {
+            nock.activate();
+        }
         return server.start()
         .then(() => {
             // Do preparation requests to force siteInfo fetch so that we don't need to mock it

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const P = require('bluebird');
 const ServiceRunner = require('service-runner');
 const logStream = require('./logStream');
 const fs        = require('fs');
@@ -16,6 +17,7 @@ const labsURL   = `${hostPort}/en.wikipedia.beta.wmflabs.org/v1`;
 const labsBucketURL = `${labsURL}/page`;
 const variantsWikiURL = `${hostPort}/sr.wikipedia.beta.wmflabs.org/v1`;
 const variantsWikiBucketURL = `${variantsWikiURL}/page`;
+const parsoidURI = 'https://parsoid-beta.wmflabs.org';
 
 function loadConfig(path, forceSqlite) {
     let confString = fs.readFileSync(path).toString();
@@ -51,7 +53,8 @@ const config = {
     variantsWikiBucketURL,
     labsApiURL: 'https://en.wikipedia.beta.wmflabs.org/w/api.php',
     logStream: logStream(),
-    conf: loadConfig(process.env.RB_TEST_CONFIG ? process.env.RB_TEST_CONFIG : `${__dirname}/../../config.test.yaml`)
+    conf: loadConfig(process.env.RB_TEST_CONFIG ? process.env.RB_TEST_CONFIG : `${__dirname}/../../config.test.yaml`),
+    parsoidURI
 };
 
 config.conf.num_workers = 0;
@@ -91,7 +94,7 @@ function start(_options) {
             return true;
         });
     } else {
-        return Promise.resolve();
+        return P.resolve();
     }
 }
 


### PR DESCRIPTION
Issue: we have 1.7.0 in storage. Client requests 1.8.0, we rerender from scratch, Parsoid gives 2.0.0, it doesn't satisfy ^1.8.0. So we need to downgrade.

cc @wikimedia/services @subbuss @arlolra 