### PR TITLE
Save SQLite DB file to temp location 

### DIFF
--- a/.pipeline/blubber.yaml
+++ b/.pipeline/blubber.yaml
@@ -19,7 +19,10 @@ variants:
     includes: [build]
     apt: { packages: [libsqlite3-0, ca-certificates] }
     entrypoint: [npm, test]
-    runs: { environment: { TEST_TARGET: sqlite, TEST_MODE: fefs } }
+    runs:
+      environment:
+        TEST_TARGET: sqlite
+        TEST_MODE: fefs
   prep:
     includes: [build]
     node: { env: production }

--- a/config.backend.test.yaml
+++ b/config.backend.test.yaml
@@ -34,7 +34,8 @@ default_project: &default_project
                               storage_groups:
                                 - name: test.group.local
                                   domains: /./
-                              dbname: test.db.sqlite3 # ignored in cassandra, but useful in SQLite testing
+                              # ignored in cassandra, but useful in SQLite testing
+                              dbname: '{env(RB_SQLITE_FILE, test.db.sqlite3)}'
                     /action:
                       x-modules:
                         - path: sys/action.js

--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -72,7 +72,8 @@ default_project: &default_project
                               storage_groups:
                                 - name: test.group.local
                                   domains: /./
-                              dbname: test.db.sqlite3 # ignored in cassandra, but useful in SQLite testing
+                              # ignored in cassandra, but useful in SQLite testing
+                              dbname: '{env(RB_SQLITE_FILE, test.db.sqlite3)}'
 
 wikimedia_project: &wikimedia_project
   x-modules:

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -21,7 +21,8 @@ fi
 
 if [ "x$test_target" = "x" ] || [ "$test_target" = "sqlite" ]; then
     echo "Running with SQLite backend"
-    rm -f test.db.sqlite3
+    export RB_SQLITE_FILE=`mktemp -t sqlite.XXXXXXXXXX`
+    echo "Saving SQLite DB to ${RB_SQLITE_FILE}"
 elif [ "$test_target" = "cassandra" ]; then
     echo "Running with Cassandra backend"
     if [ `nc -z localhost 9042 < /dev/null; echo $?` != 0 ]; then


### PR DESCRIPTION
For testing, we run in SQLite mode in docker and so can't create the test file in current directory because of permissions. Instead, let's create the DB file in OS temp location.

cc @wikimedia/services @akosiaris 

