### PR TITLE
Fix broken test for transform/wikitext/to/mobile-html

### DIFF
--- a/test/features/pcs.js
+++ b/test/features/pcs.js
@@ -85,7 +85,8 @@ describe('Page Content Service: transforms', () => {
         return preq.post({
             uri: `${server.config.baseURL()}/transform/wikitext/to/mobile-html/Main_Page`,
             body: {
-                wikitext: '== Heading =='
+                wikitext: `== Heading ==
+                hello world`
             }
         })
         .then((res) => {


### PR DESCRIPTION
This test was broken by a change to mobileapps to more aggressively
strip empty sections in mobile-html. Some section body text is added to
the input to fix it.