### PR TITLE
Update the random title endpoint to use wikifeeds

### DIFF
--- a/projects/v1/default.wmf.yaml
+++ b/projects/v1/default.wmf.yaml
@@ -69,7 +69,7 @@ paths:
       - path: v1/related.js
         options: '{{options.related}}'
       - path: v1/random.yaml
-        options: '{{merge({"random_cache_control": "s-maxage=2, max-age=1"}, options.mobileapps)}}'
+        options: '{{merge({"random_cache_control": "s-maxage=2, max-age=1"}, options.wikifeeds)}}'
       - path: v1/pdf.js
         options: '{{options.pdf}}'
       - path: v1/common_schemas.yaml # Doesn't really matter where to mount it.

--- a/projects/v1/wikidata.wmf.yaml
+++ b/projects/v1/wikidata.wmf.yaml
@@ -64,7 +64,7 @@ paths:
       - path: v1/graphoid.yaml
         options: '{{options.graphoid}}'
       - path: v1/random.yaml
-        options: '{{merge({"random_cache_control": "s-maxage=2, max-age=1"}, options.mobileapps)}}'
+        options: '{{merge({"random_cache_control": "s-maxage=2, max-age=1"}, options.wikifeeds)}}'
       - path: v1/common_schemas.yaml # Doesn't really matter where to mount it.
   /transform:
     x-modules:

--- a/projects/v1/wikipedia.wmf.yaml
+++ b/projects/v1/wikipedia.wmf.yaml
@@ -96,7 +96,7 @@ paths:
         options: '{{options.related}}'
       - path: v1/random.yaml
         options: '{{merge({"random_cache_control": "s-maxage=2, max-age=1"},
-                      options.mobileapps)}}'
+                      options.wikifeeds)}}'
       - path: v1/talk.yaml
         options:
           host: '{{options.mobileapps.host}}'

--- a/projects/v1/wikivoyage.wmf.yaml
+++ b/projects/v1/wikivoyage.wmf.yaml
@@ -99,7 +99,7 @@ paths:
         options: '{{options.related}}'
       - path: v1/random.yaml
         options: '{{merge({"random_cache_control": "s-maxage=2, max-age=1"},
-                      options.mobileapps)}}'
+                      options.wikifeeds)}}'
       - path: v1/pdf.js
         options: '{{options.pdf}}'
       - path: v1/common_schemas.yaml # Doesn't really matter where to mount it.

--- a/test/features/pcs.js
+++ b/test/features/pcs.js
@@ -85,7 +85,8 @@ describe('Page Content Service: transforms', () => {
         return preq.post({
             uri: `${server.config.baseURL()}/transform/wikitext/to/mobile-html/Main_Page`,
             body: {
-                wikitext: '== Heading =='
+                wikitext: `== Heading ==
+                hello world`
             }
         })
         .then((res) => {

--- a/v1/random.yaml
+++ b/v1/random.yaml
@@ -27,7 +27,7 @@ paths:
         303:
           description: The redirect to the desired format URI for a random page
           content:
-            application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Random/0.6.0":
+            application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Random/0.7.0":
               schema:
                 type: object
         default:


### PR DESCRIPTION
The wikifeeds service has been updated to serve the /page/random/title
endpoint, which is consumed by the apps for the Explore feed. This
updates RESTBase to obtain it from wikifeeds. After this change is live,
the random page code will be removed from mobileapps.