### PR TITLE
pcs: Customize cache control

### DIFF
--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -18,6 +18,7 @@ default_project: &default_project
                     cache-control: s-maxage=864000, max-age=86400
                   mobileapps:
                     host: https://mobileapps.wmcloud.org
+                    cache_control: test_mobileapps_cache_control
                   wikifeeds:
                     host: https://wikifeeds-beta.wmflabs.org
                   summary:

--- a/projects/v1/wikipedia.wmf.yaml
+++ b/projects/v1/wikipedia.wmf.yaml
@@ -70,13 +70,13 @@ paths:
       - path: v1/pcs/stored_endpoint.js
         options:
           name: media-list
-          response_cache_control: '{{options.purged_cache_control}}'
+          response_cache_control: '{{options.mobileapps.cache_control}}'
           host: '{{options.mobileapps.host}}'
           disabled_storage: '{{options.disabled_storage}}'
       - path: v1/pcs/stored_endpoint.js
         options:
           name: mobile-html
-          response_cache_control: '{{options.purged_cache_control}}'
+          response_cache_control: '{{options.mobileapps.cache_control}}'
           host: '{{options.mobileapps.host}}'
           disabled_storage: '{{options.disabled_storage}}'
       - path: v1/pcs/mobile-html-offline-resources.yaml

--- a/projects/v1/wikivoyage.wmf.yaml
+++ b/projects/v1/wikivoyage.wmf.yaml
@@ -73,12 +73,12 @@ paths:
       - path: v1/pcs/stored_endpoint.js
         options:
           name: media-list
-          response_cache_control: '{{options.purged_cache_control}}'
+          response_cache_control: '{{options.mobileapps.cache_control}}'
           host: '{{options.mobileapps.host}}'
       - path: v1/pcs/stored_endpoint.js
         options:
           name: mobile-html
-          response_cache_control: '{{options.purged_cache_control}}'
+          response_cache_control: '{{options.mobileapps.cache_control}}'
           host: '{{options.mobileapps.host}}'
       - path: v1/pcs/mobile-html-offline-resources.yaml
         options:

--- a/projects/v1/wiktionary.wmf.yaml
+++ b/projects/v1/wiktionary.wmf.yaml
@@ -69,12 +69,12 @@ paths:
       - path: v1/pcs/stored_endpoint.js
         options:
           name: media-list
-          response_cache_control: '{{options.purged_cache_control}}'
+          response_cache_control: '{{options.mobileapps.cache_control}}'
           host: '{{options.mobileapps.host}}'
       - path: v1/pcs/stored_endpoint.js
         options:
           name: mobile-html
-          response_cache_control: '{{options.purged_cache_control}}'
+          response_cache_control: '{{options.mobileapps.cache_control}}'
           host: '{{options.mobileapps.host}}'
       - path: v1/pcs/mobile-html-offline-resources.yaml
         options:

--- a/test/features/pcs.js
+++ b/test/features/pcs.js
@@ -31,7 +31,7 @@ describe('Page Content Service: /page/media-list', () => {
                 assert.deepEqual(/^application\/json/.test(res.headers['content-type']), true);
                 assert.deepEqual(!!res.body.items, true);
                 assert.deepEqual(!!res.headers.etag, true);
-                assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+                assert.deepEqual(res.headers['cache-control'], 'test_mobileapps_cache_control');
             });
     });
 
@@ -46,7 +46,7 @@ describe('Page Content Service: /page/media-list', () => {
                 assert.deepEqual(res.headers['x-restbase-sunset'] || null, 'true');
                 assert.deepEqual(!!res.body.items, true);
                 assert.deepEqual(!!res.headers.etag, true);
-                assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+                assert.deepEqual(res.headers['cache-control'], 'test_mobileapps_cache_control');
             });
     });
 
@@ -59,7 +59,7 @@ describe('Page Content Service: /page/media-list', () => {
                 assert.deepEqual(/^application\/json/.test(res.headers['content-type']), true);
                 assert.deepEqual(!!res.body.items, true);
                 assert.deepEqual(new RegExp(`^(?:W\/)?"${pageRev}\/.+"$`).test(res.headers.etag), true);
-                assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+                assert.deepEqual(res.headers['cache-control'], 'test_mobileapps_cache_control');
             });
     });
 });
@@ -87,7 +87,7 @@ describe('Page Content Service: /page/mobile-html', () => {
                 assert.deepEqual(res.status, 200);
                 assert.deepEqual(/^text\/html/.test(res.headers['content-type']), true);
                 assert.deepEqual(res.headers['x-restbase-sunset'] || null, null);
-                assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+                assert.deepEqual(res.headers['cache-control'], 'test_mobileapps_cache_control');
             });
     });
 
@@ -102,7 +102,7 @@ describe('Page Content Service: /page/mobile-html', () => {
                 assert.deepEqual(res.status, 200);
                 assert.deepEqual(/^text\/html/.test(res.headers['content-type']), true);
                 assert.deepEqual(res.headers['x-restbase-sunset'] || null, 'true');
-                assert.deepEqual(res.headers['cache-control'], 'test_purged_cache_control');
+                assert.deepEqual(res.headers['cache-control'], 'test_mobileapps_cache_control');
             });
     });
 });


### PR DESCRIPTION
* This patch allows PCS to have customized cache control headers so we can test optimizations only for the specific endpoint