### PR TITLE
Make parsoid transform follow disable_storage setting.

### DIFF
--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -936,12 +936,21 @@ class ParsoidService {
 
     _getOriginalContent(hyper, req, revision, tid) {
         const rp = req.params;
-        return this._getContentWithFallback(hyper, rp.domain, rp.title, revision, tid)
-            .then((res) => {
-                res = res.body;
-                res.revid = revision;
-                return res;
-            });
+
+        const disabledStorage = this._isStorageDisabled(req.params.domain);
+        let contentReq;
+
+        if (disabledStorage) {
+            contentReq = this._getPageBundleFromParsoid(hyper, req);
+        } else {
+            contentReq = this._getContentWithFallback(hyper, rp.domain, rp.title, revision, tid);
+        }
+
+        return contentReq.then((res) => {
+              res = res.body;
+              res.revid = revision;
+              return res;
+          });
     }
 }
 

--- a/sys/parsoid.js
+++ b/sys/parsoid.js
@@ -947,10 +947,10 @@ class ParsoidService {
         }
 
         return contentReq.then((res) => {
-              res = res.body;
-              res.revid = revision;
-              return res;
-          });
+            res = res.body;
+            res.revid = revision;
+            return res;
+        });
     }
 }
 

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -130,7 +130,6 @@ describe('transform api', function() {
             assert.contentType(res, contentTypes.html);
             const etag = res.headers.etag;
             const revid = res.headers.etag.match(/^"(.*?)\//)[1];
-            console.log( 'REV-ID', revid );
             return preq.post({
                 uri: `${server.config.baseURL('es.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/P%C3%A1gina_principal/${revid}`,
                 headers: {

--- a/test/features/parsoid/transform.js
+++ b/test/features/parsoid/transform.js
@@ -122,6 +122,31 @@ describe('transform api', function() {
         });
     });
 
+    it('html2wt, disabled-storage', () => {
+        preq.get({
+            uri: `${server.config.baseURL('es.wikipedia.beta.wmflabs.org')}/page/html/P%C3%A1gina_principal`
+        }).then((res) => {
+            assert.deepEqual(res.status, 200);
+            assert.contentType(res, contentTypes.html);
+            const etag = res.headers.etag;
+            const revid = res.headers.etag.match(/^"(.*?)\//)[1];
+            console.log( 'REV-ID', revid );
+            return preq.post({
+                uri: `${server.config.baseURL('es.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/P%C3%A1gina_principal/${revid}`,
+                headers: {
+                    'if-match': etag
+                },
+                body: {
+                    html: '<body>The modified HTML</body>'
+                }
+            });
+        }).then((res) => {
+              assert.deepEqual(res.status, 200);
+              assert.deepEqual(res.body, 'The modified HTML');
+              assert.contentType(res, contentTypes.wikitext);
+          });
+    });
+
     it('html2wt, selser', () => {
         return preq.post({
             uri: `${server.config.baseURL('en.wikipedia.beta.wmflabs.org')}/transform/html/to/wikitext/${testPage.title}/${testPage.revision}`,


### PR DESCRIPTION
If disable_storage is set, don't try to load the original HTML from cache for transform operations.

Bug: T350219
Change-Id: I33c3baae4f0579121b89f6d913852d6c118ebd56