### PR TITLE
Only mirror no-cache requests to Parsoid-PHP and not store results.

### DIFF
--- a/lib/parsoid.js
+++ b/lib/parsoid.js
@@ -349,10 +349,21 @@ class ParsoidService {
 
     _getPageBundleFromParsoid(hyper, req) {
         const rp = req.params;
-        return hyper.get(this._getParsoidReq(
+        const parsoidReq = this._getParsoidReq(
             req,
             `page/pagebundle/${encodeURIComponent(rp.title)}/${rp.revision}`
-        ));
+        );
+        return hyper.get(parsoidReq)
+        // TEMP: Log requests that give 412 with all headers and everything.
+        .catch({ status: 412 }, (e) => {
+            hyper.logger.log('warn/parsoid/412', {
+                msg: '412 returned by Parsoid',
+                // serialize the request to avoid blowing up logstash
+                // if there's too much headers. We donno.
+                parsoid_req: JSON.stringify(parsoidReq)
+            });
+            throw e;
+        });
     }
 
     /**

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -186,10 +186,18 @@ class ParsoidProxy {
         // mirror mode works only for getFormat, since for mirroring
         // tranforms we would need to be sure we have the php output
         // stashed
-        if (this.mode === 'mirror' && !/transform/.test(operation)) {
+        if (this.mode === 'mirror' &&
+                !/transform/.test(operation) &&
+                mwUtil.isNoCacheRequest(req)) {
             if (Math.round(Math.random() * 100) <= this.percentage) {
                 // issue an async request to the second variant and
                 // don't wait for the return value
+                req = Object.assign({}, req);
+                req.headers = Object.assign({}, req.headers);
+                // It's already a no-cache request, we've checked.
+                // Don't store the Parsoid-PHP in mirror mode, we're only
+                // doing it for Parsoid load testing.
+                req.headers['cache-control'] = 'no-cache,no-store';
                 this._req(invert(variant), operation, hyper, req, false)
                 .catch((e) => hyper.logger.log(`info/parsoidproxy/${invert(variant)}`, e));
             }


### PR DESCRIPTION
Bug: https://phabricator.wikimedia.org/T236838

cc @subbuss 