### PR TITLE
Deprecate PCS /page/media and /page/metadata endpoints

### DIFF
--- a/v1/pcs/media.yaml
+++ b/v1/pcs/media.yaml
@@ -25,7 +25,7 @@ paths:
         Gets detailed information on the media items (images, audio, and video) in the order in which they appear on a
         given wiki page.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [deprecated](https://www.mediawiki.org/wiki/API_versioning#Deprecated)
       parameters:
         - name: title
           in: path

--- a/v1/pcs/metadata.yaml
+++ b/v1/pcs/metadata.yaml
@@ -25,7 +25,7 @@ paths:
       description: |
         Gets metadata of a page that's not already covered by the summary endpoint.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [deprecated](https://www.mediawiki.org/wiki/API_versioning#Deprecated)
       parameters:
         - name: title
           in: path


### PR DESCRIPTION
These endpoints are unused by Wikimedia clients and should be dropped in the near future.