### PR TITLE
Update MCS/PCS endpoint stability designations

### DIFF
--- a/v1/css.yaml
+++ b/v1/css.yaml
@@ -25,7 +25,7 @@ paths:
         * site (Site-specific, mobile CSS from ResourceLoader, as defined in MediaWiki\:Mobile.css)
         * pcs (CSS for the Page Content Service)
 
-        The first two are the same regardless of what domain is used.
+        The `base` and `pcs` responses are the same regardless of what domain is used.
         For these we suggest meta.wikimedia.org.
 
         You can still pass pagelib for type, but this is a legacy version of the CSS for

--- a/v1/css.yaml
+++ b/v1/css.yaml
@@ -32,6 +32,8 @@ paths:
         existing app clients.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
         - name: type
           in: path

--- a/v1/css.yaml
+++ b/v1/css.yaml
@@ -33,7 +33,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
-        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api-announce](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce) for announcements of breaking changes.
       parameters:
         - name: type
           in: path

--- a/v1/css.yaml
+++ b/v1/css.yaml
@@ -31,7 +31,7 @@ paths:
         You can still pass pagelib for type, but this is a legacy version of the CSS for
         existing app clients.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
         Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:

--- a/v1/css.yaml
+++ b/v1/css.yaml
@@ -28,10 +28,10 @@ paths:
         The first two are the same regardless of what domain is used.
         For these we suggest meta.wikimedia.org.
 
-        You can still pass pagelib for type, but this is a legacy version of the CSS for 
+        You can still pass pagelib for type, but this is a legacy version of the CSS for
         existing app clients.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       parameters:
         - name: type
           in: path

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -31,6 +31,8 @@ paths:
         for background and considerations for further development.
 
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
         - name: term
           in: path

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -32,7 +32,7 @@ paths:
 
         Stability: [stable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Stable)
 
-        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api-announce](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce) for announcements of breaking changes.
       parameters:
         - name: term
           in: path

--- a/v1/definition.yaml
+++ b/v1/definition.yaml
@@ -30,7 +30,7 @@ paths:
         page](https://www.mediawiki.org/wiki/Wikimedia_Apps/Wiktionary_definition_popups_in_the_Android_Wikipedia_Beta_app)
         for background and considerations for further development.
 
-        Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+        Stability: [stable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Stable)
 
         Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:

--- a/v1/javascript.yaml
+++ b/v1/javascript.yaml
@@ -31,6 +31,8 @@ paths:
         of the wikimedia-page-library JavaScript to support existing app clients.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
         - name: type
           in: path

--- a/v1/javascript.yaml
+++ b/v1/javascript.yaml
@@ -32,7 +32,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
-        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api-announce](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce) for announcements of breaking changes.
       parameters:
         - name: type
           in: path

--- a/v1/javascript.yaml
+++ b/v1/javascript.yaml
@@ -30,7 +30,7 @@ paths:
         Page Content Service. Passing pagelib will return a deprecated legacy version
         of the wikimedia-page-library JavaScript to support existing app clients.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
         Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:

--- a/v1/javascript.yaml
+++ b/v1/javascript.yaml
@@ -26,11 +26,11 @@ paths:
         * has code to lazy load images on the page,
         * code for collapsing and expanding tables.
 
-        Valid types are pagelib or pcs. Passing pcs will return the JavaScript for the 
+        Valid types are pagelib or pcs. Passing pcs will return the JavaScript for the
         Page Content Service. Passing pagelib will return a deprecated legacy version
         of the wikimedia-page-library JavaScript to support existing app clients.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       parameters:
         - name: type
           in: path

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -18,7 +18,7 @@ paths:
         Retrieve the latest HTML for a page title optimised for viewing with
         native mobile applications. Note that the output is split by sections.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
         Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
@@ -147,7 +147,7 @@ paths:
         Retrieve the lead section of the latest HTML for a page title optimised
         for viewing with native mobile applications.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
         Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
@@ -263,7 +263,7 @@ paths:
         a page title optimised for viewing with native mobile applications,
         provided as a JSON object containing the sections.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
         Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -20,7 +20,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
-        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api-announce](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce) for announcements of breaking changes.
       parameters:
         - name: title
           in: path
@@ -149,7 +149,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
-        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api-announce](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce) for announcements of breaking changes.
       parameters:
         - name: title
           in: path
@@ -265,7 +265,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
-        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api-announce](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce) for announcements of breaking changes.
       parameters:
         - name: title
           in: path

--- a/v1/mobileapps.yaml
+++ b/v1/mobileapps.yaml
@@ -19,6 +19,8 @@ paths:
         native mobile applications. Note that the output is split by sections.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
         - name: title
           in: path
@@ -146,6 +148,8 @@ paths:
         for viewing with native mobile applications.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
         - name: title
           in: path
