### PR TITLE
Use beta for tests

### DIFF
--- a/config.frontend.test.yaml
+++ b/config.frontend.test.yaml
@@ -2,7 +2,7 @@
 test:
   parsoid: &parsoid_test_options
     disabled_storage: false
-    host: http://parsoid-external-ci-access.beta.wmflabs.org/w/rest.php
+    host: https://en.wikipedia.beta.wmflabs.org/w/rest.php
   content_types:
     html: '/^text\/html; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/HTML\/[\d.]+"$/'
     data-parsoid: '/^application\/json; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/data-parsoid/[\d.]+"$/'

--- a/config.fullstack.test.yaml
+++ b/config.fullstack.test.yaml
@@ -5,7 +5,7 @@ test:
       default: false
       # eswiki beta has parsoid storage disabled for testing purposes
       es.wikipedia.beta.wmflabs.org: true
-    host: http://parsoid-external-ci-access.beta.wmflabs.org/w/rest.php
+    host: https://en.wikipedia.beta.wmflabs.org/w/rest.php
   content_types:
     html: '/^text\/html; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/HTML\/[\d.]+"$/'
     data-parsoid: '/^application\/json; charset=utf-8; profile="https:\/\/www\.mediawiki\.org\/wiki\/Specs\/data-parsoid/[\d.]+"$/'

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -48,7 +48,7 @@ class TestRestbase {
             apiBase,
             apiPath,
             apiURL,
-            parsoidURI: 'http://parsoid-external-ci-access.beta.wmflabs.org/w/rest.php',
+            parsoidURI: 'https://en.wikipedia.beta.wmflabs.org/w/rest.php',
             conf
         }
     }


### PR DESCRIPTION
Mocha: Target the normal beta instances

Replace the use of http://parsoid-external-ci-access.beta.wmflabs.org/
with https://en.wikipedia.beta.wmflabs.org/.

Bug: T350353
