### PR TITLE
Parsoid: Use the ETag's revid to stash the content under

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -218,14 +218,14 @@ class ParsoidService {
         const rp = req.params;
         const dataParsoidResponse = parsoidResp.body['data-parsoid'];
         const htmlResponse = parsoidResp.body.html;
-        const tid = mwUtil.parseETag(parsoidResp.headers.etag).tid;
+        const etag = mwUtil.parseETag(parsoidResp.headers.etag);
         return hyper.put({
-            uri: this.getStashBucketURI(rp.domain, rp.title, rp.revision, tid),
+            uri: this.getStashBucketURI(rp.domain, rp.title, etag.rev, etag.tid),
             // Note. The headers we are storing here are for the whole pagebundle response.
             // The individual components of the pagebundle contain their own headers that
             // which are used to generate actual responses.
             headers: {
-                'x-store-etag': htmlResponse.headers.etag,
+                'x-store-etag': parsoidResp.headers.etag,
                 'content-type': 'application/octet-stream',
                 'x-store-content-type': 'application/json'
             },
@@ -549,7 +549,7 @@ class ParsoidService {
                     status: 500,
                     body: {
                         title: 'no_etag',
-                        description: 'No ETag fas been provided in the response'
+                        description: 'No ETag has been provided in the response'
                     }
                 });
             }


### PR DESCRIPTION
Clients may want to stash the contents of a document regardless of
whether they provide the revid in the URI or not. If they do, then the
contents being stashed needs to match that revid (ensured by
`generateAndSave`), but if they don't then we have to use the revid
present in the ETag. They either have to match or we must use the one in
the ETag as the client has not supplied it. Therefore, always use the
one found in the response's ETag.

Furthermore, ensure the returned ETag is the one we stash the data under.
We use the HTML's response's ETag to stash the data, but return the
overall response's ETag. While they are equal in most cases, ensure that
the proper ETag is returned without counting on the magic of them being
equal.

Also, in case we don't have an ETag to stash and return, error out as
it's better to fail in that case than create a new one since that means
that either we have incomplete data or that Parsoid did not return a
proper response (or both).

Bug: [T234928](https://phabricator.wikimedia.org/T234928)