### PR TITLE
Loosen etag expectation for talk x-ample

### DIFF
--- a/v1/talk.yaml
+++ b/v1/talk.yaml
@@ -99,7 +99,7 @@ paths:
             status: 200
             headers:
               content-type: /application\/json; charset=utf-8; profile=".+Talk.+"/
-              etag: /^"[^/"]+/[^/"]+"$/
+              etag: /.+/
             body:
               topics:
                 - id: /.+/


### PR DESCRIPTION
On the edges the etag will be weak, thus prepended with `W`. Loosen the regex to match other etag regexes we use elsewhere.

cc @wikimedia/services 