### PR TITLE
Remove parsoid self-call to get a pagebundle.

### DIFF
--- a/sys/parsoid.yaml
+++ b/sys/parsoid.yaml
@@ -6,32 +6,6 @@ info:
     Transparently generates missing content and interfaces with the MediaWiki
     API through the `action` module.
 paths:
-
-  /pagebundle/{title}: &pagebundle_title
-    get:
-      summary: Retrieve a JSON bundle containing html and data-parsoid
-      operationId: getPageBundle
-    post:
-      summary: Retrieve a JSON bundle containing html and data-parsoid
-      operationId: getPageBundle
-
-  /pagebundle/{title}/{revision}:
-    <<: *pagebundle_title
-
-  /pagebundle/{title}/{revision}/{tid}:
-    <<: *pagebundle_title
-
-  /wikitext/{title}: &wikitext_title
-    get:
-      summary: Retrieve the wikitext for a title and revision.
-      operationId: getWikitext
-
-  /wikitext/{title}/{revision}:
-    <<: *wikitext_title
-
-  /wikitext/{title}/{revision}/{tid}:
-    <<: *wikitext_title
-
   /html/{title}: &html_title
     get:
       summary: Retrieve the HTML for title and revision.


### PR DESCRIPTION
1. Remove pagebundle and wikitext external endpoints for parsoid.js
2. Removed self-call within the parsoid module that used routing
3. We only `get` the pagebundle from parsoid now, we never `post` it, so simplified the call.

cc @wikimedia/services 