### PR TITLE
Redirect docs for metrics endpoints to new docs site

### DIFF
--- a/projects/v1/wikimedia.wmf.yaml
+++ b/projects/v1/wikimedia.wmf.yaml
@@ -35,6 +35,13 @@ info:
         change policy, according to
         [our API version policy](https://www.mediawiki.org/wiki/API_versioning).
       - Endpoint specific usage limits.
+      
+      ### Metrics endpoints
+
+      For documentation for `/metrics` endpoints, including pageviews, unique
+      devices, edited pages, editors, edits, registered users, bytes difference,
+      and mediarequests data, see the
+      [Wikimedia Analytics API documentation](https://doc.wikimedia.org/analytics-api).
 
   termsOfService: https://wikimediafoundation.org/wiki/Terms_of_Use
   contact:
@@ -61,10 +68,6 @@ paths:
       - path: v1/mathoid.yaml
         options: '{{options.mathoid}}'
       - path: v1/common_schemas.yaml # Doesn't really matter where to mount it.
-  /metrics:
-    x-modules:
-      - path: v1/metrics.yaml
-        options: '{{options.pageviews}}'
   /transform:
     x-modules:
       - path: v1/transform-global.yaml

--- a/projects/v1/wikimedia.wmf.yaml
+++ b/projects/v1/wikimedia.wmf.yaml
@@ -68,6 +68,10 @@ paths:
       - path: v1/mathoid.yaml
         options: '{{options.mathoid}}'
       - path: v1/common_schemas.yaml # Doesn't really matter where to mount it.
+  /metrics:
+    x-modules:
+      - path: v1/metrics.yaml
+        options: '{{options.pageviews}}'
   /transform:
     x-modules:
       - path: v1/transform-global.yaml


### PR DESCRIPTION
As part of the project to replace the RESTBase `/metrics` endpoints (AQS 1.0) with a new set of services (AQS 2.0), we've created a new documentation site for the `/metrics` endpoints that uses OpenAPI specs generated by the new AQS 2.0 services.

My goal is to redirect users viewing the old docs (https://wikimedia.org/api/rest_v1/#/) to the new docs (https://doc.wikimedia.org/analytics-api), without breaking RESTBase or making the other portions of its docs unusable. 

Ideally, I'd like to be able to keep as much of the old structure as possible (the sections headings and endpoint titles) and replace the content with a link to the new docs site. Or, we could just remove the `/metrics` endpoints from being listed on https://wikimedia.org/api/rest_v1/#/. But I wasn't able to find a way to do either of these options without breaking RESTBase's CI. Is there an easy way to do something like this without breaking things?

This PR adds a note to the intro section of https://wikimedia.org/api/rest_v1/#/ with a link to the new docs site.

Bug: https://phabricator.wikimedia.org/T368973