### PR TITLE
Feed: Ensure `result[0].body.tfa` exists

### DIFF
--- a/v1/feed.js
+++ b/v1/feed.js
@@ -89,9 +89,11 @@ class Feed extends BaseFeed {
                 highQualityThumbRequest
             ).then((result) => {
                 const thumbRes = result[1].body;
+                result[0].body = result[0].body || {};
                 if (thumbRes.items && thumbRes.items.length && thumbRes.items[0].thumbnail) {
                     const newThumb = thumbRes.items[0].thumbnail;
                     newThumb.source = newThumb.source.replace(/^http:/, 'https:');
+                    result[0].body.tfa = result[0].body.tfa || {};
                     result[0].body.tfa.thumbnail = newThumb;
                     if (thumbRes.items[0].original) {
                         const newOriginal = thumbRes.items[0].original;


### PR DESCRIPTION
There have been ~1200 failed requests in the last 24h where `result[0].body.tfa` was undefined, which made RB fail when trying to set the thumbnail. Since the Android app expects these fields to be present, ensure they are defined.