### PR TITLE
Removed accept-language duplicate

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -623,8 +623,8 @@ mwUtil.addVaryHeader = (res, vary) => {
     if (!res.headers.vary) {
         res.headers.vary = vary;
     } else {
-        const varyPortions = res.headers.vary.split(',').map(h => h.trim());
-        if (!varyPortions.includes(vary)) {
+        const varyPortions = res.headers.vary.split(',').map(h => h.trim().toLowerCase());
+        if (!varyPortions.includes(vary.toLowerCase())) {
             varyPortions.push(vary);
             res.headers.vary = varyPortions.join(',');
         }

--- a/test/features/pagecontent/content_negotiation.js
+++ b/test/features/pagecontent/content_negotiation.js
@@ -47,8 +47,7 @@ describe('Content negotiation', function() {
     const assertCorrectResponse = (expectedContentType) => (res) => {
         assert.deepEqual(res.status, 200);
         assert.deepEqual(res.headers['content-type'], expectedContentType);
-        assert.varyContains(res, 'accept');
-        assert.varyNotContains(res, 'accept-language');
+        assert.validateListHeader(res.headers.vary,  { require: ['Accept'], disallow: ['Accept-Language'] });
         assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
         assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
     };

--- a/test/features/pagecontent/language_variants.js
+++ b/test/features/pagecontent/language_variants.js
@@ -12,7 +12,7 @@ describe('Language variants', function() {
     before(() => server.start());
 
     it('should request html with impossible variants', () => {
-        return preq.get({ uri: `${server.config.labsBucketURL}/html/Main_Page`})
+        return preq.get({ uri: `${server.config.labsBucketURL}/html/Main_Page` })
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.varyContains(res, 'accept');
@@ -38,6 +38,22 @@ describe('Language variants', function() {
             assert.deepEqual(/1\. Ово је тестна страница/.test(res.body), true);
             assert.deepEqual(/2\. Ovo je testna stranica/.test(res.body), true);
         });
+    });
+
+    it('should request html with no vary duplicates', () => {
+        return preq.get({ uri: `${server.config.variantsWikiBucketURL}/html/${variantsPageTitle}`})
+            .then((res) => {
+                storedEtag = res.headers.etag;
+                assert.deepEqual(res.status, 200);
+                assert.varyContains(res, 'accept');
+                assert.varyContains(res, 'accept-language');
+                assert.varyDoesNotContainDuplicates(res, 'accept-language');
+                assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+                assert.deepEqual(res.headers['content-language'], 'sr');
+                assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
+                assert.deepEqual(/1\. Ово је тестна страница/.test(res.body), true);
+                assert.deepEqual(/2\. Ovo je testna stranica/.test(res.body), true);
+            });
     });
 
     it('should request html with default variant, from storage', () => {

--- a/test/features/pagecontent/language_variants.js
+++ b/test/features/pagecontent/language_variants.js
@@ -12,7 +12,7 @@ describe('Language variants', function() {
     before(() => server.start());
 
     it('should request html with impossible variants', () => {
-        return preq.get({ uri: `${server.config.labsBucketURL}/html/Main_Page` })
+        return preq.get({ uri: `${server.config.labsBucketURL}/html/Main_Page`})
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.varyContains(res, 'accept');

--- a/test/features/pagecontent/language_variants.js
+++ b/test/features/pagecontent/language_variants.js
@@ -15,8 +15,7 @@ describe('Language variants', function() {
         return preq.get({ uri: `${server.config.labsBucketURL}/html/Main_Page`})
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept');
-            assert.varyNotContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept'], disallow: ['Accept-Language'] });
             assert.deepEqual(res.headers['content-language'], 'en');
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
@@ -30,30 +29,13 @@ describe('Language variants', function() {
         .then((res) => {
             storedEtag = res.headers.etag;
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept', 'Accept-Language'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
             assert.deepEqual(/1\. Ово је тестна страница/.test(res.body), true);
             assert.deepEqual(/2\. Ovo je testna stranica/.test(res.body), true);
         });
-    });
-
-    it('should request html with no vary duplicates', () => {
-        return preq.get({ uri: `${server.config.variantsWikiBucketURL}/html/${variantsPageTitle}`})
-            .then((res) => {
-                storedEtag = res.headers.etag;
-                assert.deepEqual(res.status, 200);
-                assert.varyContains(res, 'accept');
-                assert.varyContains(res, 'accept-language');
-                assert.varyDoesNotContainDuplicates(res, 'accept-language');
-                assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
-                assert.deepEqual(res.headers['content-language'], 'sr');
-                assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
-                assert.deepEqual(/1\. Ово је тестна страница/.test(res.body), true);
-                assert.deepEqual(/2\. Ovo je testna stranica/.test(res.body), true);
-            });
     });
 
     it('should request html with default variant, from storage', () => {
@@ -65,8 +47,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept', 'Accept-Language'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.deepEqual(res.headers.etag, storedEtag);
@@ -84,8 +65,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept', 'Accept-Language'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.deepEqual(res.headers.etag, storedEtag);
@@ -103,8 +83,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept', 'Accept-Language'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-language'], 'sr-ec');
             assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
@@ -122,8 +101,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept', 'Accept-Language'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-language'], 'sr-el');
             assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
@@ -140,8 +118,7 @@ describe('Language variants', function() {
         .then((res) => {
             storedEtag = res.headers.etag;
             assert.deepEqual(res.status, 200);
-            assert.varyNotContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept-Language'], disallow: ['Accept'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control_with_client_caching');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
@@ -156,8 +133,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyNotContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept-Language'], disallow: ['Accept'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control_with_client_caching');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.deepEqual(res.headers.etag, storedEtag);
@@ -172,8 +148,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyNotContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept-Language'], disallow: ['Accept'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control_with_client_caching');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.deepEqual(res.headers.etag, storedEtag);
@@ -190,8 +165,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyNotContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept-Language'], disallow: ['Accept'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control_with_client_caching');
             assert.deepEqual(res.headers['content-language'], 'sr-el');
             assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
@@ -206,8 +180,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyNotContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept-Language'], disallow: ['Accept'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control_with_client_caching');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.checkString(res.headers.etag, /^"\d+\/[a-f0-9-]+"$/);
@@ -221,8 +194,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyNotContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept-Language'], disallow: ['Accept'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.checkString(res.headers.etag, /^(:?W\/)?"\d+\/[a-f0-9-]+"$/);
@@ -238,8 +210,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept-language');
-            assert.varyNotContains(res, 'accept');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept-Language'], disallow: ['Accept'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.deepEqual(/1\. Ово је тестна страница/.test(JSON.stringify(res.body)), true);
@@ -254,7 +225,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept-Language'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.deepEqual(/1\. Ово је тестна страница/.test(JSON.stringify(res.body)), true);
@@ -271,8 +242,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyNotContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept-Language'], disallow: ['Accept'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-language'], 'sr-el');
             assert.checkString(res.headers.etag, /^(:?W\/)?"\d+\/[a-f0-9-]+"$/);
@@ -288,8 +258,7 @@ describe('Language variants', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyNotContains(res, 'accept');
-            assert.varyContains(res, 'accept-language');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept-Language'], disallow: ['Accept'] });
             assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
             assert.deepEqual(res.headers['content-language'], 'sr');
             assert.checkString(res.headers.etag, /^(:?W\/)?"\d+\/[a-f0-9-]+"$/);

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -49,8 +49,7 @@ describe('item requests', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept');
-            assert.varyNotContains(res, '');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept'], disallow: [''] });
             return preq.get({
                 uri: `${server.config.labsBucketURL}/html/Main_Page/`
             });
@@ -67,8 +66,7 @@ describe('item requests', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept');
-            assert.varyNotContains(res, '');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept'], disallow: [''] });
         });
     });
 
@@ -99,8 +97,7 @@ describe('item requests', function() {
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.varyContains(res, 'accept');
-            assert.varyNotContains(res, '');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept'], disallow: [''] });
             rev2Etag = res.headers.etag.replace(/^"(.*)"$/, '$1');
         });
     });
@@ -112,8 +109,7 @@ describe('item requests', function() {
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, contentTypes.html);
-            assert.varyContains(res, 'accept');
-            assert.varyNotContains(res, '');
+            assert.validateListHeader(res.headers.vary,  { require: ['Accept'], disallow: [''] });
             return preq.get({
                 uri: `${server.config.labsBucketURL}/data-parsoid/Foobar/${
                     res.headers.etag.replace(/^"(.*)"$/, '$1')}`

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -200,7 +200,7 @@ function validateListHeader(headerList, options) {
         });
     }
 
-    if (options.allowDuplicates === false || !options.allowDuplicates) {
+    if (!options.allowDuplicates) {
         const filterDuplicates = headerArray.filter((header, index) => headerArray.indexOf(header) === index);
         if (filterDuplicates.length !== headerArray.length) {
             throw new assert.AssertionError({

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -160,67 +160,53 @@ function checkString(result, expected, message) {
     }
 }
 
-function varyNotContains(res, header) {
-    if (!res.headers) {
+/**
+ * Validates the comma-separated list of header names.
+ * @param {string} headerList - the list of header names
+ * @param {Object} options - the validator options
+ * @param {array=} options.require - list of header names required to be present. Example: [ 'Accept', 'Accept-Encoding']. Case-insensitive.
+ * @param {array=} options.disallow - list of header names NOT allowed. Example: [ 'Accept-Language' ]. Case-insensitive.
+ * @param {boolean} [options.allowDuplicates] - whether duplicated entries could be present in the `headerList`. Default: false
+ **/
+function validateListHeader(headerList, options) {
+    if (!headerList) {
         throw new assert.AssertionError({
-            message: `Empty headers verifying vary doesn't contain ${header}`
+            message: `Can not validate with empty headers`
         });
     }
-    if (!Object.prototype.hasOwnProperty.call(res.headers, 'vary')) {
-        return;
-    }
-    if (res.headers.vary === '') {
+    if (headerList === '') {
         throw new assert.AssertionError({
-            message: `Vary header should not be an empty string ('')`
+            message: `Header list should not be an empty string ('')`
         });
     }
-    const varyAsList = res.headers.vary.split(',')
-    .map(header => header.trim().toLowerCase());
-    if (varyAsList.includes(header.toLowerCase())) {
-        throw new assert.AssertionError({
-            message: `Vary header contains ${header} while it must not`
+    const headerArray = headerList.split(',').map(header => header.trim().toLowerCase());
+    if (options.require) {
+        options.require.forEach(header => {
+            if (!headerArray.includes(header.trim().toLowerCase())) {
+                throw new assert.AssertionError({
+                    message: `Header does not contain ${header}`
+                });
+            }
         });
     }
-}
 
-function varyContains(res, header) {
-    if (!res.headers) {
-        throw new assert.AssertionError({
-            message: `Empty headers verifying vary contains ${header}`
+    if (options.disallow) {
+        options.disallow.forEach(header => {
+            if (headerArray.includes(header.trim().toLowerCase())) {
+                throw new assert.AssertionError({
+                    message: `Header contains ${header} while it must not`
+                });
+            }
         });
     }
-    if (!res.headers.vary) {
-        throw new assert.AssertionError({
-            message: `Empty vary header verifying vary contains ${header}`
-        });
-    }
-    const varyAsList = res.headers.vary.split(',')
-    .map(header => header.trim().toLowerCase());
-    if (!varyAsList.includes(header.toLowerCase())) {
-        throw new assert.AssertionError({
-            message: `Vary header does not contain ${header}`
-        });
-    }
-}
 
-function varyDoesNotContainDuplicates(res, header) {
-    if (!res.headers) {
-        throw new assert.AssertionError({
-            message: `Empty headers verifying vary contains ${header}`
-        });
-    }
-    if (!res.headers.vary) {
-        throw new assert.AssertionError({
-            message: `Empty vary header verifying vary contains ${header}`
-        });
-    }
-    const varyAsList = res.headers.vary.split(',')
-        .map(header => header.trim().toLowerCase())
-        .filter(varyItem => varyItem === header.toLowerCase());
-    if (varyAsList.length > 1) {
-        throw new assert.AssertionError({
-            message: `Vary contains duplicates of ${header}`
-        });
+    if (options.allowDuplicates === false || !options.allowDuplicates) {
+        const filterDuplicates = headerArray.filter((header, index) => headerArray.indexOf(header) === index);
+        if (filterDuplicates.length !== headerArray.length) {
+            throw new assert.AssertionError({
+                message: `${headerList} contains duplicates`
+            });
+        }
     }
 }
 
@@ -236,6 +222,4 @@ module.exports.localRequests  = localRequests;
 module.exports.remoteRequests = remoteRequests;
 module.exports.findParsoidRequest = findParsoidRequest;
 module.exports.checkString    = checkString;
-module.exports.varyNotContains = varyNotContains;
-module.exports.varyContains = varyContains;
-module.exports.varyDoesNotContainDuplicates = varyDoesNotContainDuplicates;
+module.exports.validateListHeader = validateListHeader;

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -203,6 +203,27 @@ function varyContains(res, header) {
     }
 }
 
+function varyDoesNotContainDuplicates(res, header) {
+    if (!res.headers) {
+        throw new assert.AssertionError({
+            message: `Empty headers verifying vary contains ${header}`
+        });
+    }
+    if (!res.headers.vary) {
+        throw new assert.AssertionError({
+            message: `Empty vary header verifying vary contains ${header}`
+        });
+    }
+    const varyAsList = res.headers.vary.split(',')
+        .map(header => header.trim().toLowerCase())
+        .filter(varyItem => varyItem === header.toLowerCase());
+    if (varyAsList.length > 1) {
+        throw new assert.AssertionError({
+            message: `Vary contains duplicates of ${header}`
+        });
+    }
+}
+
 module.exports.ok             = assert.ok;
 module.exports.AssertionError = assert.AssertionError;
 module.exports.fails          = fails;
@@ -217,3 +238,4 @@ module.exports.findParsoidRequest = findParsoidRequest;
 module.exports.checkString    = checkString;
 module.exports.varyNotContains = varyNotContains;
 module.exports.varyContains = varyContains;
+module.exports.varyDoesNotContainDuplicates = varyDoesNotContainDuplicates;


### PR DESCRIPTION
Added a` varyDoesNotContainDuplicates` function in test/utils/assert.js that throws an error whenever there is a duplicate.

Added a test in `test/features/pagecontent/language_variants.js` that checks to see if there are language duplicates in vary.

Changed the `addVaryHeader` method in lib/mwUtil.js to check if a version of the vary exists before adding a new one.

Bug: [T207324](https://phabricator.wikimedia.org/T207324)