### PR TITLE
[Temp] Log all requests for Parsoid sections

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -390,6 +390,7 @@ class ParsoidService {
     }
 
     getSections(hyper, req) {
+        hyper.logger.log('warn/parsoid/sections', 'getSections() called');
         const rp = req.params;
         const sections = req.query.sections.split(',').map((id) => id.trim());
         delete req.query.sections;
@@ -604,6 +605,7 @@ class ParsoidService {
                 original
             };
             if (from === 'changes') {
+                hyper.logger.log('warn/parsoid/sections', 'transformChangesToWikitext called');
                 body2.html = replaceSections(original, req.body.changes);
                 from = 'html';
             } else {


### PR DESCRIPTION
We are sunsetting the section retrieval and editing portion of the REST API. The first step is to record the requests that do come in for sections.

Bug: [T216636](https://phabricator.wikimedia.org/T216636)