### PR TITLE
Fix CI for disabled storage

### DIFF
--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -1,7 +1,10 @@
 # Hacky way to parametrize RESTBase tests. TODO: Move to config?
 test:
   parsoid: &parsoid_test_options
-    disabled_storage: false
+    disabled_storage:
+      default: false
+      # eswiki beta has parsoid storage disabled for testing purposes
+      es.wikipedia.beta.wmflabs.org: true
     host: http://parsoid-external-ci-access.beta.wmflabs.org/w/rest.php
   content_types:
     html: '/^text\/html; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/HTML\/[\d.]+"$/'
@@ -231,6 +234,8 @@ spec_root: &spec_root
     # The order is important for tests.
     # Redirect tests require en.wiki being not the first wiki in the list.
     /{domain:en.wikipedia.beta.wmflabs.org}: *wikipedia_project
+    # Used for testing parsoid storage flag
+    /{domain:es.wikipedia.beta.wmflabs.org}: *wikipedia_project
     # For testing purpose lets run de-beta with storage disabled
     /{domain:de.wikipedia.beta.wmflabs.org}: *wikipedia_project_no_storage
     /{domain:zh.wikipedia.beta.wmflabs.org}: *wikipedia_project

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -58,10 +58,6 @@ describe('item requests', function() {
     });
 
     it('should transparently create a new HTML revision for Main_Page', function () {
-        if ( disabledStorage ) {
-            this.skip();
-        }
-
         return preq.get({
             uri: `${server.config.bucketURL()}/html/Main_Page`,
         })
@@ -83,12 +79,8 @@ describe('item requests', function() {
         });
     });
     it('should not cache HTML for Main_Page when storage is disabled', function () {
-        if ( !disabledStorage ) {
-            this.skip();
-        }
-
         return preq.get({
-            uri: `${server.config.bucketURL()}/html/Main_Page`,
+            uri: `${server.config.bucketURL("es.wikipedia.beta.wmflabs.org")}/html/Página_principal`,
         })
           .then((res) => {
               assert.deepEqual(res.status, 200);

--- a/test/features/pagecontent/rerendering.js
+++ b/test/features/pagecontent/rerendering.js
@@ -30,10 +30,6 @@ describe('page re-rendering', function() {
     }
 
     it('should render & re-render independent revisions', function () {
-        if ( disabledStorage ) {
-            this.skip();
-        }
-
         let r1etag1;
         let r1etag2;
         let r2etag1;
@@ -89,10 +85,6 @@ describe('page re-rendering', function() {
     });
 
     it('should render & re-render independent revisions, if-unmodified-since support', function () {
-        if ( disabledStorage ) {
-            this.skip();
-        }
-
         return preq.get({
             uri: `${server.config.bucketURL('en.wikipedia.beta.wmflabs.org')}${dynamic2}`,
             headers: {
@@ -113,10 +105,6 @@ describe('page re-rendering', function() {
     const static2 = '/html/User:Pchelolo%2fStatic/275853';
 
     it('should render & re-render independent revisions, but not update unchanged content', function () {
-        if ( disabledStorage ) {
-            this.skip();
-        }
-
         let r1etag1;
         let r1etag2;
         let r2etag1;


### PR DESCRIPTION
Add a new beta domain in config just for testing the disabled parsoid storage feature. This way we also test the feature flag configured by domain.