### PR TITLE
mobile-html-offline-resources: make 'title' parameter optional

### DIFF
--- a/v1/pcs/mobile-html-offline-resources.yaml
+++ b/v1/pcs/mobile-html-offline-resources.yaml
@@ -11,7 +11,7 @@ info:
     name: Apache licence, v2
     url: https://www.apache.org/licenses/LICENSE-2.0
 paths:
-  /mobile-html-offline-resources/{title}:
+  /mobile-html-offline-resources:
     x-route-filters:
       - path: lib/ensure_content_type.js
     get: &mobile-html-offline-resources_title_revision_get_spec
@@ -23,6 +23,41 @@ paths:
         Provides links to scripts and styles needed for viewing mobile-html-formatted pages offline.
 
         Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
+      responses:
+        200:
+          description: links to scripts and styles to accompany the mobile-html of the page for offline consumption
+          content:
+            application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Mobile-HTML-Offline-Resources/1.2.1":
+              schema:
+                type: string
+        default:
+          description: Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
+      x-request-handler:
+        - get-mobile-html-offline-resources:
+            request:
+              method: get
+              uri: '{{options.host}}/{domain}/v1/page/mobile-html-offline-resources'
+            return:
+              status: 200
+              headers: '{{get-mobile-html-offline-resources.headers}}'
+              body: '{{get-mobile-html-offline-resources.body}}'
+      x-monitor: true
+      x-amples:
+        - title: Get offline resource links to accompany page content HTML
+          response:
+            status: 200
+            headers:
+              content-type: /^application\/json.+/
+
+  /mobile-html-offline-resources/{title}:
+    x-route-filters:
+      - path: lib/ensure_content_type.js
+    get:
+      <<: *mobile-html-offline-resources_title_revision_get_spec
       parameters:
         - name: title
           in: path


### PR DESCRIPTION
The mobile-html-offline-resources endpoint accepts a required title and
optional revision and tid path parameters despite not using any of them.
This is undesirable from a caching perspective because it will result
in the same content being cached for many different URLs per wiki.

This change makes the title parameter optional so that we can encourage
clients to stop sending title parameters to improve the cache hit rate,
while continuing to support existing clients that send it.

This change depends on a corresponding change to mobileapps itself.
(https://gerrit.wikimedia.org/r/c/mediawiki/services/mobileapps/+/608730)

Bug: https://phabricator.wikimedia.org/T254490