### PR TITLE
/edits/per-page endpoint throttling limit is now 5 reqs per sec

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -1482,7 +1482,7 @@ paths:
         You can choose between daily and monthly granularity as well.
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
-        - Rate limit: 25 req/s
+        - Rate limit: 5 req/s
         - License: Data accessible via this endpoint is available under the
           [CC0 1.0 license](https://creativecommons.org/publicdomain/zero/1.0/).
       produces:

--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -1548,8 +1548,8 @@ paths:
           name: ratelimit_route
           options:
             limits:
-              internal: 25
-              external: 25
+              internal: 5
+              external: 5
       x-request-handler:
         - get_from_backend:
             request:


### PR DESCRIPTION
Please see why we need to reduce requests ratios: https://phabricator.wikimedia.org/T219910

