### PR TITLE
Parsoid: If a stash can't be found, retry with undefined as the revid

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -346,6 +346,14 @@ class ParsoidService {
             return hyper.get({
                 uri: this.getStashBucketURI(domain, title, revision, tid)
             })
+            // TEMP TEMP TEMP TEMP
+            // T234928: if we cannot find the stash, use 'undefined' for the rev id
+            // since that's how RB stores it when the client does not provide it.
+            // This should be removed 24h after being deployed
+            .catch({ status: 404 }, () =>
+                hyper.get({ uri: this.getStashBucketURI(domain, title, 'undefined', tid) })
+            )
+            // END TEMP
             .catch({ status: 404 }, () =>
                 hyper.get({ uri: this.getLatestBucketURI(domain, title) })
                 .then((res) => {


### PR DESCRIPTION
When the client doesn't provide the revid to stash the contents under,
the key used by RESTBase is `{title}:undefined:{tid}`, so retry using
that key before falling back to fetching the latest contents.

Note: this is only a temprary work-around for the current situation in
storage where a considerable amount of stashes are stored with this key.
This should be removed after 24h.

Bug: [T234928](https://phabricator.wikimedia.org/T234928)