### PR TITLE
no-cache requests write to cache even when storage is disabled.

### DIFF
--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -137,6 +137,17 @@ wikipedia_project: &wikipedia_project
               - path: projects/proxy.yaml
                 options: *proxy_options
           /{api:sys}: *default_sys
+          /sys_passthrough/{+syspath}:
+            get:
+              x-request-handler:
+                - passthrough_sys:
+                    request:
+                      method: get
+                      uri: /{domain}/sys/{+syspath}
+                    return:
+                      status: 200
+                      headers: '{{passthrough_sys.headers}}'
+                      body: '{{passthrough_sys.body}}'
 
 wikipedia_project_no_storage: &wikipedia_project_no_storage
   x-modules:

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -30,10 +30,12 @@ describe('item requests', function() {
         return [server.config.bucketURL(), format, encodeURIComponent(deniedTitle), deniedRev].join('/');
     }
 
-    const sysURL = (domain = server.config.defaultDomain) => `${hostPort}/${domain}/sys_passthrough`;
+    const sysURL = (domain) => {
+        domain = domain || server.config.defaultDomain;
+        return `${hostPort}/${domain}/sys_passthrough`;
+    };
 
-    const sysGet = (path, opt = {}) => {
-        const domain = opt.domain || Server.DEFAULT_DOMAIN;
+    const sysGet = (domain, path, opt = {}) => {
         const uri = `${sysURL(domain)}/${path}`;
         return preq.get( { uri, ...opt } );
     };
@@ -97,7 +99,7 @@ describe('item requests', function() {
             assert.deepEqual(res.headers['x-restbase-cache'], 'disabled');
 
             // should still not be cached
-            return sysGet( `key_value/parsoidphp/Página_principal`, { domain: domainWithStorageDisabled } );
+            return sysGet( domainWithStorageDisabled, `key_value/parsoidphp/Página_principal` );
         }).then((res) => {
             // if this mails, make sure you are resetting the database between tests
             assert.deepEqual(res.status, 404);
@@ -116,7 +118,7 @@ describe('item requests', function() {
               assert.deepEqual(res.status, 200);
 
               // should now be cached
-              return sysGet( `key_value/parsoidphp/Página_principal`, { domain: domainWithStorageDisabled } );
+              return sysGet( domainWithStorageDisabled, `key_value/parsoidphp/Página_principal` );
           }).then((res) => {
               assert.deepEqual(res.status, 200);
           })

--- a/test/features/pagecontent/pagecontent.js
+++ b/test/features/pagecontent/pagecontent.js
@@ -209,7 +209,7 @@ describe('item requests', function() {
             assert.deepEqual(res.status, 200);
             assert.contentType(res, 'application/json');
             assert.deepEqual(res.body, {
-                items: ['v1' ]
+                items: ['sys_passthrough', 'v1']
             });
         });
     });


### PR DESCRIPTION
So allow us to safely switch back from disabled_storage, we need to keep pre-generated cache entries up to date. We can do this by simply continuing to handle no-cache requests as we did before, allowing them to write updated renderings to the cache.

Change-Id: Ica6f52b362d37765471ab1ed37dee62a8e0ca6f7