### PR TITLE
Add Suggested Edits endpoints to Recommendations

### DIFF
--- a/config.frontend.test.yaml
+++ b/config.frontend.test.yaml
@@ -186,6 +186,9 @@ spec_root: &spec_root
 
     # labs, used for most tests
     /{domain:en.wikipedia.beta.wmflabs.org}: *wikipedia_project
+    /{domain:commons.wikimedia.beta.wmflabs.org}: *commons_project
+    /{domain:wikidata.beta.wmflabs.org}: *wikidata_project
+
     # Serbian wiki in beta for language variants tests
     /{domain:sr.wikipedia.beta.wmflabs.org}: *wikipedia_project
 
@@ -197,6 +200,7 @@ spec_root: &spec_root
           options:
             permissions:
               - read
+
     # global domain
     /{domain:wikimedia.org}: *wikimedia_project
 

--- a/config.frontend.test.yaml
+++ b/config.frontend.test.yaml
@@ -98,6 +98,37 @@ wiktionary_project: &wiktionary_project
                 options: *default_options
           /{api:sys}: *default_sys
 
+commons_project: &commons_project
+  x-modules:
+    - spec:
+        paths:
+          /{api:v1}:
+            x-modules:
+              - path: projects/v1/default.wmf.yaml
+                options: *default_options
+              - path: projects/proxy.yaml
+                options: *proxy_options
+              - spec:
+                  paths:
+                    /data:
+                      x-modules:
+                        - path: v1/recommend-caption.yaml
+                          options: '{{options.recommendation}}'
+                options: *default_options
+          /{api:sys}: *default_sys
+
+wikidata_project: &wikidata_project
+  x-modules:
+    - spec:
+        paths:
+          /{api:v1}:
+            x-modules:
+              - path: projects/v1/wikidata.wmf.yaml
+                options: *default_options
+              - path: projects/proxy.yaml
+                options: *proxy_options
+          /{api:sys}: *default_sys
+
 testing_project: &testing_project
   x-modules:
     - spec:
@@ -150,7 +181,8 @@ spec_root: &spec_root
     /{domain:ru.wikipedia.org}: *wikipedia_project
     /{domain:de.wikipedia.org}: *wikipedia_project
     /{domain:test2.wikipedia.org}: *wikipedia_project
-    /{domain:commons.wikimedia.org}: *default_project
+    /{domain:commons.wikimedia.org}: *commons_project
+    /{domain:www.wikidata.org}: *wikidata_project
 
     # labs, used for most tests
     /{domain:en.wikipedia.beta.wmflabs.org}: *wikipedia_project

--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -221,6 +221,9 @@ spec_root: &spec_root
 
     # labs, used for most tests
     /{domain:en.wikipedia.beta.wmflabs.org}: *wikipedia_project
+    /{domain:commons.wikimedia.beta.wmflabs.org}: *commons_project
+    /{domain:wikidata.beta.wmflabs.org}: *wikidata_project
+
     # Serbian wiki in beta for language variants tests
     /{domain:sr.wikipedia.beta.wmflabs.org}: *wikipedia_project
 
@@ -232,6 +235,7 @@ spec_root: &spec_root
           options:
             permissions:
               - read
+
     # global domain
     /{domain:wikimedia.org}: *wikimedia_project
 

--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -135,6 +135,37 @@ wiktionary_project: &wiktionary_project
                 options: *proxy_options
           /{api:sys}: *default_sys
 
+commons_project: &commons_project
+  x-modules:
+    - spec:
+        paths:
+          /{api:v1}:
+            x-modules:
+              - path: projects/v1/default.wmf.yaml
+                options: *default_options
+              - spec:
+                  paths:
+                    /data:
+                      x-modules:
+                        - path: v1/recommend-caption.yaml
+                          options: '{{options.recommendation}}'
+                options: *default_options
+              - path: projects/proxy.yaml
+                options: *proxy_options
+          /{api:sys}: *default_sys
+
+wikidata_project: &wikidata_project
+  x-modules:
+    - spec:
+        paths:
+          /{api:v1}:
+            x-modules:
+              - path: projects/v1/wikidata.wmf.yaml
+                options: *default_options
+              - path: projects/proxy.yaml
+                options: *proxy_options
+          /{api:sys}: *default_sys
+
 testing_project: &testing_project
   x-modules:
     - spec:
