### PR TITLE
Add .pipeline/config.yaml with publish stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 restbase
 coverage
 config.yaml
+!.pipeline/config.yaml
 node_modules
 npm-debug.log
 package-lock.json

--- a/.pipeline/config.yaml
+++ b/.pipeline/config.yaml
@@ -1,0 +1,9 @@
+pipelines:
+  publish:
+    blubberfile: blubber.yaml
+    stages:
+      - name: dev
+        build: development
+        publish:
+          image:
+            tags: [dev]


### PR DESCRIPTION
Adds a basic pipeline configuration with a publish stage for development
images to be used in local-charts (and eventually elsewhere, probably).

Bug: T234580