### PR TITLE
TEMP: Route all linter requests to Parsoid/JS

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -189,6 +189,11 @@ class ParsoidProxy {
             // the variant has been set explicitly by the client, honour it
             return this._req(variant, operation, hyper, req, true, true);
         }
+        // TEMP: All linter requests go only to JS
+        if (/Lint/.test(operation)) {
+            return this._req('js', operation, hyper, req, false, true);
+        }
+        // END TEMP
         // we can safely check simply where to direct the request
         // using splitRegex because it won't match anything for any
         // mode other than split


### PR DESCRIPTION
Parsoid/PHP currently does not handle writing to MySQL, so route all linter requests to Parsoid/JS.

This commit must be reverted once Parsoid/PHP is ready to handle linting requests.

Bug: [T229015](https://phabricator.wikimedia.org/T229015)