### PR TITLE
Add redirect filter for domain redirects

### DIFF
--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -197,6 +197,9 @@ spec_root: &spec_root
   title: "The RESTBase root"
   # Some more general RESTBase info
   x-request-filters:
+    - path: lib/redirect_filter.js
+      options:
+        ar.wikipedia.beta.wmflabs.org: en.wikipedia.beta.wmflabs.org
     - path: lib/security_response_header_filter.js
 
   x-sub-request-filters:

--- a/lib/redirect_filter.js
+++ b/lib/redirect_filter.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const redirectLocation = (redirectTarget, uri) => {
+    const uriArray = uri.split('/');
+    uriArray[1] = redirectTarget;
+    return uriArray.join('/');
+};
+
+module.exports = (hyper, req, next, options) => {
+    const redirectSource = req.params.domain || `${req.uri}`.split('/')[1];
+    if (redirectSource in options) {
+        return {
+            status: 301,
+            headers: {
+                location: redirectLocation(options[redirectSource], `${req.uri}`)
+            }
+        };
+    }
+    return next(hyper, req);
+};

--- a/test/features/redirect_filter.js
+++ b/test/features/redirect_filter.js
@@ -1,0 +1,17 @@
+const assert = require('../utils/assert.js');
+const preq   = require('preq');
+const Server = require('../utils/server.js');
+
+describe('redirect filter', () => {
+    const server = new Server();
+    before(() => server.start());
+    after(() => server.stop());
+
+    it('should redirect the request to the set redirect target', () => {
+        return preq.get({ uri: `${server.config.baseURL('ar.wikipedia.beta.wmflabs.org')}/page/html/Main_Page` })
+            .then((res) => {
+                assert.deepEqual(res.status, 200);
+                assert.checkString(res.headers['content-location'], /en.wikipedia.beta.wmflabs.org/);
+            });
+    });
+});


### PR DESCRIPTION
The filter adds a domain level redirect similar to the one found
in apache for mediawiki to redirect restbase APIs.

Bug: T279588