### PR TITLE
Fix typo in editors by country endpoint

### DIFF
--- a/v1/metrics.yaml
+++ b/v1/metrics.yaml
@@ -2973,7 +2973,7 @@ paths:
                 keepAlive: true
       x-monitor: false
 
-  /by-country/{project}/{activity-level}/{year}/{month}:
+  /editors/by-country/{project}/{activity-level}/{year}/{month}:
     get:
       tags:
         - Editors data


### PR DESCRIPTION
The route of the editors by country endpoint has a typo, and is returning:
TypeError: Cannot read property 'type' of undefined
This patch corrects the route to fix the error.