### PR TITLE
Parsoid: Remove support for stashing

### DIFF
--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -80,15 +80,6 @@ describe('item requests', function() {
             assert.validateListHeader(res.headers.vary,  { require: ['Accept'], disallow: [''] });
         });
     });
-    it('should not allow to frontend cache HTML if requested a stash', () => {
-        return preq.get({
-            uri: `${server.config.bucketURL()}/html/${title}?stash=true`,
-        })
-        .then((res) => {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.headers['cache-control'], 'no-cache');
-        });
-    });
 
     it('should request page lints. no revision', () => {
         return preq.get({
@@ -113,7 +104,7 @@ describe('item requests', function() {
     let rev2Etag;
     it(`should transparently create data-parsoid with id ${prevRevisions[1]}, rev 2`, () => {
         return preq.get({
-            uri: `${server.config.bucketURL()}/html/${title}/${prevRevisions[1]}?stash=true`
+            uri: `${server.config.bucketURL()}/html/${title}/${prevRevisions[1]}`
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);
@@ -134,7 +125,7 @@ describe('item requests', function() {
 
     it(`should return HTML and data-parsoid just created by revision ${prevRevisions[2]}`, () => {
         return preq.get({
-            uri: `${server.config.bucketURL()}/html/${title}/${prevRevisions[2]}?stash=true`
+            uri: `${server.config.bucketURL()}/html/${title}/${prevRevisions[2]}`
         })
         .then((res) => {
             assert.deepEqual(res.status, 200);

--- a/test/features/pagecontent/rerendering.js
+++ b/test/features/pagecontent/rerendering.js
@@ -28,7 +28,7 @@ describe('page re-rendering', function() {
         let r1etag1;
         let r1etag2;
         let r2etag1;
-        return preq.get({uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${dynamic2}?stash=true`})
+        return preq.get({uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${dynamic2}`})
         .then(async (res) => {
             assert.deepEqual(res.status, 200);
             r1etag1 = res.headers.etag;
@@ -44,7 +44,7 @@ describe('page re-rendering', function() {
             return P.delay(3000)
             .then(() => {
                 return preq.get({
-                    uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${dynamic2}?stash=true`,
+                    uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${dynamic2}`,
                     headers: { 'cache-control': 'no-cache' }
                 });
             });
@@ -62,7 +62,7 @@ describe('page re-rendering', function() {
             assert.deepEqual(res.headers.etag, r1etag2);
             hasTextContentType(res);
             return preq.get({
-                uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${dynamic1}?stash=true`,
+                uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${dynamic1}`,
                 headers: { 'cache-control': 'no-cache' }
             });
         })
@@ -104,14 +104,14 @@ describe('page re-rendering', function() {
         let r1etag2;
         let r2etag1;
         let tid;
-        return preq.get({uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${static1}?stash=true`})
+        return preq.get({uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${static1}`})
         .then((res) => {
             assert.deepEqual(res.status, 200);
             r1etag1 = res.headers.etag;
             hasTextContentType(res);
 
             return preq.get({
-                uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${static1}?stash=true`,
+                uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${static1}`,
                 headers: { 'cache-control': 'no-cache' }
             });
         })
@@ -141,7 +141,7 @@ describe('page re-rendering', function() {
             assert.deepEqual(res.headers.etag, r1etag2);
             hasTextContentType(res);
 
-            return preq.get({uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${static2}?stash=true`});
+            return preq.get({uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${static2}`});
         })
         .then((res) => {
             r2etag1 = res.headers.etag;

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -170,64 +170,6 @@ describe('transform api', function() {
         });
     });
 
-    it('supports stashing content', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html/${testPage.title}/${testPage.revision}`,
-            body: {
-                wikitext: '== ABCDEF ==',
-                stash: true
-            }
-        })
-        .then((res) => {
-            assert.deepEqual(res.status, 200);
-            const etag = res.headers.etag;
-            assert.deepEqual(/\/stash"$/.test(etag), true);
-            return preq.post({
-                uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}/${testPage.revision}`,
-                headers: {
-                    'if-match': etag
-                },
-                body: {
-                    html: res.body.replace('>ABCDEF<', '>FECDBA<')
-                }
-            });
-        })
-        .then((res) => {
-            assert.deepEqual(res.status, 200);
-            assert.deepEqual(res.body, '== FECDBA ==');
-        });
-    });
-
-    it('substitutes 0 as revision if not provided for stashing', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html/${testPage.title}`,
-            body: {
-                wikitext: '== ABCDEF ==',
-                stash: true
-            }
-        })
-        .then((res) => {
-            assert.deepEqual(res.status, 200);
-            const etag = res.headers.etag;
-            assert.deepEqual(/^"0\/[^\/]+\/stash"$/.test(etag), true);
-        });
-    });
-
-    it('does not allow stashing without title', () => {
-        return preq.post({
-            uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/wikitext/to/html`,
-            body: {
-                wikitext: '== ABCDEF ==',
-                stash: true
-            }
-        })
-        .then(() => {
-            throw new Error('Error should be thrown');
-        }, (e) => {
-            assert.deepEqual(e.status, 400);
-        });
-    });
-
     it('does not allow to transform html with no tid', () => {
         return preq.post({
             uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}/${testPage.revision}`,

--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -177,12 +177,6 @@ paths:
           schema:
             type: boolean
           required: false
-        - name: stash
-          in: query
-          description: |
-            Whether to temporary stash data-parsoid in order to support transforming the
-            modified content later. If this parameter is set, requests are rate-limited on
-            a per-client basis (max 5 requests per second per client)
           schema:
             type: boolean
         - name: Accept-Language
@@ -261,8 +255,6 @@ paths:
                 if-unmodified-since: '{{if-unmodified-since}}'
                 x-restbase-mode: '{{x-restbase-mode}}'
                 x-restbase-parentrevision: '{{x-restbase-parentrevision}}'
-              query:
-                stash: '{{stash}}'
       x-monitor: true
       x-amples:
         # FIXME: This depends on our 'no change' detection optimization to
@@ -421,12 +413,6 @@ paths:
             To get a 200 response instead, supply `false` to the `redirect` parameter.
           schema:
             type: boolean
-        - name: stash
-          in: query
-          description: |
-            Whether to temporary stash data-parsoid in order to support transforming the
-            modified content later. If this parameter is set, requests are rate-limited on
-            a per-client basis (max 5 requests per second per client)
           schema:
             type: boolean
         - name: Accept-Language
@@ -517,8 +503,6 @@ paths:
                 if-unmodified-since: '{{if-unmodified-since}}'
                 x-restbase-mode: '{{x-restbase-mode}}'
                 x-restbase-parentrevision: '{{x-restbase-parentrevision}}'
-              query:
-                stash: '{{stash}}'
       x-monitor: false
 
   /data-parsoid/{title}/{revision}/{tid}:

--- a/v1/transform.yaml
+++ b/v1/transform.yaml
@@ -209,11 +209,10 @@ paths:
         - Transforms
       summary: Transform Wikitext to HTML
       description: |
-        Transform wikitext to HTML. Note that if you set `stash: true`, you
-        also need to supply the title.
+        Transform wikitext to HTML.
 
         - Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
-        - Rate limit: 25 req/s (5 req/s when `stash: true`)
+        - Rate limit: 25 req/s
       requestBody:
         content:
           multipart/form-data:
@@ -228,9 +227,6 @@ paths:
                 body_only:
                   type: boolean
                   description: Return only `body.innerHTML`
-                stash:
-                  type: boolean
-                  description: Whether to temporarily stash the result of the transformation
         required: true
       responses:
         200:
@@ -286,7 +282,6 @@ paths:
               body:
                 wikitext: '{{wikitext}}'
                 body_only: '{{body_only}}'
-                stash: '{{stash}}'
       x-monitor: false
 
   /wikitext/to/html/{title}:
@@ -313,9 +308,6 @@ paths:
                 body_only:
                   type: boolean
                   description: Return only `body.innerHTML`
-                stash:
-                  type: boolean
-                  description: Whether to temporarily stash the result of the transformation
         required: true
       x-request-handler:
         - get_from_backend:
@@ -324,7 +316,6 @@ paths:
               body:
                 wikitext: '{{wikitext}}'
                 body_only: '{{body_only}}'
-                stash: '{{stash}}'
       x-monitor: true
       x-amples:
         - title: Transform wikitext to html
@@ -371,9 +362,6 @@ paths:
                 body_only:
                   type: boolean
                   description: Return only `body.innerHTML`
-                stash:
-                  type: boolean
-                  description: Whether to temporarily stash the result of the transformation
         required: true
       x-request-handler:
         - get_from_backend:
@@ -382,7 +370,6 @@ paths:
               body:
                 wikitext: '{{wikitext}}'
                 body_only: '{{body_only}}'
-                stash: '{{stash}}'
 
   /wikitext/to/lint:
     post: &wikitext_to_lint_post_spec


### PR DESCRIPTION
Stashing is only needed by VisualEditor, and VisualEditor no longer uses RESTbase. So let's remove stashing from RESTbase.

NOTE: This was made by blindly removing all code that refers to stashing. We need to carefully test this to make sure it doesn't break anything.

Change-Id: I20aedf2206130c8d07f4419cf2dbf4dc349a2961