### PR TITLE
Replace preq with api-testing REST client

### DIFF
--- a/.api-testing.config.json
+++ b/.api-testing.config.json
@@ -1,0 +1,4 @@
+{
+    "base_uri": "",
+    "main_page": "Main_Page"
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "ajv": "^6.10.2",
+    "api-testing": "^1.3.0",
     "bunyan": "^1.8.12",
     "coveralls": "^3.1.0",
     "eslint": "^5.16.0",

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -3,6 +3,7 @@
 const assert = require('../../utils/assert.js');
 const Server = require('../../utils/server.js');
 const preq   = require('preq');
+const { REST } = require('api-testing');
 
 const testPage = {
     title: 'User:Pchelolo%2fRestbase_Test',
@@ -15,123 +16,108 @@ describe('transform api', function() {
     this.timeout(20000);
     let contentTypes;
     const server = new Server();
+    const client = new REST('');
     before(() => {
         return server.start()
         .then(() => {
             contentTypes = server.config.conf.test.content_types;
-            return preq.get({
-                uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}/html/${testPage.title}/${testPage.revision}`
-            });
+            return client.get(
+                `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}/html/${testPage.title}/${testPage.revision}`
+            );
         })
         .then((res) => {
-            testPage.html = res.body;
+            testPage.html = res.text;
         });
     });
     after(() => server.stop());
 
     it('wt2html', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html/${testPage.title}`,
-            body: {
-                wikitext: '== Heading =='
-            }
-        })
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html/${testPage.title}`,
+            { wikitext: '== Heading ==' }
+        )
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, contentTypes.html);
             const pattern = /<h2.*>Heading<\/h2>/;
-            if (!pattern.test(res.body)) {
-                throw new Error(`Expected pattern in response: ${pattern}\nSaw: ${res.body}`);
+            if (!pattern.test(res.text)) {
+                throw new Error(`Expected pattern in response: ${pattern}\nSaw: ${res.text}`);
             }
         });
     });
 
     it('wt2html, title-recision for a new page', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html/User:Pchelolo%2FRESTBaseTestPage_transform/393301`,
-            body: {
-                wikitext: '== Heading =='
-            }
-        })
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html/User:Pchelolo%2FRESTBaseTestPage_transform/393301`,
+            { wikitext: '== Heading ==' }
+        )
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, contentTypes.html);
             const pattern = /<h2.*>Heading<\/h2>/;
-            if (!pattern.test(res.body)) {
-                throw new Error(`Expected pattern in response: ${pattern}\nSaw: ${res.body}`);
+            if (!pattern.test(res.text)) {
+                throw new Error(`Expected pattern in response: ${pattern}\nSaw: ${res.text}`);
             }
         });
     });
 
     it('wt2html with body_only', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html/${testPage.title}`,
-            body: {
-                wikitext: '== Heading ==',
-                body_only: true
-            }
-        })
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html/${testPage.title}`,
+            { wikitext: '== Heading ==', body_only: true }
+        )
         .then((res) => {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, contentTypes.html);
             const pattern = /^<h2.*>Heading<\/h2>$/;
-            if (!pattern.test(res.body)) {
+            if (!pattern.test(res.text)) {
                 throw new Error(`Expected pattern in response: ${pattern
-                }\nSaw: ${res.body}`);
+                }\nSaw: ${res.text}`);
             }
         });
     });
 
-
     it('wt2lint', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/lint`,
-            body: {
-                wikitext: '== Heading =='
-            }
-        }).then((res) => {
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/lint`,
+            { wikitext: '== Heading ==' }
+        ).then((res) => {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body, []);
         });
     });
 
     it('wt2lint with errors', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/lint`,
-            body: {
-                wikitext: '<div>No div ending'
-            }
-        }).then((res) => {
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/lint`,
+            { wikitext: '<div>No div ending' }
+        ).then((res) => {
             assert.deepEqual(res.status, 200);
             assert.deepEqual(res.body.length, 1);
         });
     });
 
     it('html2wt, no-selser', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}`,
-            body: {
-                html: '<body>The modified HTML</body>'
-            }
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}`,
+            { html: '<body>The modified HTML</body>' }
 
-        })
+        )
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.body, 'The modified HTML');
+            assert.deepEqual(res.text, 'The modified HTML');
             assert.contentType(res, contentTypes.wikitext);
         });
     });
 
     it('html2wt, selser', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}/${testPage.revision}`,
-            body: {
-                html: testPage.html
-            }
-        })
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}/${testPage.revision}`,
+            { html: testPage.html }
+        )
         .then((res) => {
             assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.body, testPage.wikitext);
+            assert.deepEqual(res.text, testPage.wikitext);
             assert.contentType(res, contentTypes.wikitext);
         });
     });
@@ -153,16 +139,14 @@ describe('transform api', function() {
     it('supports reversed order of properties in TimeUuid meta', () => {
         const newHtml = testPage.html.replace(/<meta property="mw:TimeUuid" content="([^"]+)"\/?>/,
             '<meta content="$1" property="mw:TimeUuid" />');
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}/${testPage.revision}`,
-            body: {
-                html: newHtml
-            }
-        })
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}/${testPage.revision}`,
+            { html: newHtml }
+        )
         .then((res) => {
             assert.deepEqual(res.status, 200);
             const pattern = /Selser test/;
-            if (!pattern.test(res.body)) {
+            if (!pattern.test(res.text)) {
                 throw new Error(`Expected pattern in response: ${pattern
                 }\nSaw: ${JSON.stringify(res, null, 2)}`);
             }
@@ -199,13 +183,10 @@ describe('transform api', function() {
     });
 
     it('substitutes 0 as revision if not provided for stashing', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html/${testPage.title}`,
-            body: {
-                wikitext: '== ABCDEF ==',
-                stash: true
-            }
-        })
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html/${testPage.title}`,
+            { wikitext: '== ABCDEF ==', stash: true }
+        )
         .then((res) => {
             assert.deepEqual(res.status, 200);
             const etag = res.headers.etag;
@@ -214,32 +195,23 @@ describe('transform api', function() {
     });
 
     it('does not allow stashing without title', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html`,
-            body: {
-                wikitext: '== ABCDEF ==',
-                stash: true
-            }
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html`,
+            { wikitext: '== ABCDEF ==', stash: true }
+        )
+        .then((res) => {
+            assert.deepEqual(res.error.status, 400);
         })
-        .then(() => {
-            throw new Error('Error should be thrown');
-        }, (e) => {
-            assert.deepEqual(e.status, 400);
-        });
     });
 
     it('does not allow to transform html with no tid', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}/${testPage.revision}`,
-            body: {
-                html: '<h1>A</h1>'
-            }
+        return client.post(
+            `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}/${testPage.revision}`,
+            { html: '<h1>A</h1>' }
+        )
+        .then((res) => {
+            assert.deepEqual(res.error.status, 400);
         })
-        .then(() => {
-            throw new Error('Error should be thrown');
-        }, (e) => {
-            assert.deepEqual(e.status, 400);
-        });
     });
 });
 


### PR DESCRIPTION
Bug: T265846

I have been able to replace `preq` with the `api-testing` REST `client` within 11 out of 13 tests.

The two tests that are failing when I switch them to `client.post` are;

1. The `html2wt with scrub_wikitext` test fails with error 400 whenever the `scrub_wikitext: 1` parameter is added.

2. The `supports stashing content` test fails at the second `client.post`.

Could there be something I am missing that is causing these two tests to fail?