### PR TITLE
PDF: Switch to using Proton

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -47,11 +47,7 @@ default_project: &default_project
         pdf:
           # Cache PDF for 5 minutes since it's not purged
           cache_control: s-maxage=600, max-age=600
-          uri: https://pdfrender-beta.wmflabs.org
           new_uri: https://proton-beta.wmflabs.org
-          new_probability: 1
-          secret: secret
-          scheme: https
         transform:
           cx_host: https://cxserver-beta.wmflabs.org
         skip_updates: false

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -47,9 +47,7 @@ default_project: &default_project
         pdf:
           # Cache PDF for 5 minutes since it's not purged
           cache_control: s-maxage=600, max-age=600
-          uri: https://pdfrender-beta.wmflabs.org
           new_uri: https://proton-beta.wmflabs.org
-          secret: secret
         transform:
           cx_host: https://cxserver-beta.wmflabs.org
         skip_updates: false

--- a/v1/pdf.js
+++ b/v1/pdf.js
@@ -22,23 +22,14 @@ module.exports = options => ({
     operations: {
         generatePDF: (hyper, req) => {
             const rp = req.params;
-            const newProbability = options.new_probability || 0;
             return hyper.get(new URI([rp.domain, 'sys', 'page_revisions', 'page', rp.title]))
             .then((latestRevision) => {
-                if (options.new_uri && (Math.random() < newProbability || req.query.new_pdf)) {
-                    const newResult = hyper.get(new URI(
+                if (options.new_uri) {
+                    return hyper.get(new URI(
                         `${options.new_uri}/${rp.domain}/v1/`
-                        + `pdf/${encodeURIComponent(rp.title)}/a4/desktop`
-                    ))
-                    .catch((e) => {
-                        hyper.logger.log('error/proton', e);
-                        if (req.query.new_pdf) {
-                            throw e;
-                        }
-                    });
-                    if (req.query.new_pdf) {
-                        return newResult;
-                    }
+                        + `pdf/${encodeURIComponent(rp.title)}`
+                        + `/${rp.format || 'a4'}/${rp.type || `desktop`}`
+                    ));
                 }
                 return hyper.get({
                     uri: new URI(`${options.uri}/pdf`),

--- a/v1/pdf.yaml
+++ b/v1/pdf.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
-  /pdf/{title}:
+  /pdf/{title}{/format}{/type}:
     x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
@@ -34,6 +34,23 @@ paths:
           description: "Page title. Use underscores instead of spaces. Example: `Main_Page`."
           type: string
           required: true
+        - in: path
+          name: format
+          type: string
+          enum: ['a4', 'letter', 'legal']
+          required: false
+          default: a4
+          description: "PDF page format. Default: a4"
+        - in: path
+          name: type
+          schema:
+            type: string
+            enum: ['mobile', 'desktop']
+          required: false
+          default: desktop
+          description: |
+            PDF type: mobile (optimized for reading on mobile devices) or desktop
+            (regular PDF). Default: desktop
       responses:
         '200':
           description: The PDF render of an article


### PR DESCRIPTION
We are sunsetting Electron and switchng fully to Proton. Therefore, adjust the code to use Proton only if `new_uri` is specified (and consequently get rid of `new_probability` and `new_pdf`). However, for the sake of backwards compatibility, keep the code using Electron around.

Bug: [T210651](https://phabricator.wikimedia.org/T210651)