### PR TITLE
Update metrics docs after AQS patch

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -1481,6 +1481,9 @@ paths:
         You can filter by editors-type (all-editor-types, anonymous, group-bot, name-bot, user).
         You can choose between daily and monthly granularity as well.
 
+        Note: Due to performance of the data-serving backend, this endpoint limits the queryable
+        timespan to one year (whether in daily or monthly granularity).
+
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
         - Rate limit: 5 req/s
         - License: Data accessible via this endpoint is available under the
@@ -1838,6 +1841,9 @@ paths:
         difference net sums. You can filter by editors-type (all-editor-types, anonymous,
         group-bot, name-bot, user). You can choose between daily and monthly granularity as well.
 
+        Note: Due to performance of the data-serving backend, this endpoint limits the queryable
+        timespan to one year (whether in daily or monthly granularity).
+
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
         - Rate limit: 25 req/s
         - License: Data accessible via this endpoint is available under the
@@ -2118,6 +2124,9 @@ paths:
         instance 'User:Jimbo_Wales') and a date range, returns a timeseries of bytes
         difference absolute sums. You can filter by editors-type (all-editor-types, anonymous,
         group-bot, name-bot, user). You can choose between daily and monthly granularity as well.
+
+        Note: Due to performance of the data-serving backend, this endpoint limits the queryable
+        timespan to one year (whether in daily or monthly granularity).
 
         - Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
         - Rate limit: 25 req/s


### PR DESCRIPTION
edits-per-page, net-bytes-per-page and abs-bytes-per-page metrics
have been limited 1 year max timespan for performance reasons (see
https://gerrit.wikimedia.org/r/c/analytics/aqs/+/502198).
This patch adds a documentation notice on that limitation.