### PR TITLE
Replace `json-stable-stringify` with `fast-json-stable-stringify`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
   "dependencies": {
     "bluebird": "^3.5.2",
     "cassandra-uuid": "^0.1.0",
-    "restbase-mod-table-cassandra": "^1.1.2",
-    "service-runner": "^2.6.9",
-    "json-stable-stringify": "^1.0.1",
     "content-type": "git+https://github.com/wikimedia/content-type#master",
+    "entities": "^1.1.1",
+    "fast-json-stable-stringify": "^2.0.0",
     "hyperswitch": "^0.10.3",
     "jsonwebtoken": "^8.3.0",
     "mediawiki-title": "^0.6.5",
-    "entities": "^1.1.1",
-    "semver": "latest"
+    "restbase-mod-table-cassandra": "^1.1.2",
+    "semver": "latest",
+    "service-runner": "^2.6.9"
   },
   "devDependencies": {
     "ajv": "^6.5.4",

--- a/sys/key_value.js
+++ b/sys/key_value.js
@@ -7,7 +7,7 @@
 const uuid = require('cassandra-uuid').TimeUuid;
 const mwUtil = require('../lib/mwUtil');
 const HyperSwitch = require('hyperswitch');
-const stringify = require('json-stable-stringify');
+const stringify = require('fast-json-stable-stringify');
 const HTTPError = HyperSwitch.HTTPError;
 const URI = HyperSwitch.URI;
 

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -15,7 +15,7 @@ const HTTPError = HyperSwitch.HTTPError;
 const URI = HyperSwitch.URI;
 const TimeUuid = require('cassandra-uuid').TimeUuid;
 const mwUtil = require('../lib/mwUtil');
-const stringify = require('json-stable-stringify');
+const stringify = require('fast-json-stable-stringify');
 
 const spec = HyperSwitch.utils.loadSpec(`${__dirname}/page_revisions.yaml`);
 

--- a/sys/post_data.js
+++ b/sys/post_data.js
@@ -6,7 +6,7 @@
 
 const HyperSwitch = require('hyperswitch');
 const crypto = require('crypto');
-const stringify = require('json-stable-stringify');
+const stringify = require('fast-json-stable-stringify');
 const URI = HyperSwitch.URI;
 
 function calculateHash(storedData) {


### PR DESCRIPTION
fast-json-stable-stringify is being used because it does not have any dependencies and has been shown to be faster than json-stable-stringify

Bug: [T210426](https://phabricator.wikimedia.org/T210426)