### PR TITLE
Remove duplicate filter definitions

### DIFF
--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -394,19 +394,7 @@ paths:
       x-monitor: false
 
   /html/{title}/{revision}:
-    x-route-filters: &html_title_revision_filters
-      - path: ./lib/access_check_filter.js
-        options:
-          redirect_cache_control: '{{options.response_cache_control}}'
-          attach_body_to_redirect: true
-      - path: lib/security_response_header_filter.js
-        options:
-          allowInlineStyles: true
-      - path: lib/content_negotiation_filter.js
     get: &html_title_revision_get_spec
-      x-route-filters:
-        - path: lib/ensure_content_type.js
-        - path: ./lib/language_variants_filter.js
       tags:
         - Page content
       summary: Get HTML for a specific title/revision & optionally timeuuid.
@@ -645,7 +633,7 @@ paths:
       x-monitor: false
 
   /lint/{title}:
-    x-route-filters: &lint_title_filters
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -721,8 +709,6 @@ paths:
       x-monitor: false
 
   /lint/{title}/{revision}:
-    x-route-filters:
-      <<: *lint_title_filters
     get:
       <<: *lint_title_get_spec
       parameters:

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -4,7 +4,7 @@ tags:
     description: mobile-friendly page content
 paths:
   /mobile-sections/{title}:
-    x-route-filters: &mobile-sections_title_filters
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -99,8 +99,6 @@ paths:
               remaining: /.+/
 
   /mobile-sections/{title}/{revision}:
-    x-route-filters:
-      <<: *mobile-sections_title_filters
     get:
       <<: *mobile-sections_title_get_spec
       parameters:
@@ -134,7 +132,7 @@ paths:
       x-monitor: false
 
   /mobile-sections-lead/{title}:
-    x-route-filters: &mobile-sections-lead_title_filters
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -214,8 +212,6 @@ paths:
       x-monitor: false
 
   /mobile-sections-lead/{title}/{revision}:
-    x-route-filters:
-      <<: *mobile-sections-lead_title_filters
     get:
       <<: *mobile-sections-lead_title_get_spec
       parameters:
@@ -249,7 +245,7 @@ paths:
       operationId: getSectionsLeadWithRevision
 
   /mobile-sections-remaining/{title}:
-    x-route-filters:  &mobile-sections-remaining_title_filters
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -330,8 +326,6 @@ paths:
       x-monitor: false
 
   /mobile-sections-remaining/{title}/{revision}:
-    x-route-filters:
-      <<: *mobile-sections-remaining_title_filters
     get:
       <<: *mobile-sections-remaining_title_get_spec
       parameters:

--- a/v1/pcs/media-list.yaml
+++ b/v1/pcs/media-list.yaml
@@ -12,7 +12,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /media-list/{title}:
-    x-route-filters: &media_list_title_filters
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -105,7 +105,6 @@ paths:
                   showInGallery: /.+/
 
   /media-list/{title}/{revision}:
-    x-route-filters: *media_list_title_filters
     get:
       <<: *media_list_title_get_spec
       parameters:

--- a/v1/pcs/media.yaml
+++ b/v1/pcs/media.yaml
@@ -12,7 +12,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /media/{title}:
-    x-route-filters: &media_title_filters
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -97,8 +97,6 @@ paths:
       x-monitor: false
 
   /media/{title}/{revision}:
-    x-route-filters:
-      <<: *media_title_filters
     get:
       <<: *media_title_get_spec
       parameters:

--- a/v1/pcs/metadata.yaml
+++ b/v1/pcs/metadata.yaml
@@ -12,7 +12,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /metadata/{title}:
-    x-route-filters: &metadata_title_filters
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -96,8 +96,6 @@ paths:
              body: '{{get_from_pcs.body}}'
 
   /metadata/{title}/{revision}:
-    x-route-filters:
-      <<: *metadata_title_filters
     get:
       <<: *metadata_title_get_spec
       parameters:

--- a/v1/pcs/mobile-html.yaml
+++ b/v1/pcs/mobile-html.yaml
@@ -12,7 +12,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /mobile-html/{title}:
-    x-route-filters: &mobile-html_title_revision_filter
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -127,8 +127,6 @@ paths:
             body: /^<!DOCTYPE html>.*/
 
   /mobile-html/{title}/{revision}:
-    x-route-filters:
-      <<: *mobile-html_title_revision_filter
     get:
       <<: *mobile-html_title_revision_get_spec
       parameters:

--- a/v1/pcs/references.yaml
+++ b/v1/pcs/references.yaml
@@ -12,7 +12,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /references/{title}:
-    x-route-filters: &references_title_filters
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -107,8 +107,6 @@ paths:
               references_by_id: /.+/
 
   /references/{title}/{revision}:
-    x-route-filters:
-      <<: *references_title_filters
     get:
       <<: *references_title_get_spec
       parameters:

--- a/v1/pdf.yaml
+++ b/v1/pdf.yaml
@@ -13,7 +13,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /pdf/{title}:
-    x-route-filters: &pdf_get_title_filters
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.cache_control}}'
@@ -96,8 +96,6 @@ paths:
       x-monitor: false # PDF generation is expensive and it's not stored, so don't run checker script
 
   /pdf/{title}/{format}:
-    x-route-filters:
-      <<: *pdf_get_title_filters
     get:
       <<: *pdf_get_title_spec
       parameters:
@@ -140,8 +138,6 @@ paths:
       x-monitor: false # PDF generation is expensive and it's not stored, so don't run checker script
 
   /pdf/{title}/{format}/{type}:
-    x-route-filters:
-      <<: *pdf_get_title_filters
     get:
       <<: *pdf_get_title_spec
       parameters:

--- a/v1/talk.yaml
+++ b/v1/talk.yaml
@@ -12,7 +12,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /talk/{title}:
-    x-route-filters: &talk_title_revision_filter
+    x-route-filters:
       - path: ./lib/access_check_filter.js
         options:
           redirect_cache_control: '{{options.response_cache_control}}'
@@ -114,8 +114,6 @@ paths:
                     indicator: /.+/
 
   /talk/{title}/{revision}:
-    x-route-filters:
-      <<: *talk_title_revision_filter
     get:
       <<: *talk_title_revision_get_spec
       parameters:


### PR DESCRIPTION
When hyperswitch loads a route, it automatically assigns it the filters
loaded for its hierarchical parent. This can cause problems in cases
where the filter is not idempotent, as is the case of the language
variant filter which performs an extra action (calling Parsoid for
conversion); we then end up chaining the action twice, each using the
result of the previous one.

Bug: [T234266](https://phabricator.wikimedia.org/T234266)