### PR TITLE
Request users use the API less and remove reference to ISBNs

### DIFF
--- a/v1/citoid.yaml
+++ b/v1/citoid.yaml
@@ -21,11 +21,9 @@ paths:
         - Citation
       summary: Get citation data given an article identifier.
       description: |
-        Generates citation data given a URL, DOI, PMID, ISBN, or PMCID.
+        Generates citation data given a URL, DOI, PMID, or PMCID.
 
-        Because requests for ISBNs go to WorldCat and we have a limited number of these requests to their API per day, please limit requests to 100 per user or bot per day.
-
-        Automated requests for URLs and DOIs can be made at a rate of 1 request per second (rps).
+        Automated requests can be made at a rate of 1 request per second (rps).
 
         See more at [Citoid service documentation](https://www.mediawiki.org/wiki/Citoid)
 

--- a/v1/citoid.yaml
+++ b/v1/citoid.yaml
@@ -53,7 +53,7 @@ paths:
         - name: query
           in: path
           description: |
-            URL of an article, DOI, ISBN, PMCID or PMID in the URL-encoded format. Note that on the Swagger-UI doc page you don't need to URI-encode the parameter manually, it will be done by the docs engine.
+            URL of an article, DOI, PMCID or PMID in the URL-encoded format. Note that on the Swagger-UI doc page you don't need to URI-encode the parameter manually, it will be done by the docs engine.
           required: true
           schema:
             type: string

--- a/v1/citoid.yaml
+++ b/v1/citoid.yaml
@@ -25,7 +25,7 @@ paths:
 
         Because requests for ISBNs go to WorldCat and we have a limited number of these requests to their API per day, please limit requests to 100 per user or bot per day.
 
-        Automated requests for URLs and DOIs can be made at a rate of 1 request per second (rqs).
+        Automated requests for URLs and DOIs can be made at a rate of 1 request per second (rps).
 
         See more at [Citoid service documentation](https://www.mediawiki.org/wiki/Citoid)
 

--- a/v1/citoid.yaml
+++ b/v1/citoid.yaml
@@ -23,6 +23,10 @@ paths:
       description: |
         Generates citation data given a URL, DOI, PMID, ISBN, or PMCID.
 
+        Because requests for ISBNs go to WorldCat and we have a limited number of these requests to their API per day, please limit requests to 100 per user or bot per day.
+
+        Automated requests for URLs and DOIs can be made at a rate of 1 request per second (rqs).
+
         See more at [Citoid service documentation](https://www.mediawiki.org/wiki/Citoid)
 
         The citation data can be requested in one of the following formats:


### PR DESCRIPTION
Request users limit ISBN requests to 100/day
and requests for URLs and DOIs to 1 request
per second.

Bug: T302521