### PR TITLE
summary: mark title, displaytitle summary response fields deprecated

### DIFF
--- a/v1/common_schemas.yaml
+++ b/v1/common_schemas.yaml
@@ -57,11 +57,17 @@ components:
       type: object
       properties:
         title:
+          deprecated: true
           type: string
-          description: The page title
+          description: |
+            The page title.
+            Deprecated: Use `titles.normalized` instead.
         displaytitle:
+          deprecated: true
           type: string
-          description: The page title how it should be shown to the user
+          description: |
+            The page title how it should be shown to the user.
+            Deprecated: Use `titles.display` instead.
         pageid:
           type: integer
           description: The page ID

--- a/v1/summary_new.yaml
+++ b/v1/summary_new.yaml
@@ -59,7 +59,7 @@ paths:
               schema:
                 type: string
           content:
-            application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.3.7":
+            application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Summary/1.4.2":
               schema:
                 $ref: '#/components/schemas/summary'
         301:

--- a/v1/summary_new.yaml
+++ b/v1/summary_new.yaml
@@ -22,11 +22,11 @@ paths:
     get:
       tags:
         - Page content
-      summary: Get a text extract & thumb summary of a page.
+      summary: Get basic metadata and simplified article introduction.
       description: |
-        The summary response includes a text extract of the first several
-        sentences, as well as information about a thumbnail that represents
-        the page.
+        The summary response includes an extract of the first paragraph of the page in plain text
+        and HTML as well as the type of page. This is useful for page previews (fka. Hovercards,
+        aka. Popups) on the web and link previews in the apps.
 
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
       parameters:


### PR DESCRIPTION
I mainly wanted to mark api_urls as deprecated but that field has not even been described in RESTBase.

Depends on #1262.

Bug: https://phabricator.wikimedia.org/T251959