### PR TITLE
Spread requests beetween MCS nodes for onthisday

### DIFF
--- a/lib/base_feed.js
+++ b/lib/base_feed.js
@@ -19,7 +19,7 @@ class BaseFeed {
         this.options = options;
     }
 
-    _assembleResult(result, dateKey) {
+    _assembleResult(result, dateKey, req) {
         // assemble the final response to be returned
         return {
             status: 200,
@@ -29,7 +29,7 @@ class BaseFeed {
                 etag: `${dateKey}/${uuid.now().toString()}`,
                 'content-type': this.options.content_type
             },
-            body: this.constructBody(result)
+            body: this.constructBody(result, req)
         };
     }
 
@@ -41,7 +41,7 @@ class BaseFeed {
         throw new Error('Abstract. Must be overwritten');
     }
 
-    constructBody(result) {
+    constructBody(result, req) {
         throw new Error('Abstract. Must be overwritten');
     }
 
@@ -70,7 +70,7 @@ class BaseFeed {
             });
         };
         const requestCurrentContentFromMCS = () => this._makeFeedRequests(hyper, req, false)
-        .then(result => this._assembleResult(result, dateKey))
+        .then(result => this._assembleResult(result, dateKey, req))
         .tap((res) => {
             if (this.options.storeHistory) {
                 // Store async
@@ -79,7 +79,7 @@ class BaseFeed {
         });
 
         const requestHistoricContentFromMCS = () => this._makeFeedRequests(hyper, req, true)
-        .then(result => this._assembleResult(result, dateKey));
+        .then(result => this._assembleResult(result, dateKey, req));
 
         const getHistoricContent = () => {
             if (mwUtil.isNoCacheRequest(req)) {

--- a/v1/onthisday.js
+++ b/v1/onthisday.js
@@ -1,12 +1,21 @@
 'use strict';
 
+const P = require('bluebird');
 const HyperSwitch = require('hyperswitch');
 const Template = HyperSwitch.Template;
 const BaseFeed = require('../lib/base_feed');
 const mwUtil = require('../lib/mwUtil');
 
+const POSSIBLE_PARTS = [
+    'selected',
+    'births',
+    'deaths',
+    'events',
+    'holidays'
+];
+
 const REQUEST_TEMPLATE = new Template({
-    uri: '{{options.host}}/{{domain}}/v1/feed/onthisday/all/{{mm}}/{{dd}}'
+    uri: '{{options.host}}/{{domain}}/v1/feed/onthisday/{{type}}/{{mm}}/{{dd}}'
 });
 
 class Feed extends BaseFeed {
@@ -17,16 +26,16 @@ class Feed extends BaseFeed {
         };
     }
 
-    constructBody(result) {
+    constructBody(result, req) {
+        if (req.params.type === 'all') {
+            const body = {};
+            Object.keys(result).forEach(key => Object.assign(body, result[key].body));
+            return body;
+        }
         return result.body;
     }
 
     _hydrateResponse(hyper, req, res) {
-        if (req.params.type !== 'all') {
-            res.body = {
-                [req.params.type]: res.body[req.params.type]
-            };
-        }
         return super._hydrateResponse(hyper, req, res)
         .then((response) => {
             Object.keys(response.body).forEach((key) => {
@@ -45,10 +54,31 @@ class Feed extends BaseFeed {
     }
 
     _makeFeedRequests(hyper, req) {
-        return hyper.get(REQUEST_TEMPLATE.expand({
-            options: this.options,
-            request: req
-        }));
+        if (req.params.type === 'all') {
+            const requests = {};
+            const reqCopy = Object.assign({}, req);
+            POSSIBLE_PARTS.forEach((type) => {
+                reqCopy.params = Object.assign({}, req.params, { type });
+                requests[type] = hyper.get(REQUEST_TEMPLATE.expand({
+                    options: this.options,
+                    request: reqCopy
+                }))
+                .catch((e) => {
+                    hyper.logger.log('error/onthisday', {
+                        msg: `Error fetching ${type}`,
+                        error: e
+                    });
+                    // Just ignore individual portions errors
+                    return undefined;
+                });
+            });
+            return P.props(requests);
+        } else {
+            return hyper.get(REQUEST_TEMPLATE.expand({
+                options: this.options,
+                request: req
+            }));
+        }
     }
 }
 


### PR DESCRIPTION
The `/feed/onthisday` endpoint is the one that's mostly timing out on deploys and I believe the timeouts are caused by MCS, not the response hydration portion. 

For the `/feed/featured` we make several individual requests for every portion of the feed, so we spread the load between several MCS nodes. Let's try doing the same for the `onthisday` endpoint.

cc @wikimedia/services 