@@ -260,6 +264,8 @@ paths:
         provided as a JSON object containing the sections.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
         - name: title
           in: path

--- a/v1/pcs/media-list.yaml
+++ b/v1/pcs/media-list.yaml
@@ -28,7 +28,7 @@ paths:
 
         Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
-        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api-announce](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce) for announcements of breaking changes.
       parameters:
         - name: title
           in: path

--- a/v1/pcs/media-list.yaml
+++ b/v1/pcs/media-list.yaml
@@ -26,7 +26,7 @@ paths:
         Gets the list of media items (images, audio, and video) in the order in which they appear on a
         given wiki page.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
       parameters:
         - name: title
           in: path

--- a/v1/pcs/media-list.yaml
+++ b/v1/pcs/media-list.yaml
@@ -27,6 +27,8 @@ paths:
         given wiki page.
 
         Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
         - name: title
           in: path

--- a/v1/pcs/media-list.yaml
+++ b/v1/pcs/media-list.yaml
@@ -26,7 +26,7 @@ paths:
         Gets the list of media items (images, audio, and video) in the order in which they appear on a
         given wiki page.
 
-        Stability: [unstable](https://www.mediawiki.org/wiki/API_versioning#Unstable)
+        Stability: [unstable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Unstable)
 
         Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:

--- a/v1/pcs/mobile-html-offline-resources.yaml
+++ b/v1/pcs/mobile-html-offline-resources.yaml
@@ -19,7 +19,10 @@ paths:
         - Page content
         - offline
       summary: Get styles and scripts for offline consumption of mobile-html-formatted pages
-      description: Provides links to scripts and styles needed for viewing mobile-html-formatted pages offline
+      description: |
+        Provides links to scripts and styles needed for viewing mobile-html-formatted pages offline.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       parameters:
         - name: title
           in: path

--- a/v1/pcs/transform.yaml
+++ b/v1/pcs/transform.yaml
@@ -24,6 +24,8 @@ paths:
 
         - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
         - Rate limit: 25 req/s (5 req/s when `stash: true`)
+
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
         - name: title
           in: path

--- a/v1/pcs/transform.yaml
+++ b/v1/pcs/transform.yaml
@@ -22,7 +22,7 @@ paths:
       description: |
         Transform wikitext to Mobile HTML.
 
-        - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+        - Stability: [stable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Stable)
         - Rate limit: 25 req/s (5 req/s when `stash: true`)
 
         Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.

--- a/v1/pcs/transform.yaml
+++ b/v1/pcs/transform.yaml
@@ -25,7 +25,7 @@ paths:
         - Stability: [stable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Stable)
         - Rate limit: 25 req/s (5 req/s when `stash: true`)
 
-        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api-announce](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce) for announcements of breaking changes.
       parameters:
         - name: title
           in: path

--- a/v1/summary_new.yaml
+++ b/v1/summary_new.yaml
@@ -28,7 +28,7 @@ paths:
         sentences, as well as information about a thumbnail that represents
         the page.
 
-        Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+        Stability: [stable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Stable)
 
         Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:

--- a/v1/summary_new.yaml
+++ b/v1/summary_new.yaml
@@ -30,7 +30,7 @@ paths:
 
         Stability: [stable](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Stable)
 
-        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api-announce](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce) for announcements of breaking changes.
       parameters:
         - name: title
           in: path

--- a/v1/summary_new.yaml
+++ b/v1/summary_new.yaml
@@ -29,6 +29,8 @@ paths:
         the page.
 
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+
+        Please follow [wikitech-l](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) or [mediawiki-api](https://lists.wikimedia.org/mailman/listinfo/mediawiki-api) for announcements of breaking changes.
       parameters:
         - name: title
           in: path

--- a/v1/talk.yaml
+++ b/v1/talk.yaml
@@ -24,7 +24,7 @@ paths:
       description: |
         Gets structured talk page contents for the provided title.
 
-        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+        Stability: [experimental](https://www.mediawiki.org/wiki/Wikimedia_Product/Wikimedia_Product_Infrastructure_team/API_endpoint_stability_policy#Experimental)
       parameters:
         - name: title
           in: path

--- a/v1/talk.yaml
+++ b/v1/talk.yaml
@@ -21,7 +21,10 @@ paths:
       tags:
         - Talk pages
       summary: Get structured talk page contents
-      description: Gets structured talk page contents for the provided title.
+      description: |
+        Gets structured talk page contents for the provided title.
+
+        Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
       parameters:
         - name: title
           in: path


### PR DESCRIPTION
* Bump css, javascript, and media-list to unstable
* Add experimental designation to mobile-html-offline-resources and talk, which had no stability designation

Phab: https://phabricator.wikimedia.org/T250505