### PR TITLE
Citoid: Check only the structure of the response

### DIFF
--- a/v1/citoid.yaml
+++ b/v1/citoid.yaml
@@ -88,10 +88,8 @@ paths:
             headers:
               content-type:  /^application\/json/
             body:
-              - title: 'Darth Vader'
-                language: en
-                itemType: encyclopediaArticle
-                encyclopediaTitle: Wikipedia
+              - title: /.+/
+                itemType: /.+/
 
 definitions:
   result:


### PR DESCRIPTION
We have disabled Zotero in Beta, so when testing we get different
results than in production. Hence, check only the response's format so
that we make sure Citoid is working properly.

Bug: [T211386](https://phabricator.wikimedia.org/T211386)