### PR TITLE
Only expose unique values for the operationId.

### DIFF
--- a/test/features/router/misc.js
+++ b/test/features/router/misc.js
@@ -88,4 +88,28 @@ describe('router - misc', function() {
             assert.deepEqual(res.body, '');
         });
     });
+
+    it('should only use unique operationId', () => {
+        return preq.get({
+            uri: `${server.config.baseURL()}/?spec`
+        })
+        .then((res) => {
+            const spec = res.body;
+            const operations = [];
+            Object.keys(spec.paths).forEach((path) => {
+               const pathSpec = spec.paths[path];
+               Object.keys(pathSpec).forEach((method) => {
+                   const operationId = pathSpec[method].operationId;
+                   if (operationId) {
+                       if (operations.includes(operationId)) {
+                           throw new assert.AssertionError({
+                               message: `Duplicated operationId ${operationId} at path ${path}:${method}`
+                            });
+                       }
+                       operations.push(operationId);
+                   }
+               })
+            });
+        })
+    });
 });

--- a/v1/pcs/media-list.yaml
+++ b/v1/pcs/media-list.yaml
@@ -82,7 +82,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/problem'
-      operationId: getContent
+      operationId: getContent-media-list
       x-monitor: true
       x-amples:
         - title: Get media-list from storage
@@ -128,7 +128,7 @@ paths:
             To get a 200 response instead, supply `false` to the `redirect` parameter.
           schema:
             type: boolean
-      operationId: getContentWithRevision
+      operationId: getContentWithRevision-media-list
       x-monitor: false
 
 components:

--- a/v1/pcs/metadata.yaml
+++ b/v1/pcs/metadata.yaml
@@ -80,7 +80,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/problem'
-      operationId: getContent
+      operationId: getContent-metadata
       x-monitor: true
       x-amples:
         - title: Get metadata from storage
@@ -137,7 +137,7 @@ paths:
             To get a 200 response instead, supply `false` to the `redirect` parameter.
           schema:
             type: boolean
-      operationId: getContentWithRevision
+      operationId: getContentWithRevision-metadata
       x-monitor: false
 
 components:

--- a/v1/pcs/mobile-html.yaml
+++ b/v1/pcs/mobile-html.yaml
@@ -108,7 +108,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/problem'
-      operationId: getContent
+      operationId: getContent-mobile-html
       x-monitor: true
       x-amples:
         - title: Get mobile-html from storage
@@ -149,5 +149,5 @@ paths:
             To get a 200 response instead, supply `false` to the `redirect` parameter.
           schema:
             type: boolean
-      operationId: getContentWithRevision
+      operationId: getContentWithRevision-mobile-html
       x-monitor: false

--- a/v1/pcs/references.yaml
+++ b/v1/pcs/references.yaml
@@ -81,7 +81,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/problem'
-      operationId: getContent
+      operationId: getContent-references
       x-monitor: true
       x-amples:
         - title: Get references from storage
@@ -131,7 +131,7 @@ paths:
             To get a 200 response instead, supply `false` to the `redirect` parameter.
           schema:
             type: boolean
-      operationId: getContentWithRevision
+      operationId: getContentWithRevision-references
       x-monitor: false
 
 # copied from MCS spec.yaml

--- a/v1/pcs/stored_endpoint.js
+++ b/v1/pcs/stored_endpoint.js
@@ -122,8 +122,8 @@ module.exports = (options) => {
     return {
         spec,
         operations: {
-            getContent: pcs.getContent.bind(pcs),
-            getContentWithRevision: pcs.getContent.bind(pcs)
+            [`getContent-${options.name}`]: pcs.getContent.bind(pcs),
+            [`getContentWithRevision-${options.name}`]: pcs.getContent.bind(pcs)
         },
         resources: [
             { uri: `/{domain}/sys/key_value/${options.name}` }


### PR DESCRIPTION
We have to only expose unique operationIds because duplicates break swagger-ui autogenerated docs.