### PR TITLE
Proton's cache-control time is set to 10 mins but docs lie

### DIFF
--- a/config.frontend.test.yaml
+++ b/config.frontend.test.yaml
@@ -33,7 +33,7 @@ default_project: &default_project
                   # Cache control for purged endpoints allowing short-term client caching
                   purged_cache_control_client_cache: test_purged_cache_control_with_client_caching
                   pdf:
-                    # Cache PDF for 5 minutes since it's not purged
+                    # Cache PDF for 10 minutes since it's not purged
                     cache_control: s-maxage=600, max-age=600
                     uri: https://proton-beta.wmflabs.org
                   transform:

--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -32,7 +32,7 @@ default_project: &default_project
                   # Cache control for purged endpoints allowing short-term client caching
                   purged_cache_control_client_cache: test_purged_cache_control_with_client_caching
                   pdf:
-                    # Cache PDF for 5 minutes since it's not purged
+                    # Cache PDF for 10 minutes since it's not purged
                     cache_control: s-maxage=600, max-age=600
                     uri: https://proton-beta.wmflabs.org
                   transform:


### PR DESCRIPTION
Per the cache control response header emitted by RESTBase and the yaml file, the cache-control response header for Proton's PDF is set for 10 minutes instead of 5 minutes as the docs mentions.