@@ -185,7 +216,8 @@ spec_root: &spec_root
     /{domain:ru.wikipedia.org}: *wikipedia_project
     /{domain:de.wikipedia.org}: *wikipedia_project
     /{domain:test2.wikipedia.org}: *wikipedia_project
-    /{domain:commons.wikimedia.org}: *default_project
+    /{domain:commons.wikimedia.org}: *commons_project
+    /{domain:www.wikidata.org}: *wikidata_project
 
     # labs, used for most tests
     /{domain:en.wikipedia.beta.wmflabs.org}: *wikipedia_project

--- a/projects/v1/wikidata.wmf.yaml
+++ b/projects/v1/wikidata.wmf.yaml
@@ -79,4 +79,6 @@ paths:
     x-modules:
       - path: v1/lists.js
         options: '{{options.lists}}'
+      - path: v1/recommend-description.yaml
+        options: '{{options.recommendation}}'
 

--- a/test/features/recommendation.js
+++ b/test/features/recommendation.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('../utils/assert.js');
+const Server = require('../utils/server.js');
+const preq   = require('preq');
+
+// Tests for Recommendation API description and caption suggestion endpoints.
+// TODO: Move to monitored schema checks when non-enwiki domains are supported by the service checker
+describe('Recommendation API', () => {
+
+    const server = new Server();
+    before(() => server.start());
+    after(() => server.stop());
+
+    describe('captions', () => {
+
+        it('addition request succeeds and is well formed', () => {
+            const url = `${server.config.baseURL('commons.wikimedia.beta.wmflabs.org')}/data/recommendation/caption/addition/en`;
+            return preq.get(url).then((res) => {
+                assert.deepEqual(res.status, 200);
+                assert.ok(Array.isArray(res.body));
+                res.body.forEach((item) => {
+                    assert.ok(item.pageid); // pageid is present and is not 0
+                    assert.deepEqual(item.ns, 6); // namespace ID is 6 (NS_FILE)
+                    assert.ok(item.title); // title is present
+                    assert.ok(item.mime);  // MIME type is present
+                    assert.ok(item.structured); // structured data is present
+                    assert.ok(item.structured.captions); // captions field is present
+                    assert.ok(item.globalusage); //global usage field is present
+                });
+            });
+        });
+
+        it('translation request succeeds and is well formed', () => {
+            const url = `${server.config.baseURL('commons.wikimedia.beta.wmflabs.org')}/data/recommendation/caption/translation/from/en/to/ru`;
+            return preq.get(url).then((res) => {
+                assert.deepEqual(res.status, 200);
+                assert.ok(Array.isArray(res.body));
+                res.body.forEach((item) => {
+                    assert.ok(item.pageid); // pageid is present and is not 0
+                    assert.deepEqual(item.ns, 6); // namespace ID is 6 (NS_FILE)
+                    assert.ok(item.title); // title is present
+                    assert.ok(item.mime);  // MIME type is present
+                    assert.ok(item.structured); // structured data is present
+                    assert.ok(item.structured.captions); // captions field is present
+                    assert.ok(item.globalusage); //global usage field is present
+                });
+            });
+        });
+
+    });
+
+    describe('descriptions', () => {
+
+        it('addition request succeeds and is well formed', () => {
+            const url = `${server.config.baseURL('wikidata.beta.wmflabs.org')}/data/recommendation/description/addition/en`;
+            return preq.get(url).then((res) => {
+                assert.deepEqual(res.status, 200);
+                assert.ok(Array.isArray(res.body));
+                res.body.forEach((item) => {
+                    assert.ok(item.pageid); // pageid is present and is not 0
+                    assert.deepEqual(item.ns, 0); // namespace ID is 6 (NS_MAIN)
+                    assert.ok(item.title); // title is present
+                    assert.ok(item.wikibase_item); // wikibase item info is presesnt
+                    assert.deepEqual(item.wikibase_item.type, 'item'); // type is 'item'
+                    assert.ok(item.wikibase_item.id.startsWith('Q')); // ID is a Q-number
+                    assert.ok(item.wikibase_item.labels); // labels field is present
+                    assert.ok(item.wikibase_item.descriptions); // descriptions field is present
+                    assert.ok(item.wikibase_item.sitelinks); // sitelinks field is present
+                });
+            });
+        });
+
+        it('translation request succeeds and is well formed', () => {
+            const url = `${server.config.baseURL('wikidata.beta.wmflabs.org')}/data/recommendation/description/translation/from/en/to/ru`;
+            return preq.get(url).then((res) => {
+                assert.deepEqual(res.status, 200);
+                assert.ok(Array.isArray(res.body));
+                res.body.forEach((item) => {
+                    assert.ok(item.pageid); // pageid is present and is not 0
+                    assert.deepEqual(item.ns, 0); // namespace ID is 6 (NS_MAIN)
+                    assert.ok(item.title); // title is present
+                    assert.ok(item.wikibase_item); // wikibase item info is present
+                    assert.deepEqual(item.wikibase_item.type, 'item'); // type is 'item'
+                    assert.ok(item.wikibase_item.id.startsWith('Q')); // ID is a Q-number
+                    assert.ok(item.wikibase_item.labels); // labels field is present
+                    assert.ok(item.wikibase_item.descriptions); // descriptions field is present
+                    assert.ok(item.wikibase_item.sitelinks); // sitelinks field is present
+                });
+            });
+        });
+
+    });
+
+});

