### PR TITLE
Rm backwards compatibility for mediawiki-basefields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "REST storage and service dispatcher",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "0.19.5",
+  "version": "0.19.4",
   "description": "REST storage and service dispatcher",
   "main": "index.js",
   "scripts": {

--- a/v1/citoid.js
+++ b/v1/citoid.js
@@ -19,14 +19,9 @@ class Citoid {
             acceptLanguagePromise = mwUtil.getSiteInfo(hyper, req).get('general').get('lang');
         }
         return acceptLanguagePromise.then((acceptLanguage) => {
-            let reqURI;
-            if (rp.format === 'mediawiki-basefields') {
-                reqURI = `${this._options.host}/api?format=mediawiki&` +
-                    `search=${encodeURIComponent(rp.query)}&basefields=true`;
-            } else {
-                reqURI = `${this._options.host}/api?format=${rp.format}&` +
-                    `search=${encodeURIComponent(rp.query)}`;
-            }
+            let reqURI = `${this._options.host}/api?format=${rp.format}&` +
+                `search=${encodeURIComponent(rp.query)}`;
+
             return hyper.get({
                 uri: reqURI,
                 headers: {


### PR DESCRIPTION
Backwards compatibility for the format
mediawiki-basefields is no longer needed because
this is the native name of the format.

The ability to use the extra basefields parameter
was removed in citoid in change I7fc0004abe6