### PR TITLE
Bump mediawiki-title to v0.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fast-json-stable-stringify": "^2.1.0",
     "hyperswitch": "^0.14.0",
     "jsonwebtoken": "^8.5.1",
-    "mediawiki-title": "^0.7.2",
+    "mediawiki-title": "^0.7.4",
     "restbase-mod-table-cassandra": "^1.2.1",
     "semver": "^7.3.2",
     "service-runner": "^2.8.1",


### PR DESCRIPTION
Should fix a redirect loop where the core Title implementation allows
soft-hyphens (U+00AD) but mediawiki-title was stripping them.  This
mismatch happened because a change only got reverted in one of the
implementations.

See https://github.com/wikimedia/mediawiki-title/pull/51

Bug: T284734

/cc @Pchelolo @subbuss 