### PR TITLE
Parsoid: Rate limit stashing requests

### DIFF
--- a/config.example.wikimedia.yaml
+++ b/config.example.wikimedia.yaml
@@ -21,6 +21,7 @@ default_project: &default_project
         parsoid:
           host: https://parsoid-beta.wmflabs.org
           grace_ttl: 1000000
+          stash_ratelimit: 5
         action:
           apiUriTemplate: "{{'https://{domain}/w/api.php'}}"
           baseUriTemplate: "{{'https://{domain}/api/rest_v1'}}"

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -174,7 +174,8 @@ paths:
           in: query
           description: >
             Whether to temporary stash data-parsoid in order to support transforming the
-            modified content later.
+            modified content later. If this parameter is set, requests are rate-limited on
+            a per-client basis (max 5 requests per second per client)
           type: boolean
           required: false
         - name: Accept-Language
@@ -426,7 +427,8 @@ paths:
           in: query
           description: >
             Whether to temporary stash data-parsoid in order to support transforming the
-            modified content later.
+            modified content later. If this parameter is set, requests are rate-limited on
+            a per-client basis (max 5 requests per second per client)
           type: boolean
           required: false
         - name: Accept-Language
@@ -541,7 +543,8 @@ paths:
           in: query
           description: >
             Whether to temporary stash data-parsoid in order to support transforming the
-            modified content later.
+            modified content later. If this parameter is set, requests are rate-limited on
+            a per-client basis (max 5 requests per second per client)
           type: boolean
           required: false
         - name: Accept-Language

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -190,7 +190,7 @@ paths:
         also need to supply the title.
 
         - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
-        - Rate limit: 25 req/s
+        - Rate limit: 25 req/s (5 req/s when `stash: true`)
       consumes:
         - multipart/form-data
       produces:


### PR DESCRIPTION
Stashing requests are expensive and take up storage, so make sure they are rate-limited. We check the rates only for external requests that explicitly request stashing. By default, at most 5 requests per second per client IP are allowed, but that can be adjusted by setting the `stash_ratelimit` in the module's configuration options.

Bug: [T224055](https://phabricator.wikimedia.org/T224055)