### PR TITLE
[DISCUSSION] Enable bucket creation caching in key_value

### DIFF
--- a/projects/wikimedia.org.yaml
+++ b/projects/wikimedia.org.yaml
@@ -95,6 +95,8 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
+                  options:
+                    groups: '{{options.table.storage_groups}}'
             /post_data: &sys_post_data
               x-modules:
                 - path: sys/post_data.js

--- a/projects/wmf_default.yaml
+++ b/projects/wmf_default.yaml
@@ -115,6 +115,8 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
+                  options:
+                    groups: '{{options.table.storage_groups}}'
             /page_revisions:
               x-modules:
                 - path: sys/page_revisions.js

--- a/projects/wmf_enwiki.yaml
+++ b/projects/wmf_enwiki.yaml
@@ -142,6 +142,8 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
+                  options:
+                    groups: '{{options.table.storage_groups}}'
             /page_revisions:
               x-modules:
                 - path: sys/page_revisions.js

--- a/projects/wmf_wikidata.yaml
+++ b/projects/wmf_wikidata.yaml
@@ -97,6 +97,8 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
+                  options:
+                    groups: '{{options.table.storage_groups}}'
             /page_revisions:
               x-modules:
                 - path: sys/page_revisions.js

--- a/projects/wmf_wikipedia.yaml
+++ b/projects/wmf_wikipedia.yaml
@@ -142,6 +142,8 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
+                  options:
+                    groups: '{{options.table.storage_groups}}'
             /page_revisions:
               x-modules:
                 - path: sys/page_revisions.js

--- a/projects/wmf_wikivoyage.yaml
+++ b/projects/wmf_wikivoyage.yaml
@@ -137,6 +137,8 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
+                  options:
+                    groups: '{{options.table.storage_groups}}'
             /page_revisions:
               x-modules:
                 - path: sys/page_revisions.js

--- a/projects/wmf_wiktionary.yaml
+++ b/projects/wmf_wiktionary.yaml
@@ -131,6 +131,8 @@ paths:
             /key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
+                  options:
+                    groups: '{{options.table.storage_groups}}'
             /page_revisions:
               x-modules:
                 - path: sys/page_revisions.js


### PR DESCRIPTION
**DO NOT MERGE**: I'm creating this PR to discuss caching inside the `key_value` bucket.

Currently, we issue `createBucket` requests for each bucket in each domain. This means that we uselessly issue ~800 requests per table on each RB start-up, making it a major contributor to the start-up delay. This delay will be exacerbated once we split RESTBase in two services (cf. #1103 and #1144) because all these requests will be issued by the front-end service and directed to the back-end service, hence adding network latency.

In this PR, I'm proposing to explore the idea of caching the responses and return immediately when a particular bucket is known to exist. This is tracked in the `key_value` bucket by using the `storage_groups` config supplied to `sys/table`. If a `createBucket` request has already been issued for a particular combination of storage group and bucket name, the previous result is returned. Otherwise, the request is executed and its resulting status is stored in module's cache.

Note that once RB is split in two, this logic would need to reside in both the front-end and back-end service (for performance reasons).The pro of such an approach include increased performance during start-up, both in terms of querying the data store as well in minimising the network latency needed to complete the start-up procedure (after the split). The (obvious) contra in doing so is that we would need to replicate the storage groups configuration. However, IMHO, this is ok to do in this particular instance since (i) the storage groups definition is fairly stable and not trivial to change; and (ii) the performance benefits far outweigh the _conceptual breakage_ that doing so incurs.

The alternative is to put this logic in the respective storage modules (Cassandra, SQLite). Alas, the only pro here is the fact that the storage layer **is** the canonical place for storage groups definitions. Putting the caching there would bring us some performance benefits, but we would not be able to get rid of futile network requests after the split.