### PR TITLE
summary spec: add titles

### DIFF
--- a/v1/common_schemas.yaml
+++ b/v1/common_schemas.yaml
@@ -53,9 +53,29 @@ components:
         - source
         - width
 
+    titles_set:
+      type: object
+      description: a good example of the differences can be seen in https://en.wikipedia.org/api/rest_v1/page/summary/IOS_13
+      properties:
+        canonical:
+          type: string
+          description: the DB key (non-prefixed), e.g. may have _ instead of spaces, best for making request URIs, still requires Percent-encoding
+        normalized:
+          type: string
+          description: the normalized title (https://www.mediawiki.org/wiki/API:Query#Example_2:_Title_normalization), e.g. may have spaces instead of _
+        display:
+          type: string
+          description: the title as it should be displayed to the user
+      required:
+        - canonical
+        - normalized
+        - display
+
     summary:
       type: object
       properties:
+        titles:
+          $ref: '#/components/schemas/titles_set'
         title:
           deprecated: true
           type: string
@@ -119,7 +139,7 @@ components:
         - dir
         - extract
         - lang
-        - title
+        - titles
 
     cx_mt:
       type: object

--- a/v1/common_schemas.yaml
+++ b/v1/common_schemas.yaml
@@ -95,7 +95,7 @@ components:
           example: ltr
         timestamp:
           type: string
-          description: The time when the page was last editted in the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+          description: The time when the page was last edited in the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
             format
           example: 1970-01-01T00:00:00.000Z
         description:


### PR DESCRIPTION
We should add the `titles` property to the OAS documentation when referring to it in deprecation notices.