### PR TITLE
Citoid: Disable automatic check

### DIFF
--- a/v1/citoid.yaml
+++ b/v1/citoid.yaml
@@ -75,21 +75,23 @@ paths:
             $ref: '#/definitions/problem'
 
       operationId: getCitation
-      x-monitor: true
-      x-amples:
-        - title: Get citation for Darth Vader
-          request:
-            params:
-              domain: en.wikipedia.org
-              format: mediawiki
-              query: 'https://en.wikipedia.org/wiki/Darth_Vader'
-          response:
-            status: 200
-            headers:
-              content-type:  /^application\/json/
-            body:
-              - title: /.+/
-                itemType: /.+/
+      # TEMP TEMP TEMP
+      # Citoid monitoring temporarily disabled due to T211411
+      x-monitor: false
+#      x-amples:
+#        - title: Get citation for Darth Vader
+#          request:
+#            params:
+#              domain: en.wikipedia.org
+#              format: mediawiki
+#              query: 'https://en.wikipedia.org/wiki/Darth_Vader'
+#          response:
+#            status: 200
+#            headers:
+#              content-type:  /^application\/json/
+#            body:
+#              - title: /.+/
+#                itemType: /.+/
 
 definitions:
   result:


### PR DESCRIPTION
Citoid requests to Zotero time out currently, so disable the check in RESTBase until the situation is fixed.

Bug: [T211411](https://phabricator.wikimedia.org/T211411)