### PR TITLE
Temp: Log VE requests

### DIFF
--- a/lib/ve_logger_filter.js
+++ b/lib/ve_logger_filter.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = (hyper, req, next, options, specInfo) => {
+
+    options.probability = options.probability || 1;
+    const ua = req.headers && req.headers['user-agent'] || '';
+    const aua = req.headers && req.headers['api-user-agent'] || '';
+
+    if (`${ua}|${aua}`.includes('VisualEditor') &&
+            Math.floor(1000 * Math.random()) <= Math.floor(1000 * options.probability)) {
+        hyper.logger.log('warn/visualeditor', {
+            msg: 'VisualEditor request',
+            req_headers: JSON.stringify(req.headers, null, 2)
+        });
+    }
+
+    return next(hyper, req);
+
+};

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -119,6 +119,9 @@ paths:
 
   /html/{title}:
     x-route-filters:
+      - path: ./lib/ve_logger_filter.js
+        options:
+          probability: 0.5
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -403,6 +406,9 @@ paths:
 
   /html/{title}/{revision}{/tid}:
     x-route-filters:
+      - path: ./lib/ve_logger_filter.js
+        options:
+          probability: 0.5
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -93,6 +93,9 @@ paths:
             $ref: '#/definitions/problem'
 
       x-route-filters:
+        - path: ./lib/ve_logger_filter.js
+          options:
+            probability: 0.25
         - type: default
           name: ratelimit_route
           options:
@@ -181,6 +184,9 @@ paths:
             $ref: '#/definitions/problem'
 
       x-route-filters:
+        - path: ./lib/ve_logger_filter.js
+          options:
+            probability: 0.25
         - type: default
           name: ratelimit_route
           options:


### PR DESCRIPTION
As part of the Parsoid storage simplification effort, we need to have
insight into which headers are actually sent by VE. This commit adds a
temporary logging facility to VE requests as a route filter for
/page/html and /transform end points.

Bug: [T215956](https://phabricator.wikimedia.org/T215956)