### PR TITLE
Blubber: allow file writes in tests

### DIFF
--- a/.pipeline/blubber.yaml
+++ b/.pipeline/blubber.yaml
@@ -16,6 +16,8 @@ variants:
     includes: [build]
     apt: { packages: [libsqlite3-0, ca-certificates] }
     entrypoint: [node, server.js]
+    runs:
+      insecurely: true
   test:
     includes: [build]
     apt: { packages: [libsqlite3-0, ca-certificates] }
@@ -24,6 +26,7 @@ variants:
       environment:
         TEST_TARGET: sqlite
         TEST_MODE: fefs
+      insecurely: true
   prep:
     includes: [build]
     node: { env: production }


### PR DESCRIPTION
Add the "runs: insecurely" flag in the "development" and "test" variants in the blubber file. This is needed to allow restbase to use sqlite for storage, since without it, the database file cannot be opened in read/write mode.

Change-Id: I6dfc2fa0676d02039caba6833bcf295ad8953ffc