### PR TITLE
Update HTML content type profile to v2.1.0 in the spec

### DIFF
--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -189,7 +189,7 @@ paths:
           required: false
           type: string
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/2.1.0"
         - application/json
         - application/problem+json
       responses:
@@ -403,7 +403,7 @@ paths:
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       operationId: getFormatRevision
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/2.1.0"
         - application/json
         - application/problem+json
       parameters:
@@ -598,7 +598,7 @@ paths:
 
         Stability: [Stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       produces:
-        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/1.7.0"
+        - application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/data-parsoid/2.1.0"
         - application/problem+json
       parameters:
         - name: title

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -194,7 +194,7 @@ paths:
       consumes:
         - multipart/form-data
       produces:
-        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
+        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/2.1.0"
         - application/problem+json
       parameters:
         - name: wikitext
@@ -468,7 +468,7 @@ paths:
 #      consumes:
 #        - multipart/form-data
 #      produces:
-#        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/1.7.0"
+#        - text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/HTML/2.1.0"
 #        - application/problem+json
 #      parameters:
 #        - name: title


### PR DESCRIPTION
We have been serving v2.1.0 content for a while, but forgot apparently to update the spec to reflect that.

Bug: [T221432](https://phabricator.wikimedia.org/T221432)