### PR TITLE
Update appservice.wmflabs.org references to mobileapps.wmflabs.org

### DIFF
--- a/config.frontend.test.yaml
+++ b/config.frontend.test.yaml
@@ -20,11 +20,11 @@ default_project: &default_project
                     # 10 days Varnish caching, one day client-side
                     cache-control: s-maxage=864000, max-age=86400
                   mobileapps:
-                    host: https://appservice.wmflabs.org
+                    host: https://mobileapps.wmflabs.org
                   summary:
                     protocol: https
                     implementation: mcs
-                    host: https://appservice.wmflabs.org
+                    host: https://mobileapps.wmflabs.org
                   citoid:
                     host: https://citoid-beta.wmflabs.org
                   recommendation:

--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -19,11 +19,11 @@ default_project: &default_project
                     # 10 days Varnish caching, one day client-side
                     cache-control: s-maxage=864000, max-age=86400
                   mobileapps:
-                    host: https://appservice.wmflabs.org
+                    host: https://mobileapps.wmflabs.org
                   summary:
                     protocol: https
                     implementation: mcs
-                    host: https://appservice.wmflabs.org
+                    host: https://mobileapps.wmflabs.org
                   citoid:
                     host: https://citoid-beta.wmflabs.org
                   recommendation:

--- a/test/features/feed.js
+++ b/test/features/feed.js
@@ -5,7 +5,7 @@ const Server = require('../utils/server.js');
 const preq   = require('preq');
 
 function assertMCSRequest(content, date, expected) {
-    const serviceURI = 'https://appservice.wmflabs.org';
+    const serviceURI = 'https://mobileapps.wmflabs.org';
     let path = `/en.wikipedia.org/v1/${content}`;
     if (date) {
         path += `/${date}`;


### PR DESCRIPTION
Move dev/testing traffice away from the legacy appservice labs instance,
which is being replaced by mobileapps.wmflabs.org (a web proxy for
mobileapps.mobile.eqiad.wmflabs).

Bug: https://phabricator.wikimedia.org/T225837