### PR TITLE
pcs: Use if-unmodified-since to avoid unnecessary rendering

### DIFF
--- a/lib/mwUtil.js
+++ b/lib/mwUtil.js
@@ -182,6 +182,33 @@ mwUtil.isNoCacheRequest = (req) => req.headers && /no-cache/i.test(req.headers['
  */
 mwUtil.isNoStoreRequest = (req) => req.headers && /no-store/i.test(req.headers['cache-control']);
 
+/**
+ * Checks whether the request is an 'if-unmodified-since' request
+ * @param   {Object}    req
+ * @return  {boolean}
+ */
+mwUtil.isUnmodifiedSinceRequest = (req) => Boolean(req.headers && req.headers['if-unmodified-since']);
+
+/**
+ * Checks whether the response has been modified since the timestamp
+ * in `if-unmodified-since` header of the request
+ * @param  {Object} req the request
+ * @param  {Object} res the response
+ * @return {boolean}    true if content has beed modified
+ */
+mwUtil.isUnmodifiedSince = (req, res) => {
+    try {
+        if (req.headers['if-unmodified-since']) {
+            const jobTime = Date.parse(req.headers['if-unmodified-since']);
+            const revInfo = mwUtil.parseETag(res.headers.etag);
+            return revInfo && uuidUtils.getDate(revInfo.tid) < jobTime;
+        }
+    } catch (e) {
+        // Ignore errors from date parsing
+    }
+    return true;
+};
+
 mwUtil.parseRevision = (rev, bucketName) => {
     if (!/^[0-9]+/.test(rev)) {
         throw new HTTPError({

--- a/v1/summary_new.yaml
+++ b/v1/summary_new.yaml
@@ -107,6 +107,7 @@ paths:
               method: get
               headers:
                 cache-control: '{{cache-control}}'
+                if-unmodified-since: '{{if-unmodified-since}}'
               uri: /{domain}/sys/key_value/page_summary/{request.params.title}
             catch:
               status: 404


### PR DESCRIPTION
Replicate what Parsoid on RESTBase is doing to avoid unnecessary rendering from template changes.

* From what it looks from prod metrics we do get changeprop requests that the job date is for content that has already been superseded (old events)
* Currently parsoid is doing all the heavylifting that checks the `if-unmodified-since` and if the events are stale doesn't propagate more resource change events
* By disabling pregeneration on parsoid and replacing the pregeneration trigger for PCS/summary with MW resource changes we end up with the same problem (and increased load).
* This patch is replicating the logic from parsoid to PCS/Summary endpoints