### PR TITLE
Replace hardcoded domains in Mathoid APIs

### DIFF
--- a/sys/mathoid.js
+++ b/sys/mathoid.js
@@ -104,14 +104,14 @@ class MathoidService {
                         body: checkRes.body
                     }),
                     indirectionP,
-                    this._invalidateCache.bind(this, hyper, hash),
+                    this._invalidateCache.bind(this, hyper, req, hash),
                     () => checkRes
                 );
             }));
 
     }
 
-    _storeRenders(hyper, domain, hash, completeBody) {
+    _storeRenders(hyper, req, domain, hash, completeBody) {
         let idx;
         const len = FORMATS.length;
         const reqs = new Array(len);
@@ -152,7 +152,7 @@ class MathoidService {
         }
 
         // invalidate the cache
-        reqs.push(this._invalidateCache(hyper, hash));
+        reqs.push(this._invalidateCache(hyper, req, hash));
 
         // now do them all
         return P.all(reqs).then(() => completeBody);
@@ -169,7 +169,7 @@ class MathoidService {
             headers: { 'content-type': 'application/json' },
             body: req.body
         }).then((res) => // now store all of the renders
-            this._storeRenders(hyper, rp.domain, hash, res.body)).then((res) => {
+            this._storeRenders(hyper, req, rp.domain, hash, res.body)).then((res) => {
             // and return a proper response
             const ret = res[rp.format];
             ret.status = 200;
@@ -179,26 +179,30 @@ class MathoidService {
 
     }
 
-    _invalidateCache(hyper, hash) {
+    _invalidateCache(hyper, req, hash) {
 
         const routes = [];
-        const uri = '//wikimedia.org/api/rest_v1/media/math/';
 
-        routes.push(`${uri}formula/${hash}`);
+        return mwUtil.getSiteInfo(hyper, req)
+            .then((siteInfo) => {
+                const baseUri = siteInfo.baseUri.replace(/^https?:/, '');
+                const uri = `${baseUri}/api/rest_v1/media/math/`;
 
-        FORMATS.forEach((fmt) => {
-            routes.push(`${uri}render/${fmt}/${hash}`);
-        });
+                routes.push(`${uri}formula/${hash}`);
 
-        return hyper.post({
-            uri: new URI(['wikimedia.org', 'sys', 'events', '']),
-            body: routes.map((route) => ({
-                meta: { uri: route }
-            }))
-        }).catch((e) => {
-            hyper.logger.log('warn/bg-updates', e);
-        });
+                FORMATS.forEach((fmt) => {
+                    routes.push(`${uri}render/${fmt}/${hash}`);
+                });
 
+                return hyper.post({
+                    uri: new URI([this.options.host, 'sys', 'events', '']),
+                    body: routes.map((route) => ({
+                        meta: { uri: route }
+                    }))
+                }).catch((e) => {
+                    hyper.logger.log('warn/bg-updates', e);
+                });
+            });
     }
 
     getFormula(hyper, req) {

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -81,7 +81,7 @@ paths:
         - get_from_sys:
             request:
               method: post
-              uri: /wikimedia.org/sys/mathoid/check/{type}
+              uri: /{domain}/sys/mathoid/check/{type}
               headers: '{{ request.headers }}'
               body: '{{ request.body }}'
 
@@ -127,7 +127,7 @@ paths:
         - get_from_sys:
             request:
               method: get
-              uri: /wikimedia.org/sys/mathoid/formula/{hash}
+              uri: /{domain}/sys/mathoid/formula/{hash}
               headers: '{{ request.headers }}'
 
   /math/render/{format}/{hash}:
@@ -192,7 +192,7 @@ paths:
         - check_storage:
             request:
               method: get
-              uri: /wikimedia.org/sys/key_value/mathoid_ng.{format}/{hash}
+              uri: /{domain}/sys/key_value/mathoid_ng.{format}/{hash}
               headers:
                 cache-control: '{{ cache-control }}'
             catch:
@@ -205,11 +205,11 @@ paths:
               body: '{{ check_storage.body }}'
         - postdata:
             request:
-              uri: /wikimedia.org/sys/mathoid/formula/{request.params.hash}
+              uri: /{domain}/sys/mathoid/formula/{request.params.hash}
         - mathoid:
             request:
               method: post
-              uri: /wikimedia.org/sys/mathoid/render/{request.params.format}
+              uri: /{domain}/sys/mathoid/render/{request.params.format}
               headers:
                 content-type: application/json
                 x-resource-location: '{{ request.params.hash }}'


### PR DESCRIPTION
There are hardcoded domains and URI in Mathoid APIs, therefore a maintainer of a non-WMF wiki who wants to deploy Mathoid would replace those manually. [1] [2] [3]

Using the utils resolving domain and URI makes it easy to set RESTBase with Mathoid.

[1] https://phabricator.wikimedia.org/T154394#3356580
[2] https://www.mediawiki.org/w/index.php?title=Extension:Math/Restbase&oldid=4054010
[3] https://github.com/physikerwelt/mathoid-docs/blob/master/Guide%20for%20Installing%20and%20Setting%20up%20Mediawiki%20with%20Restbase%20and%20Mathoid.pdf