### PR TITLE
Remove mathoids PNG images

### DIFF
--- a/sys/mathoid.js
+++ b/sys/mathoid.js
@@ -6,7 +6,7 @@ const URI = HyperSwitch.URI;
 const HTTPError = HyperSwitch.HTTPError;
 const mwUtil = require('../lib/mwUtil');
 
-const FORMATS = ['mml', 'svg', 'png'];
+const FORMATS = ['mml', 'svg'];
 
 function prefixHeaders(headers, prefix = 'x-store-') {
     const prefixedHeaders = {};
@@ -141,12 +141,6 @@ class MathoidService {
                 }, prefixHeaders(completeBody[format].headers)),
                 body: completeBody[format].body
             };
-            if (format === 'png' && reqObj.body && reqObj.body.type === 'Buffer') {
-                // for png, we need to convert the encoded data manually
-                // because we are receiving it wrapped inside a JSON
-                reqObj.body = Buffer.from(reqObj.body.data);
-                completeBody[format].body = reqObj.body;
-            }
             // store the emit Promise
             reqs[idx] = hyper.put(reqObj);
         }
@@ -162,7 +156,10 @@ class MathoidService {
     requestAndStore(hyper, req) {
         const rp = req.params;
         const hash = req.headers['x-resource-location'];
-
+        // T334842 redirect png traffic to svg endpoint.
+        if (rp.format === 'png') {
+            rp.format = 'svg';
+        }
         // first ask for all the renders from Mathoid
         return hyper.post({
             uri: `${this.options.host}/complete`,
@@ -289,15 +286,6 @@ module.exports = (options) => {
                 body: {
                     keyType: 'string',
                     valueType: 'string'
-                }
-            }, {
-                uri: '/{domain}/sys/key_value/mathoid_ng.png',
-                headers: {
-                    'content-type': 'application/json'
-                },
-                body: {
-                    keyType: 'string',
-                    valueType: 'blob'
                 }
             }
         ]

--- a/sys/mathoid.js
+++ b/sys/mathoid.js
@@ -287,6 +287,15 @@ module.exports = (options) => {
                     keyType: 'string',
                     valueType: 'string'
                 }
+            }, {
+                uri: '/{domain}/sys/key_value/mathoid_ng.png',
+                headers: {
+                    'content-type': 'application/json'
+                },
+                body: {
+                    keyType: 'string',
+                    valueType: 'string'
+                }
             }
         ]
     };

--- a/test/features/mathoid.js
+++ b/test/features/mathoid.js
@@ -9,8 +9,8 @@ describe('Mathoid', function() {
     const server = new Server();
     const f = 'c^2 = a^2 + b^2';
     const nf = 'c^{2}=a^{2}+b^{2}';
-    const formats = ['mml', 'svg', 'png'];
-    const formats_regex = [/mathml/, /svg/, /png/];
+    const formats = ['mml', 'svg'];
+    const formatRegexp = [/mathml/, /svg/];
     let hash;
 
     before(() => server.start());
@@ -84,7 +84,7 @@ describe('Mathoid', function() {
 
     for (let i = 0; i < formats.length; i++) {
         const format = formats[i];
-        const regex = formats_regex[i];
+        const regex = formatRegexp[i];
         it(`gets the render in ${format}`, () => { // eslint-disable-line no-loop-func
             return preq.get({
                 uri: `${server.config.baseURL('wikimedia.org')}/media/math/render/${format}/${hash}`

--- a/v1/mathoid.yaml
+++ b/v1/mathoid.yaml
@@ -171,10 +171,6 @@ paths:
             application/mathml+xml:
               schema:
                 type: string
-            image/png:
-              schema:
-                type: string
-                format: binary
         404:
           description: Unknown format or hash ID
           content:


### PR DESCRIPTION
Remove mathoids PNG images from RestBase endpoint.

* Stop storing PNG response from mathoid
* Redirect PNG endpoint to SVG endpoint

Unfortunately, one can not remove the PNG option from swagger, as the same .yaml file is used for the swagger ui and the parameter check.

See https://gerrit.wikimedia.org/r/c/mediawiki/services/mathoid/+/875405/8/test/restbase/README.md for local testing.

Bug: T334842
Change-Id: I6e16ccb5f3d84e76393ae72172a91e77a8c8b447