### PR TITLE
PCS: Do not use storage for /page/metadata; release v1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restbase",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "REST storage and service dispatcher",
   "main": "index.js",
   "scripts": {

--- a/projects/v1/wikipedia.wmf.yaml
+++ b/projects/v1/wikipedia.wmf.yaml
@@ -73,14 +73,13 @@ paths:
         options:
           response_cache_control: '{{options.purged_cache_control}}'
           host: '{{options.mobileapps.host}}'
-      - path: v1/pcs/stored_endpoint.js
+      - path: v1/pcs/metadata.yaml
         options:
-          name: media-list
           response_cache_control: '{{options.purged_cache_control}}'
           host: '{{options.mobileapps.host}}'
       - path: v1/pcs/stored_endpoint.js
         options:
-          name: metadata
+          name: media-list
           response_cache_control: '{{options.purged_cache_control}}'
           host: '{{options.mobileapps.host}}'
       - path: v1/pcs/stored_endpoint.js

--- a/projects/v1/wikivoyage.wmf.yaml
+++ b/projects/v1/wikivoyage.wmf.yaml
@@ -76,14 +76,13 @@ paths:
         options:
           response_cache_control: '{{options.purged_cache_control}}'
           host: '{{options.mobileapps.host}}'
-      - path: v1/pcs/stored_endpoint.js
+      - path: v1/pcs/metadata.yaml
         options:
-          name: media-list
           response_cache_control: '{{options.purged_cache_control}}'
           host: '{{options.mobileapps.host}}'
       - path: v1/pcs/stored_endpoint.js
         options:
-          name: metadata
+          name: media-list
           response_cache_control: '{{options.purged_cache_control}}'
           host: '{{options.mobileapps.host}}'
       - path: v1/pcs/stored_endpoint.js

--- a/projects/v1/wiktionary.wmf.yaml
+++ b/projects/v1/wiktionary.wmf.yaml
@@ -70,14 +70,13 @@ paths:
         options:
           response_cache_control: '{{options.purged_cache_control}}'
           host: '{{options.mobileapps.host}}'
-      - path: v1/pcs/stored_endpoint.js
+      - path: v1/pcs/metadata.yaml
         options:
-          name: media-list
           response_cache_control: '{{options.purged_cache_control}}'
           host: '{{options.mobileapps.host}}'
       - path: v1/pcs/stored_endpoint.js
         options:
-          name: metadata
+          name: media-list
           response_cache_control: '{{options.purged_cache_control}}'
           host: '{{options.mobileapps.host}}'
       - path: v1/pcs/stored_endpoint.js

--- a/v1/pcs/metadata.yaml
+++ b/v1/pcs/metadata.yaml
@@ -81,36 +81,19 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/problem'
-      operationId: getContent-metadata
-      x-monitor: true
-      x-amples:
-        - title: Get metadata from storage
-          request:
-            params:
-              domain: en.wikipedia.org
-              title: User:BSitzmann_(WMF)/MCS/Test/Frankenstein
-          response:
-            status: 200
-            headers:
-              etag: /.+/
-              content-type: /^application\/json/
-            body:
-              revision: /.+/
-              tid: /.+/
-              hatnotes:
-                - section: /.+/
-                  html: /.+/
-              toc:
-                title: /.+/
-                entries:
-                  - level: /.+/
-                    section: /.+/
-                    number: /.+/
-                    anchor: /.+/
-                    html: /.+/
-              protection:
-                edit: [ /.+/ ]
-                move: [ /.+/ ]
+      x-monitor: false
+      x-request-handler:
+        - get_from_pcs:
+           request:
+             method: get
+             headers:
+               cache-control: '{{cache-control}}'
+               accept-language: '{{accept-language}}'
+             uri: '{{options.host}}/{domain}/v1/page/metadata/{title}'
+           return:
+             status: 200
+             headers: '{{ merge({"cache-control": options.response_cache_control}, get_from_pcs.headers) }}'
+             body: '{{get_from_pcs.body}}'
 
   /metadata/{title}/{revision}:
     x-route-filters:
@@ -138,8 +121,18 @@ paths:
             To get a 200 response instead, supply `false` to the `redirect` parameter.
           schema:
             type: boolean
-      operationId: getContentWithRevision-metadata
-      x-monitor: false
+      x-request-handler:
+        - get_from_pcs:
+           request:
+             method: get
+             headers:
+               cache-control: '{{cache-control}}'
+               accept-language: '{{accept-language}}'
+             uri: '{{options.host}}/{domain}/v1/page/metadata/{title}/{revision}'
+           return:
+             status: 200
+             headers: '{{ merge({"cache-control": options.response_cache_control}, get_from_pcs.headers) }}'
+             body: '{{get_from_pcs.body}}'
 
 components:
   schemas:


### PR DESCRIPTION
We will not be pre-generating content for it any more, so bypass the
storage and always hit PCS directly.

Bug: [T235173](https://phabricator.wikimedia.org/T235173)