### PR TITLE
Add ensure_content_type filter to mobile-html and mobile-html-offline-resources

### DIFF
--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -82,7 +82,7 @@ module.exports = (hyper, req, next, options, specInfo) => {
     const responseCodes = responses && Object.keys(responses);
     let defaultContentType;
     const validContentTypes = new Set();
-    responseCodes.forEach(code => {
+    responseCodes.forEach((code) => {
         const response = responses[code];
         if (!response) {
             return;
@@ -92,7 +92,7 @@ module.exports = (hyper, req, next, options, specInfo) => {
             return;
         }
         const contentTypesForResponseCode = Object.keys(contents);
-        contentTypesForResponseCode.forEach(contentType => {
+        contentTypesForResponseCode.forEach((contentType) => {
             defaultContentType = defaultContentType || contentType;
             validContentTypes.add(contentType);
         });

--- a/lib/ensure_content_type.js
+++ b/lib/ensure_content_type.js
@@ -78,18 +78,34 @@ function checkContentType(hyper, req, next, expectedContentType, responsePromise
 }
 
 module.exports = (hyper, req, next, options, specInfo) => {
-    const produces = specInfo.spec.produces;
+    const responses = specInfo.spec.responses;
+    const responseCodes = responses && Object.keys(responses);
+    let defaultContentType;
+    const validContentTypes = new Set();
+    responseCodes.forEach(code => {
+        const response = responses[code];
+        if (!response) {
+            return;
+        }
+        const contents = response.content;
+        if (!contents) {
+            return;
+        }
+        const contentTypesForResponseCode = Object.keys(contents);
+        contentTypesForResponseCode.forEach(contentType => {
+            defaultContentType = defaultContentType || contentType;
+            validContentTypes.add(contentType);
+        });
+    });
     return next(hyper, req)
     .then((res) => {
+        const contentType = res.headers && res.headers['content-type'];
         // Most likely it's application/json for sections,
         // check if it exactly matches one of the list
-        if (Array.isArray(produces) &&
-            produces.some((expected) =>
-                res.headers && res.headers['content-type'] === expected)) {
+        if (contentType && validContentTypes.has(contentType)) {
             return res;
         } else {
-            const expectedContentType = options.expected ||
-                (Array.isArray(produces) && produces[0]);
+            const expectedContentType = options.expected || defaultContentType;
             if (expectedContentType) {
                 // Found a content type. Ensure that we return the latest profile.
                 return checkContentType(hyper, req, next, expectedContentType, P.resolve(res));

--- a/v1/pcs/mobile-html-offline-resources.yaml
+++ b/v1/pcs/mobile-html-offline-resources.yaml
@@ -12,6 +12,8 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
   /mobile-html-offline-resources/{title}:
+    x-route-filters:
+      - path: lib/ensure_content_type.js
     get: &mobile-html-offline-resources_title_revision_get_spec
       tags:
         - Page content
@@ -29,7 +31,7 @@ paths:
         200:
           description: links to scripts and styles to accompany the mobile-html of the page for offline consumption
           content:
-            application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Mobile-HTML-Offline-Resources/1.0.0":
+            application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Mobile-HTML-Offline-Resources/1.2.0":
               schema:
                 type: string
         default:

--- a/v1/pcs/mobile-html.yaml
+++ b/v1/pcs/mobile-html.yaml
@@ -20,6 +20,7 @@ paths:
         options:
           mobile_html: true
       - path: lib/language_variants_filter.js
+      - path: lib/ensure_content_type.js
     get: &mobile-html_title_revision_get_spec
       tags:
         - Page content
@@ -80,7 +81,7 @@ paths:
               schema:
                 type: string
           content:
-            text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Mobile-HTML/1.0.0":
+            text/html; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Mobile-HTML/1.2.0":
               schema:
                 type: string
         301:


### PR DESCRIPTION
Added the `ensure_content_type` filter to `mobile-html` and `mobile-html-offline-resources`. It looks like the spec format had changed, so I updated the filter itself to work with the new format. Let me know if I missed something or if those changes were unnecessary.

https://phabricator.wikimedia.org/T247295

