### PR TITLE
Expose new PCS javascript endpoints: pagelib_body_start and pagelib_body_end

### DIFF
--- a/v1/javascript.yaml
+++ b/v1/javascript.yaml
@@ -56,3 +56,96 @@ paths:
               get_from_pcs.headers) }}'
               body: '{{get_from_pcs.body}}'
       x-monitor: false
+  /javascript/mobile/pagelib_body_start:
+    x-route-filters:
+      - path: lib/security_response_header_filter.js
+    get:
+      tags:
+        - Mobile
+      summary: |
+        Get the JavaScript to run at the start of the body tag from the wikimedia-page-library
+      description: |
+        Gets the javascript that is intended to be run at the start of the body tag to apply
+        settings with the wikimedia-page-library. It reads an object from document.pcsSetupSettings
+        and utilizes it as the parameter for pagelib.c1.Page.setup(). It applies settings like
+        margins and theming that need to be applied before the page body starts rendering.
+        It also reads a function that takes a single parameter from document.pcsActionHandler and
+        utilizes it to notify the client of page events. Alternatively, clients can set a
+        pcsClient variable that returns a JSON string with settings from
+        pcsClient.getSetupSettings() and receives a JSON string to pcsClient.onReceiveMessage().
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      responses:
+        200:
+          description: Success
+          headers:
+            ETag:
+              description: Different values indicate that the content has changed
+              schema:
+                type: string
+          content:
+            application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/JavaScript/1.0.0":
+              schema:
+                type: object
+        default:
+          description: Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
+      x-request-handler:
+        - get_from_pcs:
+            request:
+              method: get
+              uri: '{{options.host}}/{domain}/v1/data/javascript/mobile/pagelib_body_start'
+            return:
+              status: 200
+              headers: '{{ merge({"cache-control": options.response_cache_control},
+              get_from_pcs.headers) }}'
+              body: '{{get_from_pcs.body}}'
+      x-monitor: false
+  /javascript/mobile/pagelib_body_end:
+    x-route-filters:
+      - path: lib/security_response_header_filter.js
+    get:
+      tags:
+        - Mobile
+      summary: Get the JavaScript to run at the end of the body tag from the wikimedia-page-library
+      description: |
+        Gets the javascript that is intended to be run at the end of the body tag to apply
+        settings with the wikimedia-page-library. It reads an object from document.pcsSetupSettings
+        and utilizes it as the parameter for pagelib.c1.Page.setup(). It applies settings that can
+        wait until the document finishes loading to be applied. Alternatively, clients can set a
+        pcsClient variable that returns a JSON string with settings from
+        pcsClient.getSetupSettings().
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      responses:
+        200:
+          description: Success
+          headers:
+            ETag:
+              description: Different values indicate that the content has changed
+              schema:
+                type: string
+          content:
+            application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/JavaScript/1.0.0":
+              schema:
+                type: object
+        default:
+          description: Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
+      x-request-handler:
+        - get_from_pcs:
+            request:
+              method: get
+              uri: '{{options.host}}/{domain}/v1/data/javascript/mobile/pagelib_body_end'
+            return:
+              status: 200
+              headers: '{{ merge({"cache-control": options.response_cache_control},
+              get_from_pcs.headers) }}'
+              body: '{{get_from_pcs.body}}'
+      x-monitor: false


### PR DESCRIPTION
There are two new Page Content Service endpoints that return JavaScript for mobile-html

https://phabricator.wikimedia.org/T232449