### PR TITLE
Still use MCS instead of Wikifeeds

### DIFF
--- a/projects/v1/wikimedia.wmf.yaml
+++ b/projects/v1/wikimedia.wmf.yaml
@@ -72,4 +72,4 @@ paths:
   /feed:
     x-modules:
       - path: v1/availability.yaml
-        options: '{{options.wikifeeds}}'
+        options: '{{options.mobileapps}}'

--- a/projects/v1/wikipedia.wmf.yaml
+++ b/projects/v1/wikipedia.wmf.yaml
@@ -107,11 +107,11 @@ paths:
   /feed:
     x-modules:
       - path: v1/feed.js
-        options: '{{merge({"feed_cache_control": "s-maxage=300, max-age=60"}, options.wikifeeds)}}'
+        options: '{{merge({"feed_cache_control": "s-maxage=300, max-age=60"}, options.mobileapps)}}'
       - path: v1/announcements.yaml
-        options: '{{merge({"announcement_cache_control": "s-maxage=86400, max-age=86400"}, options.wikifeeds)}}'
+        options: '{{merge({"announcement_cache_control": "s-maxage=86400, max-age=86400"}, options.mobileapps)}}'
       - path: v1/onthisday.js
-        options: '{{merge({"feed_cache_control": "s-maxage=300, max-age=60"}, options.wikifeeds)}}'
+        options: '{{merge({"feed_cache_control": "s-maxage=300, max-age=60"}, options.mobileapps)}}'
   /transform:
     x-modules:
       - path: v1/transform.yaml

--- a/test/features/feed.js
+++ b/test/features/feed.js
@@ -5,7 +5,7 @@ const Server = require('../utils/server.js');
 const preq   = require('preq');
 
 function assertMCSRequest(content, date, expected) {
-    const serviceURI = 'https://wikifeeds.wmflabs.org';
+    const serviceURI = 'https://mobileapps.wmflabs.org';
     let path = `/en.wikipedia.org/v1/${content}`;
     if (date) {
         path += `/${date}`;


### PR DESCRIPTION
There are some issues with Wikifeeds, so until the service is fully
production-ready, use MCS for feed end points.

Bug: [T170455](https://phabricator.wikimedia.org/T170455)