### PR TITLE
[WIP] Modify key_value bucket.

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -17,12 +17,13 @@ const mwUtil = {};
 /**
  * Create an etag value of the form
  * "<revision>/<tid>/<optional_suffix>"
- * @param   {Integer}   rev         page revision number
- * @param   {string}    tid         page render UUID
+ * @param   {Integer}   [rev]       page revision number
+ * @param   {string}    [tid]       page render UUID
  * @param   {string}    [suffix]    optional suffix
  * @return  {string}                the value of the ETag header
  */
-mwUtil.makeETag = (rev, tid, suffix) => {
+mwUtil.makeETag = (rev = 0, tid, suffix) => {
+    tid = tid || uuid.now();
     let etag = `"${rev}/${tid}`;
     if (suffix) {
         etag += `/${suffix}`;

--- a/sys/key_value.yaml
+++ b/sys/key_value.yaml
@@ -2,7 +2,13 @@ swagger: '2.0'
 info:
   version: '1.0.0'
   title: RESTBase key-value module
-  description: Revisioned blob storage with HTTP interface, backed by table storage
+  description: >
+    Blob storage with HTTP interface, backed by table storage.
+    It only accepts serialized binary data as `application/octet-stream`
+    All the headers, prefixed with `x-store-` are stored and upon response
+    returned without the prefix. It's expected that the client will provide
+    a meaningful `etag` header upon storing the content, otherwise it will be
+    generated as a hash of the content.
 paths:
   /{bucket}:
     put:

--- a/test/features/buckets/key_value_bucket.js
+++ b/test/features/buckets/key_value_bucket.js
@@ -86,7 +86,7 @@ describe('Key value buckets', () => {
             const tids = [ uuid.now().toString(),
                 uuid.now().toString(),
                 uuid.now().toString() ];
-            return P.each(tids, (tid) => {
+            return P.each(tids, () => {
                 return preq.put({
                     uri: `${bucketBaseURI}/List_Test_1`,
                     body: new Buffer(testData),
@@ -94,7 +94,7 @@ describe('Key value buckets', () => {
                         'if-none-hash-match': '*'
                     }
                 })
-                .catch(() => {});
+                .catch({ status: 412 }, () => {});
             })
             .then(() => {
                 return preq.get({

--- a/test/features/buckets/key_value_bucket.js
+++ b/test/features/buckets/key_value_bucket.js
@@ -4,6 +4,7 @@ const preq   = require('preq');
 const assert = require('../../utils/assert.js');
 const Server = require('../../utils/server.js');
 const uuid = require('cassandra-uuid').TimeUuid;
+const mwUtils = require('../../../lib/mwUtil');
 const P = require('bluebird');
 const parallel = require('mocha.parallel');
 
@@ -46,10 +47,14 @@ describe('Key value buckets', () => {
             });
         });
 
-        it('assigns etag to a value', () => {
+        it('preserves headers', () => {
             const testData = randomString(100);
+            const testEtag = mwUtils.makeETag();
             return preq.put({
                 uri: `${bucketBaseURI}/Test3`,
+                headers: {
+                    etag: testEtag
+                },
                 body: new Buffer(testData)
             })
             .then((res) => {
@@ -60,7 +65,7 @@ describe('Key value buckets', () => {
             })
             .then((res) => {
                 assert.deepEqual(res.status, 200);
-                assert.ok(res.headers.etag);
+                assert.deepEqual(res.headers.etag, testEtag);
                 assert.ok(new RegExp('^"0\/').test(res.headers.etag), true);
             });
         });

--- a/test/features/router/handlerTemplate.js
+++ b/test/features/router/handlerTemplate.js
@@ -15,17 +15,12 @@ describe('handler template', function() {
         assert.deepEqual(/^text\/html/.test(res.headers['content-type']), true);
     }
 
-    let slice;
-
     it('retrieve content from backend service', () => {
-        let tid1;
-        let tid2;
         return preq.get({
             uri: `${server.config.baseURL()}/service/test/User:GWicke%2fDate`
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            tid1 = res.headers.etag;
             hasTextContentType(res);
 
             // Delay for 1s to make sure that the content differs on
@@ -40,9 +35,6 @@ describe('handler template', function() {
             });
         })
         .then((res) => {
-            tid2 = res.headers.etag;
-            assert.notDeepEqual(tid2, tid1);
-            assert.notDeepEqual(tid2, undefined);
             hasTextContentType(res);
             assert.remoteRequests(true);
             assert.cleanupRecorder();
@@ -56,12 +48,9 @@ describe('handler template', function() {
             });
         })
         .then((res) => {
-            const tid3 = res.headers.etag;
-            assert.deepEqual(tid3, tid2);
-            assert.notDeepEqual(tid3, undefined);
             // Check that there were no remote requests
             assert.remoteRequests(false);
             hasTextContentType(res);
-        });
+        }).tapCatch(console.log);
     });
 });

--- a/test/features/specification/monitoring.js
+++ b/test/features/specification/monitoring.js
@@ -193,6 +193,7 @@ describe('Monitoring tests', function() {
                             .then((res) => {
                                 validateTestResponse(testCase, res);
                             }, (err) => {
+                                console.log(err);
                                 validateTestResponse(testCase, err);
                             });
                         });

--- a/test/test_module.yaml
+++ b/test/test_module.yaml
@@ -39,9 +39,7 @@ paths:
                   - return_response:
                       return:
                         status: '{{get_from_api.status}}'
-                        headers:
-                          'content-type': '{{get_from_api.headers.content-type}}'
-                          'etag': '{{store.headers.etag}}'
+                        headers: '{{get_from_api.headers}}'
                         body: '{{get_from_api.body}}'
 
                 x-monitor: false

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -115,17 +115,20 @@ paths:
         - extract:
             request:
               method: get
-              uri: '{{$$.options.host}}/{domain}/v1/page/definition/{term}'
+              uri: '{{options.host}}/{domain}/v1/page/definition/{term}'
             response:
-              # Define the response to save & return.
-              headers:
-                content-type: '{{extract.headers.content-type}}'
+              status: '{{extract.status}}'
+              headers: '{{extract.headers}}'
               body: '{{extract.body}}'
         - store:
             request:
               method: put
-              uri: /{domain}/sys/key_value/term.definition-ng/{request.params.term}
-              headers: '{{merge({"if-none-hash-match": "*"}, extract.headers)}}'
+              uri: /{domain}/sys/key_value/term.definition-ng/{term}
+              headers:
+                content-type: '{{extract.headers.content-type}}'
+                etag: '{{extract.headers.etag}}'
+                content-language: '{{extract.headers.content-language}}'
+                if-none-hash-match: '*'
               body: '{{extract.body}}'
             # With the if-none-hash-match header the storage will return 412
             # if the content is not changed. In that case, return from the
@@ -138,7 +141,7 @@ paths:
               status: 200
               headers:
                 content-type: '{{extract.headers.content-type}}'
-                etag: '{{store.headers.etag}}'
+                etag: '{{extract.headers.etag}}'
                 cache-control: '{{options.response_cache_control}}'
               body: '{{extract.body}}'
         - emit_change_event:
@@ -152,7 +155,7 @@ paths:
               status: 200
               headers:
                 content-type: '{{extract.headers.content-type}}'
-                etag: '{{store.headers.etag}}'
+                etag: '{{extract.headers.etag}}'
                 cache-control: '{{options.response_cache_control}}'
               body: '{{extract.body}}'
 

--- a/v1/summary_new.yaml
+++ b/v1/summary_new.yaml
@@ -135,7 +135,13 @@ paths:
             request:
               method: put
               uri: /{domain}/sys/key_value/page_summary/{request.params.title}
-              headers: '{{merge({"if-none-hash-match": "*", "cache-control": request.headers.cache-control}, extract.headers)}}'
+              headers:
+                content-type: '{{extract.headers.content-type}}'
+                cache-control: '{{request.headers.cache-control}}'
+                etag: '{{extract.headers.etag}}'
+                content-language: '{{extract.headers.content-language}}'
+                vary: '{{extract.headers.vary}}'
+                if-none-hash-match: '*'
               body: '{{extract.body}}'
             # With the if-none-hash-match header the storage will return 412
             # if the content is not changed. In that case, return from the
@@ -149,7 +155,7 @@ paths:
               status: 200
               headers:
                 content-type: '{{extract.headers.content-type}}'
-                etag: '{{store_and_return.headers.etag}}'
+                etag: '{{extract.headers.etag}}'
                 cache-control: '{{options.response_cache_control}}'
                 content-language: '{{extract.headers.content-language}}'
                 vary: '{{extract.headers.vary}}'
@@ -165,7 +171,7 @@ paths:
               status: 200
               headers:
                 content-type: '{{extract.headers.content-type}}'
-                etag: '{{store_and_return.headers.etag}}'
+                etag: '{{extract.headers.etag}}'
                 cache-control: '{{options.response_cache_control}}'
                 content-language: '{{extract.headers.content-language}}'
                 vary: '{{extract.headers.vary}}'


### PR DESCRIPTION
Open questions:
- How to provide headers like `vary` that we want to store and return back by which are not valid HTTP request headers.
- Where to do serialization/deserialization. If we make clients give us proper `content-type`, we will automatically parse the incoming data stream and will need to re-serialize it. So should we only support `application/octet-stream` as a content type and provide the actual content-type in `x-rv-content-type` header? if yes - we should return the data with the same header. Alternatively, we can add a patch to hyperswitch to NOT deserialize content and always store is as a Buffer and use proper client-provided content type. Doing so will basically make us reimplement kask here, which we did not want to do and might be to much work for an intermediate solution.
- What to use a default etag? a hash of the content buffer seems like an appropriate solution.
- How to prefix headers that need to be stored? Do header prefixing (that seem to be standard solution for existing http storage services (S3 for example) or put the content into an envelope containing headers and body? given that parsoid content is already an envelope containg multiple content parts, that might be anavoidable.