### PR TITLE
Update deploy target images

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "node": ">=6"
   },
   "deploy": {
-    "node": "6.11.1",
-    "target": "debian:stretch",
+    "node": "10",
+    "target": "debian:bullseye",
     "dependencies": {
       "_all": []
     }


### PR DESCRIPTION
After running locally the build/deploy commands it looks like its broken because of the docker image being outdated. This patch is fixing the builds.

`./server.js build --deploy-repo --force`