### PR TITLE
Use debian:stretch as the base image; release v1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "REST storage and service dispatcher",
   "main": "index.js",
   "scripts": {
@@ -39,13 +39,13 @@
     "content-type": "git+https://github.com/wikimedia/content-type#master",
     "entities": "^2.0.0",
     "fast-json-stable-stringify": "^2.0.0",
-    "hyperswitch": "^0.12.6",
+    "hyperswitch": "^0.12.7",
     "jsonwebtoken": "^8.5.1",
     "mediawiki-title": "^0.7.2",
     "restbase-mod-table-cassandra": "^1.2.1",
     "semver": "latest",
     "service-runner": "^2.7.3",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "ajv": "^6.10.2",
@@ -70,7 +70,7 @@
   },
   "deploy": {
     "node": "6.11.1",
-    "target": "debian",
+    "target": "debian:stretch",
     "dependencies": {
       "_all": []
     }


### PR DESCRIPTION
Start using Stretch as the base image to build the deploy repo.

Bug: [T224553](https://phabricator.wikimedia.org/T224553)