### PR TITLE
Hygiene: replace names Reading Infrastructure with Product Infrastructure

### DIFF
--- a/v1/availability.yaml
+++ b/v1/availability.yaml
@@ -6,8 +6,8 @@ info:
     by wiki language
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/v1/css.yaml
+++ b/v1/css.yaml
@@ -5,8 +5,8 @@ info:
   description: API for retrieving CSS for mobile apps
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/v1/javascript.yaml
+++ b/v1/javascript.yaml
@@ -5,8 +5,8 @@ info:
   description: API for retrieving JavaScript for mobile apps
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/v1/lists.yaml
+++ b/v1/lists.yaml
@@ -5,8 +5,8 @@ info:
   description: API for manipulating private [reading lists](https://www.mediawiki.org/wiki/Reading/Reading_Lists)
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/v1/pcs/media-list.yaml
+++ b/v1/pcs/media-list.yaml
@@ -5,8 +5,8 @@ info:
   description: API for retrieving data about media items appearing on a given page
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/v1/pcs/media.yaml
+++ b/v1/pcs/media.yaml
@@ -5,8 +5,8 @@ info:
   description: API for retrieving data about media items appearing on a given page
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/v1/pcs/metadata.yaml
+++ b/v1/pcs/metadata.yaml
@@ -5,8 +5,8 @@ info:
   description: API for retrieving additional metadata of a given page
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/v1/pcs/mobile-html.yaml
+++ b/v1/pcs/mobile-html.yaml
@@ -5,8 +5,8 @@ info:
   description: API for retrieving page content for reading purposes
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/v1/pcs/references.yaml
+++ b/v1/pcs/references.yaml
@@ -5,8 +5,8 @@ info:
   description: API for retrieving references of a given page
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/v1/pcs/transform.yaml
+++ b/v1/pcs/transform.yaml
@@ -5,8 +5,8 @@ info:
   description: API for retrieving page content for reading purposes
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/v1/talk.yaml
+++ b/v1/talk.yaml
@@ -5,8 +5,8 @@ info:
   description: API for retrieving structured representation of the talk page
   termsOfService: https://www.mediawiki.org/wiki/REST_API#Terms_and_conditions
   contact:
-    name: Reading Infrastructure
-    url: https://www.mediawiki.org/wiki/Wikimedia_Reading_Infrastructure_team
+    name: Product Infrastructure
+    url: https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team
   license:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
The Reading Infrastructure team is now called Product Infrastructure team.