### PR TITLE
Remove obsolete documentation

### DIFF
--- a/v1/recommend.yaml
+++ b/v1/recommend.yaml
@@ -72,8 +72,6 @@ paths:
         Recommends articles similar to the seed article but are missing
         from the domain language Wikipedia.
 
-        Currently, this end point works only on eswiki, fawiki, and uzwiki.
-
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       produces:
         - application/json


### PR DESCRIPTION
The API works on enwiki too. In the future we'll be supporting more
Wikipedias. By removing this docstring, we won't have to worry about
updating it. It's pretty obvious on each Wikipedia's REST API whether
this end point works anyway.