### PR TITLE
Replace cassandra-uuid with uuid

### DIFF
--- a/lib/base_feed.js
+++ b/lib/base_feed.js
@@ -2,7 +2,7 @@
 
 const P = require('bluebird');
 const HyperSwitch = require('hyperswitch');
-const uuid = require('cassandra-uuid').TimeUuid;
+const uuidv1 = require('uuid/v1');
 const mwUtil = require('./mwUtil');
 const URI = HyperSwitch.URI;
 
@@ -25,7 +25,7 @@ class BaseFeed {
             headers: {
                 'cache-control': this.options.feed_cache_control,
                 // mimic MCS' ETag value
-                etag: `${dateKey}/${uuid.now().toString()}`,
+                etag: `${dateKey}/${uuidv1()}`,
                 'content-type': this.options.content_type
             },
             body: this.constructBody(result, req)

--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('cassandra-uuid').TimeUuid;
+const uuidUtils = require('./uuidUtils');
 const contentType = require('content-type');
 const jwt = require('jsonwebtoken');
 const P = require('bluebird');
@@ -118,14 +118,14 @@ mwUtil.shouldConvertLangVariant = (hyper, req, pageLang, acceptLang) => {
 mwUtil.extractDateFromEtag = (etag) => {
     const bits = mwUtil.parseETag(etag);
     if (bits) {
-        return uuid.fromString(bits.tid).getDate();
+        return uuidUtils.getDate(bits.tid);
     } else {
         return null;
     }
 };
 
 mwUtil.coerceTid = (tidString, bucket) => {
-    if (uuid.test(tidString)) {
+    if (uuidUtils.test(tidString)) {
         return tidString;
     }
 

--- a/lib/uuidUtils.js
+++ b/lib/uuidUtils.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const uuidRegEx = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+const uuidUtils = {};
+
+uuidUtils.V1_EPOCH_OFFSET = 122192928000000000; //  100 nanosecond intervals since 15 October 1582
+
+/**
+ * Extract time in nanoseconds from UUID V1
+ *
+ * @param {string} uuidv1
+ * @return {number|null}
+ *
+ */
+uuidUtils.getTimeInNs = (uuidv1) => {
+    if (!(typeof uuidv1 === 'string' || uuidv1 instanceof String)) {
+        return undefined;
+    }
+
+    const uuidComponents = uuidv1.split('-');
+    return parseInt(
+        [
+            uuidComponents[2].substring(1),
+            uuidComponents[1],
+            uuidComponents[0]
+        ].join(''), 16);
+};
+
+/**
+ * Extract time in microseconds from UUID V1
+ *
+ * @param {string} uuidv1
+ * @return {number|undefined}
+ *
+ */
+uuidUtils.getTime = (uuidv1) => {
+    const timeInNs = uuidUtils.getTimeInNs(uuidv1);
+    // Convert ns intervals to ms since Jan 1 1970
+    return timeInNs ? Math.floor((timeInNs - uuidUtils.V1_EPOCH_OFFSET) / 10000) : undefined;
+};
+
+/**
+ * Extract date from UUID V1
+ *
+ * @param {string} uuidv1
+ * @return {Date|undefined}
+ *
+ */
+uuidUtils.getDate = (uuidv1) => {
+    const timeInMs = uuidUtils.getTime(uuidv1);
+    return timeInMs ? new Date(timeInMs) : undefined;
+};
+
+/**
+ * Validate UUID
+ *
+ * @param {string} uuid
+ * @return {boolean}
+ *
+ */
+uuidUtils.test = (uuid) => {
+    if (!(typeof uuid === 'string' || uuid instanceof String)) {
+        return false;
+    }
+
+    return uuidRegEx.test(uuid);
+};
+
+module.exports = uuidUtils;

--- a/package.json
+++ b/package.json
@@ -36,16 +36,16 @@
   "readme": "README.md",
   "dependencies": {
     "bluebird": "^3.5.5",
-    "cassandra-uuid": "^0.1.0",
     "content-type": "git+https://github.com/wikimedia/content-type#master",
     "entities": "^1.1.2",
     "fast-json-stable-stringify": "^2.0.0",
-    "hyperswitch": "^0.12.3",
+    "hyperswitch": "^0.12.4",
     "jsonwebtoken": "^8.5.1",
     "mediawiki-title": "^0.6.5",
-    "restbase-mod-table-cassandra": "^1.1.4",
+    "restbase-mod-table-cassandra": "^1.2.0",
     "semver": "latest",
-    "service-runner": "^2.7.0"
+    "service-runner": "^2.7.1",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "ajv": "^6.10.0",
@@ -63,7 +63,7 @@
     "nyc": "^14.1.1",
     "openapi-schema-validator": "^3.0.3",
     "preq": "^0.5.8",
-    "restbase-mod-table-sqlite": "^1.1.2"
+    "restbase-mod-table-sqlite": "^1.1.3"
   },
   "engines": {
     "node": ">=6"

--- a/sys/events.js
+++ b/sys/events.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const P         = require('bluebird');
-const uuid = require('cassandra-uuid').TimeUuid;
+const uuidv1 = require('uuid/v1');
 
 class EventService {
     constructor(options) {
@@ -47,7 +47,7 @@ class EventService {
                 event.meta.uri = `http:${event.meta.uri}`;
                 event.meta.topic = topic;
                 event.meta.request_id = hyper.reqId;
-                event.meta.id = uuid.now().toString();
+                event.meta.id = uuidv1();
                 event.meta.dt = new Date().toISOString();
                 event.meta.domain = req.params.domain;
                 event.tags = event.tags || [];

--- a/sys/key_value.js
+++ b/sys/key_value.js
@@ -4,7 +4,7 @@
  * Key-value bucket handler
  */
 
-const uuid = require('cassandra-uuid').TimeUuid;
+const uuidv1 = require('uuid/v1');
 const mwUtil = require('../lib/mwUtil');
 const HyperSwitch = require('hyperswitch');
 const stringify = require('fast-json-stable-stringify');
@@ -99,7 +99,7 @@ class KVBucket {
         }
 
         const rp = req.params;
-        const tid = uuid.now().toString();
+        const tid = uuidv1();
 
         // In case specific content-type to store is not provided,
         // default to the request content type. Ideally this should not happen.

--- a/sys/page_revisions.js
+++ b/sys/page_revisions.js
@@ -13,7 +13,7 @@
 const HyperSwitch = require('hyperswitch');
 const HTTPError = HyperSwitch.HTTPError;
 const URI = HyperSwitch.URI;
-const TimeUuid = require('cassandra-uuid').TimeUuid;
+const uuidv1 = require('uuid/v1');
 const mwUtil = require('../lib/mwUtil');
 const stringify = require('fast-json-stable-stringify');
 
@@ -154,7 +154,7 @@ class PRS {
                 // deletion/ un-deletion events.
                 .then((result) => {
                     result = result.body.items[0];
-                    result.tid = TimeUuid.now().toString();
+                    result.tid = uuidv1();
                     result.page_deleted = result.rev;
                     // TODO: Object.assign here is to avoid a bug in sqlite
                     // backend that modifies original attribute.
@@ -408,7 +408,7 @@ class PRS {
                     title: normTitle,
                     page_id: parseInt(dataResp.pageid, 10),
                     rev: parseInt(apiRev.revid, 10),
-                    tid: TimeUuid.now().toString(),
+                    tid: uuidv1(),
                     namespace: parseInt(dataResp.ns, 10),
                     user_id: restrictions.indexOf('userhidden') < 0 ? apiRev.userid : null,
                     user_text: restrictions.indexOf('userhidden') < 0 ? apiRev.user : null,

--- a/sys/page_save.js
+++ b/sys/page_save.js
@@ -11,7 +11,7 @@ const HyperSwitch = require('hyperswitch');
 const URI = HyperSwitch.URI;
 const HTTPError = HyperSwitch.HTTPError;
 const mwUtil = require('../lib/mwUtil');
-const TimeUuid = require('cassandra-uuid').TimeUuid;
+const uuidUtils = require('../lib/uuidUtils');
 
 class PageSave {
     saveWikitext(hyper, req) {
@@ -84,7 +84,7 @@ class PageSave {
             return;
         }
         const etag = mwUtil.parseETag(req.headers['if-match']);
-        if (!etag || !TimeUuid.test(etag.tid) || !/^(?:[0-9]+)$/.test(etag.rev)) {
+        if (!etag || !uuidUtils.test(etag.tid) || !/^(?:[0-9]+)$/.test(etag.rev)) {
             throw new HTTPError({
                 status: 400,
                 body: {
@@ -94,7 +94,7 @@ class PageSave {
                 }
             });
         } else {
-            return TimeUuid.fromString(etag.tid).getDate().toISOString();
+            return uuidUtils.getDate(etag.tid).toISOString();
         }
     }
 

--- a/test/features/buckets/key_value_bucket.js
+++ b/test/features/buckets/key_value_bucket.js
@@ -3,7 +3,7 @@
 const preq   = require('preq');
 const assert = require('../../utils/assert.js');
 const Server = require('../../utils/server.js');
-const uuid = require('cassandra-uuid').TimeUuid;
+const uuidv1 = require('uuid');
 const P = require('bluebird');
 const parallel = require('mocha.parallel');
 
@@ -82,10 +82,10 @@ describe('Key value buckets', () => {
 
         it('key_value should not overwrite same content with ignore_duplicates', () => {
             const testData = randomString(100);
-            const originalEtag = uuid.now().toString();
+            const originalEtag = uuidv1();
             const etags = [ originalEtag,
-                uuid.now().toString(),
-                uuid.now().toString() ];
+                uuidv1(),
+                uuidv1() ];
             return P.each(etags, (etag) => preq.put({
                     uri: `${bucketBaseURI}/List_Test_1`,
                     body: new Buffer(testData),

--- a/test/features/events/events.js
+++ b/test/features/events/events.js
@@ -2,7 +2,7 @@
 
 const preq   = require('preq');
 const http   = require('http');
-const uuid   = require('cassandra-uuid').TimeUuid;
+const uuidUtils   = require('../../../lib/uuidUtils');
 
 const Server = require('../../utils/server.js');
 const assert = require('../../utils/assert.js');
@@ -36,8 +36,8 @@ describe('Change event emitting', () => {
                         const event = events[0];
                         assert.deepEqual(event.meta.domain, 'en.wikipedia.org');
                         assert.deepEqual(!!new Date(event.meta.dt), true);
-                        assert.deepEqual(uuid.test(event.meta.id), true);
-                        assert.deepEqual(!!event.meta.request_id, true);
+                        assert.deepEqual(uuidUtils.test(event.meta.id), true);
+                        assert.deepEqual(uuidUtils.test(event.meta.request_id), true);
                         assert.deepEqual(event.meta.topic, eventOptions.topic);
                         assert.deepEqual(event.meta.uri, eventOptions.uri);
                         assert.deepEqual(event.tags, ['test', 'restbase']);

--- a/test/features/parsoid/ondemand/ondemand.js
+++ b/test/features/parsoid/ondemand/ondemand.js
@@ -7,7 +7,7 @@ const assert = require('../../../utils/assert.js');
 const Server = require('../../../utils/server.js');
 const preq   = require('preq');
 const mwUtil = require('../../../../lib/mwUtil');
-const uuid   = require('cassandra-uuid');
+const uuidv1   = require('uuid');
 
 const revB = '275844';
 const revC = '275845';
@@ -40,7 +40,7 @@ describe('on-demand generation of html and data-parsoid', function() {
 
     it('should not transparently create revision B via Parsoid if TID is provided', () => {
         return preq.get({
-            uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}/html/${title}/${revB}/${uuid.TimeUuid.now().toString()}`,
+            uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}/html/${title}/${revB}/${uuidv1()}`,
         })
         .then(() => {
             throw new Error('404 should have been thrown');

--- a/test/features/uuidutils.js
+++ b/test/features/uuidutils.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * Unit tests for uuid helper methods
+ */
+
+// require('uuid') deprecated with version 3.x
+const uuidv1 = require('uuid/v1');
+const uuidv3 = require('uuid/v3');
+const uuidv4 = require('uuid/v4');
+const uuidv5 = require('uuid/v5');
+
+const uuidUtils = require('../../lib/uuidUtils');
+const assert = require('../utils/assert');
+
+describe('UUID Utils', () => {
+    const orig_time = Date.parse('04 Dec 1995 00:12:00 GMT');
+
+    it('Should retrieve the correct time from UUID v1', () => {
+        const uuid_time = uuidUtils.getTime(uuidv1({msecs: orig_time}));
+        assert.deepEqual(uuid_time, orig_time);
+    });
+
+    it('Should retrieve the correct date from UUID v1', () => {
+        const orig_dt = new Date(orig_time);
+        const uuid_dt = uuidUtils.getDate(uuidv1({msecs: orig_time}));
+        assert.deepEqual(uuid_dt, orig_dt);
+    });
+
+    it('Should validate all UUID versions', () => {
+        const MY_NAMESPACE = uuidv4();
+        const uuids = [uuidv1(), uuidv3('MY_NAME', MY_NAMESPACE), 
+            uuidv4(), uuidv5('MY_NAME', MY_NAMESPACE)];
+
+        uuids.forEach(u => {
+            assert.deepEqual(uuidUtils.test(u), true);
+        });
+    });
+});
+


### PR DESCRIPTION
Added uuidUtils module to provide some helper functions. Bumped the version number  to 0.19.5

Note: hyperswitch and restbase-mod-sqlite PRs for uuid need to be merged first for this to build.

Bug:  T223690