### PR TITLE
Ignore cache-control on store requests

### DIFF
--- a/sys/key_value.js
+++ b/sys/key_value.js
@@ -97,6 +97,7 @@ class KVBucket {
         if (mwUtil.isNoStoreRequest(req)) {
             return { status: 202 };
         }
+        delete req.headers['cache-control'];
 
         const rp = req.params;
         const tid = uuidv1();

--- a/test/features/buckets/key_value_bucket.js
+++ b/test/features/buckets/key_value_bucket.js
@@ -56,6 +56,27 @@ describe('Key value buckets', () => {
                 assert.deepEqual(res.body, new Buffer(testData));
             });
         });
+        it('stores a content in a bucket and gets it back, no-cache and if-hash-match', () => {
+            const testData = randomString(100);
+            return preq.put({
+                uri: `${bucketBaseURI}/${testData}`,
+                headers: {
+                    'cache-control': 'no-cache',
+                    'if-none-hash-match': '*'
+                },
+                body: new Buffer(testData)
+            })
+            .then((res) => {
+                assert.deepEqual(res.status, 201);
+                return preq.get({
+                    uri: `${bucketBaseURI}/${testData}`
+                });
+            })
+            .then((res) => {
+                assert.deepEqual(res.status, 200);
+                assert.deepEqual(res.body, new Buffer(testData));
+            });
+        });
         it('Supports text/plain', () => {
             const testData = randomString(100);
             return preq.put({


### PR DESCRIPTION
A fallout from split - we've accidentally started to respect 'cache-control: no-cache' header on write in case `if-none-hash-match` header is provided as well.

Bug: https://phabricator.wikimedia.org/T226983