### PR TITLE
Downgrade uuid package to 7.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
       # With a huge matrix that we have it's better to rerun failed jobs.
       fail-fast: false
       matrix:
-        node-version: [6.x, 10.x, 12.x]
+        node-version: [6.11, 10.x, 12.x]
         cassandra-version: [3.11.4]
         test-target: [sqlite, cassandra]
         test-mode: [fs, fefs, febe]

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "restbase-mod-table-cassandra": "^1.2.1",
     "semver": "^7.3.2",
     "service-runner": "^2.7.8",
-    "uuid": "^8.1.0"
+    "uuid": "^7.0.3"
   },
   "devDependencies": {
     "ajv": "^6.10.2",


### PR DESCRIPTION
We're running node 6.11 in production, and it seems like even though
uuid 8+ is compatible with node 6, it uses a function added in node 6.13.

Fixed CI to run the specific version run in production to catch mistakes
like this in future.