### PR TITLE
Add metrics to config.example.yaml

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -119,3 +119,8 @@ info:
 logging:
   name: restbase
   level: info
+
+metrics:
+  - type: statsd
+    host: localhost
+    port: 8125


### PR DESCRIPTION
Ensure that the standalone restbase example configuration doesn't throw
"No such metrics client: 'undefined'" errors on startup.

Change-Id: I4dfbe33a0f25ef28f877c41290d433d5bcf50984