### PR TITLE
Mathoid: Move resource declarations into the sys/ module

### DIFF
--- a/sys/mathoid.js
+++ b/sys/mathoid.js
@@ -257,6 +257,24 @@ module.exports = (options) => {
             }, {
                 uri: '/{domain}/sys/key_value/mathoid_ng.check',
                 body: { valueType: 'json' }
+            }, {
+                uri: '/{domain}/sys/key_value/mathoid_ng.svg',
+                body: {
+                    keyType: 'string',
+                    valueType: 'string'
+                }
+            }, {
+                uri: '/{domain}/sys/key_value/mathoid_ng.mml',
+                body: {
+                    keyType: 'string',
+                    valueType: 'string'
+                }
+            }, {
+                uri: '/{domain}/sys/key_value/mathoid_ng.png',
+                body: {
+                    keyType: 'string',
+                    valueType: 'blob'
+                }
             }
         ]
     };

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -188,22 +188,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/problem'
       x-monitor: false
-      x-setup-handler:
-        - init_svg:
-            uri: /wikimedia.org/sys/key_value/mathoid_ng.svg
-            body:
-              keyType: string
-              valueType: string
-        - init_mml:
-            uri: /wikimedia.org/sys/key_value/mathoid_ng.mml
-            body:
-              keyType: string
-              valueType: string
-        - init_png:
-            uri: /wikimedia.org/sys/key_value/mathoid_ng.png
-            body:
-              keyType: string
-              valueType: blob
       x-request-handler:
         - check_storage:
             request:


### PR DESCRIPTION
The resource declarations for the images' buckets resided in
v1/mathoid.yaml, all of them creating the images' buckets in the global
domain. Alas, this causes RESTBase to issue check-and-create-bucket
requests for them for each domain it loads. Therefore, to optimise the
start-up process, move them to sys/mathoid.js, which is loaded only for
the global domain.