### PR TITLE
Use HTTPS to access parsoid backend

### DIFF
--- a/config.frontend.test.yaml
+++ b/config.frontend.test.yaml
@@ -8,7 +8,8 @@ default_project: &default_project
               - path: projects/v1/default.wmf.yaml
                 options: &default_options
                   parsoid:
-                    host: http://parsoid-external-ci-access.beta.wmflabs.org/w/rest.php
+                    # NOTE: You may need NODE_TLS_REJECT_UNAUTHORIZED=0 to make this work!
+                    host: https://parsoid-external-ci-access.beta.wmflabs.org/w/rest.php
                     grace_ttl: 1000000
                   action:
                     apiUriTemplate: "{{'https://{domain}/w/api.php'}}"

--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -7,7 +7,8 @@ default_project: &default_project
               - path: projects/v1/default.wmf.yaml
                 options: &default_options
                   parsoid:
-                    host: http://parsoid-external-ci-access.beta.wmflabs.org/w/rest.php
+                    # NOTE: You may need NODE_TLS_REJECT_UNAUTHORIZED=0 to make this work!
+                    host: https://parsoid-external-ci-access.beta.wmflabs.org/w/rest.php
                     grace_ttl: 1000000
                   action:
                     apiUriTemplate: "{{'https://{domain}/w/api.php'}}"

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -7,6 +7,7 @@ const DEFAULT_DOMAIN = 'en.wikipedia.beta.wmflabs.org';
 class TestRestbase {
     constructor() {
         const testMode = process.env.TEST_MODE || 'fs';
+
         switch (testMode) {
             case 'fs':
                 this._frontendServer = new TestRunner(`${__dirname}/../../config.fullstack.test.yaml`);
@@ -48,7 +49,8 @@ class TestRestbase {
             apiBase,
             apiPath,
             apiURL,
-            parsoidURI: 'http://parsoid-external-ci-access.beta.wmflabs.org/w/rest.php',
+            // NOTE: You may need NODE_TLS_REJECT_UNAUTHORIZED=0 to make this work!
+            parsoidURI: 'https://parsoid-external-ci-access.beta.wmflabs.org/w/rest.php',
             conf
         }
     }


### PR DESCRIPTION
The Mocha tests should use HTTPS to access the parsoid-external-ci-access.beta.wmflabs.org host. Using plain HTTP may result in POST requests being rejected with "Insecure request forbidden, use HTTPS instead.".

Note that parsoid-external-ci-access.beta.wmflabs.org doesn't have a valid TLS certificate. Setting NODE_TLS_REJECT_UNAUTHORIZED=0 can be used to disable certificate validation.

Change-Id: Ib8f4af45687e13e44f77409c697779c2d8dcfdc3