### PR TITLE
assert.js: report expected value when strings are not equal

### DIFF
--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -59,6 +59,7 @@ function findRequests(predicate) {
 
 function isDeepEqual(result, expected, message) {
     try {
+        message = message || `expected: ${expected}; actual: ${result}`;
         if (typeof expected === 'string') {
             assert.ok(result === expected || (new RegExp('^' + expected + '$').test(result)), message);
         } else {
@@ -73,7 +74,8 @@ function isDeepEqual(result, expected, message) {
 function deepEqual(result, expected, message) {
     try {
         if (typeof expected === 'string') {
-            assert.ok(result === expected || (new RegExp('^' + expected + '$').test(result)));
+            message = message || `expected: ${expected}; actual: ${result}`;
+            assert.ok(result === expected || (new RegExp('^' + expected + '$').test(result)), message);
         } else {
             assert.deepEqual(result, expected, message);
         }


### PR DESCRIPTION
This makes it much easier to see what's happenign when tests fail.
