### PR TITLE
For mobile-html always use the configured CSP

### DIFF
--- a/lib/security_response_header_filter.js
+++ b/lib/security_response_header_filter.js
@@ -88,17 +88,21 @@ module.exports = function addCSPHeaders(hyper, req, next, options) {
 
         let csp;
         if (isHtmlSvgContent(res)) {
-            // Let backend services override CSP headers for HTML / SVG
-            // XXX: Re-consider this policy
-            if (rh['content-security-policy']) {
-                csp = rh['content-security-policy'];
-            } else if (options.mobile_html) {
+            if (options.mobile_html) {
                 // TODO: This is a copy-paste from MCS. T229016
                 // In future we would want MCS to manage it's storage,
                 // but currently we can not store special CSP as changing them would require
                 // truncating all the stored content. So we have no option other then
                 // setting them explicitly in RESTBase code.
-                csp = MOBILE_HTML_CSP;
+                if (hyper.config.mobile_html_csp) {
+                    csp = hyper.config.mobile_html_csp;
+                } else {
+                    csp = MOBILE_HTML_CSP;
+                }
+            } else if (rh['content-security-policy']) {
+                // Let backend services override CSP headers for HTML / SVG
+                // XXX: Re-consider this policy
+                csp = rh['content-security-policy'];
             } else {
                 // Our main production clients will ignore CSP anyway (by loading via
                 // XHR or fetch), so we need to sanitize our HTML assuming that no


### PR DESCRIPTION
Check first for mobile_html instead of accepting backend CSP.
Also allow overrides from config file.