### PR TITLE
Propagate header downstream to Page Content Services, and add tests

### DIFF
--- a/test/features/pcs.js
+++ b/test/features/pcs.js
@@ -46,6 +46,9 @@ describe('Page Content Service: transforms', () => {
     it('should transform wikitext to mobile-html', () => {
         return preq.post({
             uri: `${server.config.baseURL()}/transform/wikitext/to/mobile-html/Main_Page`,
+            headers: {
+                'output-mode': 'contentAndReferences'
+            },
             body: {
                 wikitext: `== Heading ==
                 hello world`
@@ -56,6 +59,25 @@ describe('Page Content Service: transforms', () => {
             assert.deepEqual(res.headers['content-language'], 'en');
             assert.checkString(res.headers['cache-control'], /private/, 'Must not be cached');
             assert.checkString(res.body, /<h2 id="Heading" class="(:?[^"]+)">Heading<\/h2>/);
+            assert.checkString(res.body, /pcs-edit-section-link-container/);
+        })
+    });
+
+    it('should transform wikitext to mobile-html, propagating output flags', () => {
+        return preq.post({
+            uri: `${server.config.baseURL()}/transform/wikitext/to/mobile-html/Main_Page`,
+            headers: {
+                'output-mode': 'editPreview'
+            },
+            body: {
+                wikitext: `== Heading ==
+                hello world`
+            }
+        })
+        .then((res) => {
+            assert.deepEqual(res.status, 200);
+            assert.deepEqual(res.headers['content-language'], 'en');
+            assert.deepEqual(/pcs-edit-section-link-container/.test(res.body), false);
         })
     });
 

--- a/v1/pcs/transform.js
+++ b/v1/pcs/transform.js
@@ -29,7 +29,8 @@ class TransformService {
                 uri: new URI(`${this._options.mobileapps_host}/${rp.domain}` +
                     `/v1/transform/html/to/mobile-html/${rp.title}`),
                 headers: {
-                    'content-type': res.headers['content-type']
+                    'content-type': res.headers['content-type'],
+                    'output-mode': req.headers['output-mode']
                 },
                 body: res.body
             })

--- a/v1/pcs/transform.yaml
+++ b/v1/pcs/transform.yaml
@@ -37,6 +37,13 @@ paths:
             The desired language variant code for wikis where LanguageConverter is enabled. Example: `sr-el` for Latin transcription of the Serbian language.
           schema:
             type: string
+        - name: output-mode
+          in: header
+          description: |
+            Output mode for mobile-html. Valid options: `contentAndReferences` (default), `content`, `references`, `editPreview`.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           multipart/form-data:


### PR DESCRIPTION
Page Content Services recently added a new header argument for `/transform/html/to/mobile-html` in [this patch](https://gerrit.wikimedia.org/r/c/mediawiki/services/mobileapps/+/594294) and improved in [this patch](https://gerrit.wikimedia.org/r/c/mediawiki/services/mobileapps/+/596284). Since restbase's `/transform/wikitext/to/mobile-html` stitches together `/transform/wikitext/to/html` and `/transform/html/to/mobile-html`, we need restbase's `wikitext-to-mobilehtml` to propagate this new header.

I also added tests for this header.

This is my first PR for restbase, so please let me know if I should write/do anything for the PR differently. Thanks!

(Please note - The YAML description claims that `contentAndReferences` is default, which will be accurate... very soon. Temporarily, PCS defaults to `editPreview`, so that a current feature works as expected prior to this PR being merged and deployed in restbase. After this is merged and deployed, we're going to go back in this [Phab ticket](https://phabricator.wikimedia.org/T252921) to update the default to `contentAndReferences`, as explained in that description.)