### PR TITLE
Parsoid: Remove the TID suffix, if present

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -59,15 +59,27 @@ mwUtil.normalizeTitle = (hyper, req, title) =>  mwUtil.getSiteInfo(hyper, req)
  */
 mwUtil.parseETag = (etag) => {
     const bits = /^(?:W\/)?"?([^"/]+)(?:\/([^"/]+))(?:\/([^"]+))?"?$/.exec(etag);
-    if (bits) {
-        return {
-            rev: bits[1],
-            tid: bits[2],
-            suffix: bits[3]
-        };
-    } else {
+    if (!bits) {
         return null;
     }
+    const ret = {
+        rev: bits[1],
+        tid: bits[2],
+        suffix: bits[3]
+    };
+    // T230272: the TID itself may be suffixed (this is allowed by
+    // RfC7232), so extract only the proper TID
+    if (ret.tid && ret.tid.length > 36) {
+        const tidBits = /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-?(.*)$/i.exec(ret.tid);
+        if (tidBits) {
+            ret.tid = tidBits[1];
+            ret.tidSuffix = tidBits[2];
+        } else {
+            // this is not a valid UUIDv1, but ignore this case for now
+            // and let the TID through unmodified
+        }
+    }
+    return ret;
 };
 
 /**

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -545,6 +545,14 @@ class ParsoidService {
                     hyper.logger.log('error/parsoid/etag_mismatch', {
                         msg: 'Client-supplied etag did not match mw:TimeUuid!'
                     });
+                } else if (tid && etag.tidSuffix) {
+                    // T230272: the TID has a suffix, just log this
+                    // occurrence and continue with the original value
+                    hyper.logger.log('warn/parsoid/etag_tidsuffix', {
+                        msg: 'Client-supplied etag TID has a suffix',
+                        tid,
+                        suffix: etag.tidSuffix
+                    });
                 } else if (!tid) {
                     tid = htmlTid;
                     hyper.logger.log('warn/parsoid/etag', {


### PR DESCRIPTION
As per RfC7232, ETags can be suffixed depending on the content type sent. Normally, the suffix should not be present in the If-Match header sent by the client. Alas, in certain circumstances (yet to be exactly pinned down) VE sends us an If-Match header that is suffixed by `-df` (presumably indicating deflate-compressed content, which is not the case), causing RESTBase to throw 404s for content that is in reality available in storage.

This has been happening for 15 days now with at least 2000 occurrences per day, which is problematic since users are unable to save their modifications because of it. To work around this problem, RESTBase now strips the suffix and complains only by logging the event.

Bug: [T230272](https://phabricator.wikimedia.org/T230272)