### PR TITLE
Optimize the performance of parsoid regular expressions

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -17,7 +17,7 @@ const spec = HyperSwitch.utils.loadSpec(`${__dirname}/parsoid.yaml`);
 function normalizeHtml(html) {
     return html && html.toString &&
         html.toString()
-            .replace(/ about="[^"]+"(?=[/> ])|<meta property="mw:TimeUuid"[^>]+>/g, '');
+            .replace(/ about="[^"]+"(?=[/> ])|<meta property="mw:TimeUuid"[^>]{1,128}>/g, '');
 }
 function sameHtml(a, b) {
     return normalizeHtml(a) === normalizeHtml(b);
@@ -30,8 +30,8 @@ function sameHtml(a, b) {
  * @return {string}      modified html
  */
 function insertTidMeta(html, tid) {
-    if (!/<meta property="mw:TimeUuid" [^>]+>/.test(html)) {
-        return html.replace(/(<head [^>]+>)/,
+    if (!/<meta property="mw:TimeUuid" [^>]{1,128}>/.test(html)) {
+        return html.replace(/(<head [^>]{1,128}>)/,
             `$1<meta property="mw:TimeUuid" content="${tid}"/>`);
     }
     return html;

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -17,7 +17,7 @@ const spec = HyperSwitch.utils.loadSpec(`${__dirname}/parsoid.yaml`);
 function normalizeHtml(html) {
     return html && html.toString &&
         html.toString()
-            .replace(/ about="[^"]+"(?=[/> ])|<meta property="mw:TimeUuid"[^>]{1,128}>/g, '');
+            .replace(/ about="[^"]+"(?=[/> ])|<meta property="mw:TimeUuid"[^>]{0,128}>/g, '');
 }
 function sameHtml(a, b) {
     return normalizeHtml(a) === normalizeHtml(b);
@@ -30,8 +30,8 @@ function sameHtml(a, b) {
  * @return {string}      modified html
  */
 function insertTidMeta(html, tid) {
-    if (!/<meta property="mw:TimeUuid" [^>]{1,128}>/.test(html)) {
-        return html.replace(/(<head [^>]{1,128}>)/,
+    if (!/<meta property="mw:TimeUuid" [^>]{0,128}>/.test(html)) {
+        return html.replace(/(<head [^>]{0,128}>)/,
             `$1<meta property="mw:TimeUuid" content="${tid}"/>`);
     }
     return html;


### PR DESCRIPTION
* Sets length ranges for a few regular expressions that may
  result in polynomial-time performance in worst-case
  scenarios.  A max range length of 128 seems reasonable
  based upon a limited analysis of available patterns.

Bug: T337274