### PR TITLE
Parsoid: Stash: Honour our own ETag when retrieving the stash

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -596,8 +596,24 @@ class ParsoidService {
             contentPromise = P.resolve(undefined);
         } else {
             if (etag && etag.suffix === 'stash' && from === 'html' && to === 'wikitext') {
+                // T235465: RB should trust its own ETag over the client-supplied revision, but
+                // allow for the client to be right, so provide their revision as a fall-back
+                const revMismatch = etag.rev !== rp.revision;
+                if (revMismatch) {
+                    // the ETag and URI parameter do not agree, log this (for now?)
+                    hyper.logger.log('warn/parsoid/etag_rev', {
+                        msg: 'The revisions in If-Match and URI differ'
+                    });
+                }
                 contentPromise = this._getStashedContent(hyper, rp.domain,
-                    rp.title, rp.revision, tid);
+                    rp.title, etag.rev, etag.tid)
+                .catch({ status: 404 }, (e) => {
+                    if (!revMismatch) {
+                        // the revisions match, so this is a genuine 404
+                        throw e;
+                    }
+                    return this._getStashedContent(hyper, rp.domain, rp.title, rp.revision, tid);
+                });
             } else {
                 contentPromise = this._getOriginalContent(hyper, req, rp.revision, tid);
             }


### PR DESCRIPTION
If a client is switching between wikitext and HTML and in one of the two
transforms they fail to provide the revision in the URI, trust that the
ETag is correct and try to retrieve the stashed content using the
information in the ETag. As a fall-back, though, try with the
client-supplied revision as well.

Bug: [T235465](https://phabricator.wikimedia.org/T235465)