### PR TITLE
Tests: Do not set `skip_resources: true` in config.frontend.test.yaml

### DIFF
--- a/config.frontend.test.yaml
+++ b/config.frontend.test.yaml
@@ -237,7 +237,6 @@ services:
       ui_name: REST API
       ui_url: https://www.mediawiki.org/wiki/RESTBase
       ui_title: REST API docs
-      skip_resources: true
 
 logging:
   name: restrouter


### PR DESCRIPTION
Setting it to `true` causes the `febe` tests to fail because the
back-end never receives any instructions on which buckets to create.