### PR TITLE
Change /page/data-parsoid stability to deprecated

### DIFF
--- a/v1/content.yaml
+++ b/v1/content.yaml
@@ -442,7 +442,7 @@ paths:
         For this reason, you need to supply the exact `revision` and `tid` as
         provided in the `ETag` header of the HTML response.
 
-        Stability: [Stable](https://www.mediawiki.org/wiki/API_versioning#Stable)
+        Stability: [Deprecated](https://www.mediawiki.org/wiki/API_versioning#Deprecated)
       parameters:
         - name: title
           in: path


### PR DESCRIPTION
Bug: [T393557](https://phabricator.wikimedia.org/T393557)