--- a/test/features/specification/monitoring.js
+++ b/test/features/specification/monitoring.js
@@ -180,6 +180,14 @@ describe('Monitoring tests', function() {
         {
             domain: 'en.wiktionary.org',
             specURI: `${server.config.baseURL('en.wiktionary.org')}/?spec`
+        },
+        {
+            domain: 'www.wikidata.org',
+            specURI: `${server.config.baseURL('www.wikidata.org')}/?spec`
+        },
+        {
+            domain: 'commons.wikimedia.org',
+            specURI: `${server.config.baseURL('commons.wikimedia.org')}/?spec`
         }],
         (options) => {
             return preq.get(options.specURI)

--- a/v1/recommend-caption.yaml
+++ b/v1/recommend-caption.yaml
@@ -1,0 +1,110 @@
+info:
+  version: 1.0.0
+  title: Recommendation API
+  description: Recommendation API
+  termsOfService: https://github.com/wikimedia/restbase
+  license:
+    name: Apache license, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+tags:
+  - name: Recommendation
+    description: contribution recommendations
+paths:
+  /recommendation/caption/addition/{target}:
+    get:
+      tags:
+        - Recommendation
+      summary: Recommend files missing a caption (label) in the target language
+      parameters:
+        - name: target
+          in: path
+          description: The target wiki language code for suggestions
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: list of candidates for caption addition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/caption_recommendation_result'
+        default:
+          description: Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/{{domain}}/v1/caption/addition/{target}'
+      x-monitor: false
+
+  /recommendation/caption/translation/from/{source}/to/{target}:
+    get:
+      tags:
+        - Recommendation
+      summary: Recommend files with a caption (label) in the source language but missing one in the target language
+      parameters:
+        - name: source
+          in: path
+          description: The source wiki language code for suggestions
+          required: true
+          schema:
+            type: string
+        - name: target
+          in: path
+          description: The target wiki language code for suggestions
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: list of candidates for caption translation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/caption_recommendation_result'
+        default:
+          description: Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/{{domain}}/v1/caption/translation/from/{source}/to/{target}'
+      x-monitor: false
+
+components:
+  schemas:
+    caption_recommendation_result:
+      type: array
+      description: list of candidates for caption addition or translation
+      items:
+        type: object
+        properties:
+          pageid:
+            type: integer
+            description: wiki page id
+          ns:
+            type: integer
+            description: numeric page namespace (should always be 6)
+          title:
+            type: string
+            description: page title (with namespace prefix)
+          mime:
+            type: string
+            description: the MIME type of the file
+          structured:
+            type: object
+            description: structured data from Structured Data on Commons
+            properties:
+              captions:
+                type: object
+                description: captions, by language, from Structured Data on Commons
+          globalusage:
+            type: object
+            description: pages using this image on the source or target wiki, by language

--- a/v1/recommend-description.yaml
+++ b/v1/recommend-description.yaml
@@ -1,0 +1,116 @@
+info:
+  version: 1.0.0
+  title: Recommendation API
+  description: Recommendation API
+  termsOfService: https://github.com/wikimedia/restbase
+  license:
+    name: Apache license, v2
+    url: https://www.apache.org/licenses/LICENSE-2.0
+tags:
+  - name: Recommendation
+    description: contribution recommendations
+paths:
+  /recommendation/description/addition/{target}:
+    get:
+      tags:
+        - Recommendation
+      summary: Recommend Wikibase items missing a description in the target language
+      parameters:
+        - name: target
+          in: path
+          description: The target wiki language code for suggestions
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: list of candidates for description addition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/description_recommendation_result'
+        default:
+          description: Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/{{domain}}/v1/description/addition/{target}'
+      x-monitor: false
+
+  /recommendation/description/translation/from/{source}/to/{target}:
+    get:
+      tags:
+        - Recommendation
+      summary: Recommend Wikibase items with a description in the source language but missing one in the target language
+      parameters:
+        - name: source
+          in: path
+          description: The source wiki language code for suggestions
+          required: true
+          schema:
+            type: string
+        - name: target
+          in: path
+          description: The target wiki language code for suggestions
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: list of candidates for description translation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/description_recommendation_result'
+        default:
+          description: Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
+      x-request-handler:
+        - get_from_backend:
+            request:
+              uri: '{{options.host}}/{{domain}}/v1/description/translation/from/{source}/to/{target}'
+      x-monitor: false
+
+components:
+  schemas:
+    description_recommendation_result:
+      type: array
+      description: list of candidates for description addition or translation
+      items:
+        type: object
+        properties:
+          pageid:
+            type: integer
+            description: wiki page id
+          ns:
+            type: integer
+            description: numeric page namespace (should always be 0)
+          title:
+            type: string
+            description: page title
+          wikibase_item:
+            type: object
+            description: info about the corresponding item in Wikidata
+            properties:
+              type:
+                type: string
+                description: entity type (should always be "item")
+              id:
+                type: string
+                description: Wikibase ID (should be Q-prefixed)
+              labels:
+                type: object
+                description: item labels by language
+              descriptions:
+                type: object
+                description: item descriptions by language
+              sitelinks:
+                type: object
+                description: item sitelinks by wiki (e.g., 'dewiki')

--- a/v1/recommend.yaml
+++ b/v1/recommend.yaml
@@ -8,7 +8,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 tags:
   - name: Recommendation
-    description: article translation recommendations
+    description: contribution recommendations
 paths:
   /recommendation/article/creation/translation/{from_lang}:
     get: &recommendation_article_creation_translation_from-lang_get_spec


### PR DESCRIPTION
Adds four new recommendation endpoints:

- /data/recommendation/caption/addition/{target}
- /data/recommendation/caption/translation/from/{source}/to/{target}
- /data/recommendation/description/addition/{target}
- /data/recommendation/description/translation/from/{source}/to/{target}

The caption suggestion endpoints are supported for Commons domains,
and the description suggestion endpoints are supported for Wikidata domains.

Phab: https://phabricator.wikimedia.org/T224754