### PR TITLE
Removed mwUtil.decodeBody

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -5,7 +5,6 @@ const contentType = require('content-type');
 const jwt = require('jsonwebtoken');
 const P = require('bluebird');
 const entities = require('entities');
-const gunzip = P.promisify(require('zlib').gunzip);
 const Title = require('mediawiki-title').Title;
 const HyperSwitch = require('hyperswitch');
 const querystring = require('querystring');
@@ -270,24 +269,6 @@ mwUtil.decodePagingToken = (hyper, token) => {
             }
         });
     }
-};
-
-mwUtil.decodeBody = (contentResponse) => {
-    let prepare;
-    if (contentResponse.headers &&
-            contentResponse.headers['content-encoding'] === 'gzip') {
-        delete contentResponse.headers['content-encoding'];
-        prepare = gunzip(contentResponse.body);
-    } else {
-        prepare = P.resolve(contentResponse.body);
-    }
-    return prepare.then((body) => {
-        if (body && Buffer.isBuffer(body)) {
-            body = body.toString();
-        }
-        contentResponse.body = body;
-        return contentResponse;
-    });
 };
 
 /**

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -390,9 +390,7 @@ class ParsoidService {
         .then((revInfo) => {
             rp.revision = revInfo.rev;
         })
-        .then(() => P.join(
-            this._getPageBundleFromParsoid(hyper, req),
-            mwUtil.decodeBody(currentContentRes))
+        .then(() => P.join(this._getPageBundleFromParsoid(hyper, req), currentContentRes)
         .spread((res, currentContentRes) => {
             const tid  = uuid.now().toString();
             const etag = mwUtil.makeETag(rp.revision, tid);


### PR DESCRIPTION
The buffer to string method is no longer needed since _getContentWithFallback provides the response object and the body is already decoded to string.

Bug: T221720